### PR TITLE
feat(management): support force-mapping in OAuth model aliases

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -338,6 +338,7 @@ nonstream-keepalive-interval: 0
 #   claude:
 #     - name: "claude-sonnet-4-5-20250929"
 #       alias: "cs4.5"
+#       force-mapping: true
 #   codex:
 #     - name: "gpt-5"
 #       alias: "g5"

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -345,7 +345,7 @@ Example response:
   },
   "oauth-model-alias": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   },
   "payload": {
@@ -2880,7 +2880,7 @@ GET response:
 {
   "oauth-model-alias": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   }
 }
@@ -2891,7 +2891,7 @@ PUT input:
 ```json
 {
   "claude": [
-    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
   ]
 }
 ```
@@ -2902,7 +2902,7 @@ or:
 {
   "items": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   }
 }
@@ -2915,7 +2915,7 @@ PATCH input:
   "channel": "claude",
   "provider": "claude",
   "aliases": [
-    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
   ]
 }
 ```
@@ -3000,6 +3000,7 @@ These fields are accepted by Home YAML config. `PUT /config.yaml` accepts non-cr
 | `vertex-api-key` | array of `VertexCompatKey` | Vertex-compatible API-key credentials; use provider-key routes. |
 | `oauth-excluded-models` | object string to array of string | Per-provider OAuth/file-backed auth excluded models. |
 | `oauth-model-alias` | object string to array of `OAuthModelAlias` | Per-channel OAuth model aliases. |
+| `oauth-model-alias.*[].force-mapping` | boolean | When true, response model fields use the mapped upstream model name. |
 | `payload.default` | array of `PayloadRule` | Sets missing JSON payload params. |
 | `payload.default-raw` | array of `PayloadRule` | Sets missing raw JSON payload params. |
 | `payload.override` | array of `PayloadRule` | Overrides JSON payload params. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -345,7 +345,7 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
   },
   "oauth-model-alias": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   },
   "payload": {
@@ -2880,7 +2880,7 @@ GET 输出：
 {
   "oauth-model-alias": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   }
 }
@@ -2891,7 +2891,7 @@ PUT 输入：
 ```json
 {
   "claude": [
-    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
   ]
 }
 ```
@@ -2902,7 +2902,7 @@ PUT 输入：
 {
   "items": {
     "claude": [
-      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+      { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
     ]
   }
 }
@@ -2915,7 +2915,7 @@ PATCH 输入：
   "channel": "claude",
   "provider": "claude",
   "aliases": [
-    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true }
+    { "name": "claude-sonnet-4", "alias": "sonnet", "fork": true, "force-mapping": true }
   ]
 }
 ```
@@ -3000,6 +3000,7 @@ DELETE query：
 | `vertex-api-key` | array of `VertexCompatKey` | Vertex-compatible API-key credentials；应使用 provider-key routes。 |
 | `oauth-excluded-models` | object string to array of string | 每个 provider 的 OAuth/file-backed auth 排除模型。 |
 | `oauth-model-alias` | object string to array of `OAuthModelAlias` | 每个 channel 的 OAuth model aliases。 |
+| `oauth-model-alias.*[].force-mapping` | boolean | 为 `true` 时，响应中的 model 字段使用映射后的上游 model name。 |
 | `payload.default` | array of `PayloadRule` | 设置缺失的 JSON payload params。 |
 | `payload.default-raw` | array of `PayloadRule` | 设置缺失的 raw JSON payload params。 |
 | `payload.override` | array of `PayloadRule` | 覆盖 JSON payload params。 |

--- a/internal/cluster/management/config_test.go
+++ b/internal/cluster/management/config_test.go
@@ -162,6 +162,63 @@ vertex-api-key:
 	}
 }
 
+func TestOAuthModelAliasForceMappingRoundTrip(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	handler := NewHandler(repo, nil, "127.0.0.1", 0)
+	engine := gin.New()
+	engine.PUT("/oauth-model-alias", handler.PutOAuthModelAlias)
+	engine.GET("/oauth-model-alias", handler.GetOAuthModelAlias)
+	engine.GET("/config", handler.GetConfig)
+	engine.GET("/config.yaml", handler.GetConfigYAML)
+
+	payload := `{
+  "claude": [
+    { "name": " claude-sonnet-4 ", "alias": " sonnet ", "fork": true, "force-mapping": true },
+    { "name": "claude-haiku-4", "alias": "haiku" }
+  ]
+}`
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/oauth-model-alias", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", resp.Code, resp.Body.String())
+	}
+
+	getResp := httptest.NewRecorder()
+	getReq := httptest.NewRequest(http.MethodGet, "/oauth-model-alias", nil)
+	engine.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getResp.Code, getResp.Body.String())
+	}
+	assertOAuthModelAliasForceMapping(t, getResp.Body.Bytes())
+
+	configResp := httptest.NewRecorder()
+	configReq := httptest.NewRequest(http.MethodGet, "/config", nil)
+	engine.ServeHTTP(configResp, configReq)
+	if configResp.Code != http.StatusOK {
+		t.Fatalf("config status = %d, body = %s", configResp.Code, configResp.Body.String())
+	}
+	assertOAuthModelAliasForceMapping(t, configResp.Body.Bytes())
+
+	yamlResp := httptest.NewRecorder()
+	yamlReq := httptest.NewRequest(http.MethodGet, "/config.yaml", nil)
+	engine.ServeHTTP(yamlResp, yamlReq)
+	if yamlResp.Code != http.StatusOK {
+		t.Fatalf("yaml status = %d, body = %s", yamlResp.Code, yamlResp.Body.String())
+	}
+	if !strings.Contains(yamlResp.Body.String(), "force-mapping: true") {
+		t.Fatalf("config yaml = %s, want force-mapping true", yamlResp.Body.String())
+	}
+	if strings.Contains(yamlResp.Body.String(), "force-mapping: false") {
+		t.Fatalf("config yaml = %s, should omit false force-mapping", yamlResp.Body.String())
+	}
+}
+
 func providerKeyFirstModel(t *testing.T, raw []byte, key string) map[string]any {
 	t.Helper()
 
@@ -182,6 +239,41 @@ func providerKeyFirstModel(t *testing.T, raw []byte, key string) map[string]any 
 		t.Fatalf("%s first model = %+v, want object", key, rawModels[0])
 	}
 	return model
