### PR TITLE
chore: ignore local agent and IDE tooling paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,19 @@ cluster.yaml
 .env
 AGENTS.md
 plugins
+
+# Local agent / IDE tooling (project-specific; skills, settings, worktrees)
+.agents
+.agents/*
+.agent
+.agent/*
+.claude
+.claude/*
+.codex
+.codex/*
+.cursor
+.cursor/*
+.cursorrules
+.gemini
+.gemini/*
+.worktrees/


### PR DESCRIPTION
Ignore local-only agent/IDE paths (.agents, .claude, .codex, .cursor, .gemini, .worktrees/).