+}
+
+func assertOAuthModelAliasForceMapping(t *testing.T, raw []byte) {
+	t.Helper()
+
+	var root map[string]any
+	if errDecode := json.Unmarshal(raw, &root); errDecode != nil {
+		t.Fatalf("decode oauth model alias response: %v; body = %s", errDecode, string(raw))
+	}
+	aliasesRoot := root["oauth-model-alias"]
+	aliases, ok := aliasesRoot.(map[string]any)
+	if !ok {
+		t.Fatalf("oauth-model-alias = %#v, want object; body = %s", aliasesRoot, string(raw))
+	}
+	rawClaude, ok := aliases["claude"].([]any)
+	if !ok || len(rawClaude) != 2 {
+		t.Fatalf("claude aliases = %#v, want two aliases; body = %s", aliases["claude"], string(raw))
+	}
+	first, ok := rawClaude[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first alias = %#v, want object", rawClaude[0])
+	}
+	if first["name"] != "claude-sonnet-4" || first["alias"] != "sonnet" {
+		t.Fatalf("first alias = %#v, want trimmed name and alias", first)
+	}
+	if first["force-mapping"] != true {
+		t.Fatalf("first force-mapping = %#v, want true; alias = %#v", first["force-mapping"], first)
+	}
+	second, ok := rawClaude[1].(map[string]any)
+	if !ok {
+		t.Fatalf("second alias = %#v, want object", rawClaude[1])
+	}
+	if _, exists := second["force-mapping"]; exists {
+		t.Fatalf("second alias = %#v, should omit false force-mapping", second)
+	}
 }
 
 func stringSliceContains(values []string, target string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,9 +248,10 @@ type RoutingConfig struct {
 // When Fork is true, the alias is added as an additional model in listings while
 // keeping the original model ID available.
 type OAuthModelAlias struct {
-	Name  string `yaml:"name" json:"name"`
-	Alias string `yaml:"alias" json:"alias"`
-	Fork  bool   `yaml:"fork,omitempty" json:"fork,omitempty"`
+	Name         string `yaml:"name" json:"name"`
+	Alias        string `yaml:"alias" json:"alias"`
+	Fork         bool   `yaml:"fork,omitempty" json:"fork,omitempty"`
+	ForceMapping bool   `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
 // PayloadConfig defines default and override parameter rules applied to provider payloads.
@@ -781,7 +782,7 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 				continue
 			}
 			seenAlias[aliasKey] = struct{}{}
-			clean = append(clean, OAuthModelAlias{Name: name, Alias: alias, Fork: entry.Fork})
+			clean = append(clean, OAuthModelAlias{Name: name, Alias: alias, Fork: entry.Fork, ForceMapping: entry.ForceMapping})
 		}
 		if len(clean) > 0 {
 			out[channel] = clean

--- a/internal/watcher/diff/oauth_model_alias.go
+++ b/internal/watcher/diff/oauth_model_alias.go
@@ -86,6 +86,9 @@ func summarizeOAuthModelAliasList(list []config.OAuthModelAlias) OAuthModelAlias
 		if alias.Fork {
 			key += "|fork"
 		}
+		if alias.ForceMapping {
+			key += "|force-mapping"
+		}
 		if _, exists := seen[key]; exists {
 			continue
 		}

--- a/internal/watcher/diff/oauth_model_alias_test.go
+++ b/internal/watcher/diff/oauth_model_alias_test.go
@@ -1,0 +1,29 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/config"
+)
+
+func TestDiffOAuthModelAliasChangesDetectsForceMapping(t *testing.T) {
+	oldMap := map[string][]config.OAuthModelAlias{
+		"claude": []config.OAuthModelAlias{
+			{Name: "claude-sonnet-4", Alias: "sonnet"},
+		},
+	}
+	newMap := map[string][]config.OAuthModelAlias{
+		"claude": []config.OAuthModelAlias{
+			{Name: "claude-sonnet-4", Alias: "sonnet", ForceMapping: true},
+		},
+	}
+
+	changes, affected := DiffOAuthModelAliasChanges(oldMap, newMap)
+
+	if len(changes) != 1 || changes[0] != "oauth-model-alias[claude]: updated (1 -> 1 entries)" {
+		t.Fatalf("changes = %#v, want force-mapping update", changes)
+	}
+	if len(affected) != 1 || affected[0] != "claude" {
+		t.Fatalf("affected = %#v, want claude", affected)
+	}
+}


### PR DESCRIPTION
## Summary

  - Add `force-mapping` to the OAuth model alias config schema and preserve it during sanitization.
  - Support round-trip reads/writes for `force-mapping: true` through `/oauth-model-alias`, `/config`, and `/config.yaml`.
  - Include `force-mapping` in OAuth model alias diff detection so config reloads detect changes to this field.
  - Update Management API docs and `config.example.yaml`.

  ## Validation

  - `gofmt -w internal/config/config.go internal/cluster/management/config_test.go internal/watcher/diff/oauth_model_alias.go internal/watcher/diff/
  oauth_model_alias_test.go`
  - `go test ./internal/cluster/management ./internal/watcher/diff`
  - `go build -o test-output ./cmd/home && rm test-output`