### PR TITLE
Fix cluster-wide CPA node listing in Management API

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -474,7 +474,7 @@ Successful writes return:
 
 ### GET `/nodes`
 
-Lists nodes currently connected to Home.
+Lists CPA nodes currently connected to the Home cluster. When multiple Home nodes share a database, the route returns CPA connection snapshots reported by every live Home node instead of only the in-process connections on the Home node handling the request.
 
 Input: none.
 
@@ -507,6 +507,9 @@ Example response:
       "connected_time": "2026-05-27T10:30:00Z",
       "client_count": 1,
       "healthy": true,
+      "home_ip": "10.0.0.10",
+      "home_port": 8327,
+      "last_seen_at": "2026-05-27T10:30:05Z",
       "plugin_report_state": "reported_ok",
       "plugin_report_statuses": [
         {
@@ -523,7 +526,7 @@ Example response:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `nodes` | array | Active node list. |
+| `nodes` | array | Active CPA node list aggregated from connection snapshots written by all live Home nodes into the shared database. |
 | `plugin_report_required` | boolean | Whether the current Home config expects CPA plugin reports because at least one enabled plugin has a pinned store manifest. |
 | `plugin_report_statuses` | array | Latest plugin reports stored in the shared database, grouped by reporting node and report metadata. Delete reports for one plugin can coexist with preserved status rows for other plugins. These are retained until the node reports again or is explicitly cleaned up; they do not expire by TTL and are self-reported observations, not authoritative install proof. |
 | `nodes[].node_id` | string | CPA node ID derived from the Home client certificate when available. |
@@ -531,6 +534,9 @@ Example response:
 | `nodes[].connected_time` | string | First connection time for the active node entry. |
 | `nodes[].client_count` | integer | Active RESP subscription connection count from this IP. |
 | `nodes[].healthy` | boolean | Whether the node has an active RESP subscription connection. Plugin reports do not make this field unhealthy. |
+| `nodes[].home_ip` | string | Home node address currently serving this CPA node. |
+| `nodes[].home_port` | integer | Home node port currently serving this CPA node. |
+| `nodes[].last_seen_at` | string | Time when the serving Home node last refreshed this CPA connection snapshot in the shared database. |
 | `nodes[].plugin_report_state` | string | Current configured plugin observation state: `not_required`, `missing_report`, `reported_partial`, `reported_failed`, or `reported_ok`. Failed reports for plugins that are not currently required do not make this state failed. |
 | `nodes[].plugin_report_statuses` | array | Plugin reports associated with this active node, matched by node ID when possible and IP as a fallback. |
 | `plugin_report_statuses[].node_type` | string | Reporting node type, currently `cpa` for CPA node reports and reserved for `home` reports. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -474,7 +474,7 @@ openai-compatibility
 
 ### GET `/nodes`
 
-列出当前连接到 Home 的节点。
+列出当前连接到 Home 集群的 CPA 节点。多 Home 节点共享数据库时，接口返回所有 live Home 上报的 CPA 连接快照，而不只返回当前处理请求的 Home 进程内连接。
 
 输入：无。
 
@@ -507,6 +507,9 @@ openai-compatibility
       "connected_time": "2026-05-27T10:30:00Z",
       "client_count": 1,
       "healthy": true,
+      "home_ip": "10.0.0.10",
+      "home_port": 8327,
+      "last_seen_at": "2026-05-27T10:30:05Z",
       "plugin_report_state": "reported_ok",
       "plugin_report_statuses": [
         {
@@ -523,7 +526,7 @@ openai-compatibility
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `nodes` | array | 当前活跃节点列表。 |
+| `nodes` | array | 当前活跃 CPA 节点列表，聚合自所有 live Home 节点写入共享数据库的连接快照。 |
 | `plugin_report_required` | boolean | 当前 Home 配置是否期望 CPA 上报插件状态；至少一个已启用插件带有固定的 store manifest 时为 `true`。 |
 | `plugin_report_statuses` | array | 共享数据库中保存的最新插件上报，按上报节点和上报元数据分组；单插件删除上报可以和其他插件保留的状态行同时存在。它们会一直保留到节点再次上报或被显式清理，不按 TTL 自动过期。这是 CPA 自报告的观测信息，不是强可信安装事实。 |
 | `nodes[].node_id` | string | 从 Home 客户端证书得到的 CPA node ID。 |
@@ -531,6 +534,9 @@ openai-compatibility
 | `nodes[].connected_time` | string | 当前活跃节点条目的首次连接时间。 |
 | `nodes[].client_count` | integer | 当前 IP 下活跃 RESP 订阅连接数。 |
 | `nodes[].healthy` | boolean | 节点是否存在活跃 RESP 配置订阅连接；插件上报不会直接让该字段变为不健康。 |
+| `nodes[].home_ip` | string | 该 CPA 节点当前连接的 Home 节点地址。 |
+| `nodes[].home_port` | integer | 该 CPA 节点当前连接的 Home 节点端口。 |
+| `nodes[].last_seen_at` | string | 该 CPA 节点连接快照最近一次由对应 Home 节点刷新到共享数据库的时间。 |
 | `nodes[].plugin_report_state` | string | 当前已配置插件的观测状态：`not_required`、`missing_report`、`reported_partial`、`reported_failed` 或 `reported_ok`；当前不需要的插件上报失败不会让该状态变为失败。 |
 | `nodes[].plugin_report_statuses` | array | 关联到当前活跃节点的插件上报，优先按 node ID 匹配，缺失时按 IP fallback。 |
 | `plugin_report_statuses[].node_type` | string | 上报节点类型；CPA 节点上报为 `cpa`，`home` 预留给 Home 节点上报。 |

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -148,10 +148,13 @@ func (c *Coordinator) UpdateClientCount(ctx context.Context, clientCount int) er
 	if errDB != nil {
 		return errDB
 	}
-	return db.WithContext(contextOrBackground(ctx)).
+	if errUpdate := db.WithContext(contextOrBackground(ctx)).
 		Model(&ClusterNodeRecord{}).
 		Where("ip = ? AND port = ?", c.node.IP, c.node.Port).
-		Update("client_count", clientCount).Error
+		Update("client_count", clientCount).Error; errUpdate != nil {
+		return errUpdate
+	}
+	return c.syncCPANodeSnapshot(ctx, time.Now().UTC())
 }
 
 // SetOnMasterChanged sets an on master changed.
@@ -224,6 +227,9 @@ func (c *Coordinator) heartbeatAndElect(ctx context.Context) error {
 	}).Create(&record).Error; errUpsert != nil {
 		return errUpsert
 	}
+	if errSnapshot := c.syncCPANodeSnapshot(ctx, now); errSnapshot != nil {
+		return errSnapshot
+	}
 
 	elected, errMaster := c.CurrentMaster(ctx)
 	if errMaster != nil {
@@ -235,6 +241,13 @@ func (c *Coordinator) heartbeatAndElect(ctx context.Context) error {
 
 	c.setMaster(clusterNodeMatches(*elected, c.node.IP, c.node.Port))
 	return nil
+}
+
+func (c *Coordinator) syncCPANodeSnapshot(ctx context.Context, seenAt time.Time) error {
+	if c == nil || c.repo == nil {
+		return nil
+	}
+	return c.repo.ReplaceCPANodeSnapshot(ctx, c.node.IP, c.node.Port, node.GlobalRegistry().List(), seenAt)
 }
 
 // setMaster sets a master.

--- a/internal/cluster/db.go
+++ b/internal/cluster/db.go
@@ -100,7 +100,7 @@ func AutoMigrate(db *gorm.DB) error {
 	if db == nil {
 		return fmt.Errorf("database connection is nil")
 	}
-	if errMigrate := db.AutoMigrate(&AuthRecord{}, &ConfigRecord{}, &KVRecord{}, &PluginStatusRecord{}, &PluginTaskRecord{}, &UserRecord{}, &APIKeyRecord{}, &ChannelGroupRecord{}, &ChannelGroupDetailRecord{}, &ModelGroupRecord{}, &ModelGroupDetailRecord{}, &ClusterNodeRecord{}, &ClusterEventRecord{}, &UsageRecord{}, &BillingModelPriceRecord{}, &BillingBalanceRecord{}, &BillingChargeRecord{}, &ProxyPoolRecord{}, &AppLogRecord{}, &OAuthSessionRecord{}, &CertificateRecord{}); errMigrate != nil {
+	if errMigrate := db.AutoMigrate(&AuthRecord{}, &ConfigRecord{}, &KVRecord{}, &PluginStatusRecord{}, &PluginTaskRecord{}, &UserRecord{}, &APIKeyRecord{}, &ChannelGroupRecord{}, &ChannelGroupDetailRecord{}, &ModelGroupRecord{}, &ModelGroupDetailRecord{}, &ClusterNodeRecord{}, &CPANodeRecord{}, &ClusterEventRecord{}, &UsageRecord{}, &BillingModelPriceRecord{}, &BillingBalanceRecord{}, &BillingChargeRecord{}, &ProxyPoolRecord{}, &AppLogRecord{}, &OAuthSessionRecord{}, &CertificateRecord{}); errMigrate != nil {
 		return errMigrate
 	}
 	if errMigrate := migrateBillingIndexes(db); errMigrate != nil {

--- a/internal/cluster/management/nodes.go
+++ b/internal/cluster/management/nodes.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
@@ -17,6 +19,16 @@ const (
 	pluginLoadStatusFailed       = "failed"
 	pluginLoadStatusLoaded       = "loaded"
 )
+
+type activeCPANode struct {
+	NodeID      string
+	IP          string
+	Connected   time.Time
+	ClientCount int
+	HomeIP      string
+	HomePort    int
+	LastSeenAt  time.Time
+}
 
 // ListNodes returns a nodes.
 func (h *Handler) ListNodes(c *gin.Context) {
@@ -44,7 +56,11 @@ func (h *Handler) ListNodes(c *gin.Context) {
 		statusesByIP[clientIP] = append(statusesByIP[clientIP], status)
 	}
 	requiredPluginIDs := h.pluginTaskRequiredIDs(ctx)
-	activeNodes := node.GlobalRegistry().List()
+	activeNodes, errNodes := h.activeCPANodes(ctx)
+	if errNodes != nil {
+		respondError(c, http.StatusInternalServerError, "node_load_failed", errNodes)
+		return
+	}
 	nodes := make([]gin.H, 0, len(activeNodes))
 	for _, activeNode := range activeNodes {
 		statuses := statusesByNodeID[strings.TrimSpace(activeNode.NodeID)]
@@ -58,6 +74,9 @@ func (h *Handler) ListNodes(c *gin.Context) {
 			"connected_time":         activeNode.Connected,
 			"client_count":           activeNode.ClientCount,
 			"healthy":                activeNode.ClientCount > 0,
+			"home_ip":                activeNode.HomeIP,
+			"home_port":              activeNode.HomePort,
+			"last_seen_at":           activeNode.LastSeenAt,
 			"plugin_report_state":    state,
 			"plugin_report_statuses": statuses,
 		})
@@ -67,6 +86,90 @@ func (h *Handler) ListNodes(c *gin.Context) {
 		"plugin_report_required": len(requiredPluginIDs) > 0,
 		"plugin_report_statuses": taskStatuses,
 	})
+}
+
+func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
+	nodesByKey := make(map[string]activeCPANode)
+	if h != nil && h.repo != nil {
+		records, errRecords := h.repo.ListLiveCPANodes(ctx, time.Time{})
+		if errRecords != nil {
+			return nil, errRecords
+		}
+		for _, record := range records {
+			key := activeCPANodeKey(record.HomeIP, record.HomePort, record.NodeID, record.ClientIP)
+			if key == "" {
+				continue
+			}
+			nodesByKey[key] = activeCPANode{
+				NodeID:      strings.TrimSpace(record.NodeID),
+				IP:          strings.TrimSpace(record.ClientIP),
+				Connected:   record.ConnectedAt,
+				ClientCount: record.ClientCount,
+				HomeIP:      strings.TrimSpace(record.HomeIP),
+				HomePort:    record.HomePort,
+				LastSeenAt:  record.LastSeenAt,
+			}
+		}
+	}
+
+	localHomeIP := ""
+	localHomePort := 0
+	if h != nil {
+		localHomeIP = strings.TrimSpace(h.nodeIP)
+		localHomePort = h.nodePort
+	}
+	for _, localNode := range node.GlobalRegistry().List() {
+		key := activeCPANodeKey(localHomeIP, localHomePort, localNode.NodeID, localNode.IP)
+		if key == "" {
+			continue
+		}
+		nodesByKey[key] = activeCPANode{
+			NodeID:      strings.TrimSpace(localNode.NodeID),
+			IP:          strings.TrimSpace(localNode.IP),
+			Connected:   localNode.Connected,
+			ClientCount: localNode.ClientCount,
+			HomeIP:      localHomeIP,
+			HomePort:    localHomePort,
+			LastSeenAt:  time.Now().UTC(),
+		}
+	}
+
+	nodes := make([]activeCPANode, 0, len(nodesByKey))
+	for _, item := range nodesByKey {
+		nodes = append(nodes, item)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Connected.Equal(nodes[j].Connected) {
+			if nodes[i].IP == nodes[j].IP {
+				if nodes[i].NodeID == nodes[j].NodeID {
+					if nodes[i].HomeIP == nodes[j].HomeIP {
+						return nodes[i].HomePort < nodes[j].HomePort
+					}
+					return nodes[i].HomeIP < nodes[j].HomeIP
+				}
+				return nodes[i].NodeID < nodes[j].NodeID
+			}
+			return nodes[i].IP < nodes[j].IP
+		}
+		return nodes[i].Connected.Before(nodes[j].Connected)
+	})
+	return nodes, nil
+}
+
+func activeCPANodeKey(homeIP string, homePort int, nodeID string, clientIP string) string {
+	homeIP = strings.TrimSpace(homeIP)
+	nodeID = strings.TrimSpace(nodeID)
+	clientIP = strings.TrimSpace(clientIP)
+	nodeKey := ""
+	if nodeID != "" {
+		nodeKey = "node:" + nodeID
+	} else if clientIP != "" {
+		nodeKey = "ip:" + clientIP
+	}
+	if nodeKey == "" {
+		return ""
+	}
+	return homeIP + ":" + strconv.Itoa(homePort) + "/" + nodeKey
 }
 
 func (h *Handler) pluginTaskStatuses(ctx context.Context) ([]node.PluginTaskStatus, error) {

--- a/internal/cluster/management/nodes_test.go
+++ b/internal/cluster/management/nodes_test.go
@@ -13,6 +13,80 @@ import (
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
 )
 
+func TestListNodesIncludesCPASnapshotsFromAllHomeNodes(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	now := time.Now().UTC()
+	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-a", 8327, []node.Node{
+		{NodeID: "cpa-a-1", IP: "10.0.1.1", Connected: now.Add(-4 * time.Minute), ClientCount: 1},
+		{NodeID: "cpa-a-2", IP: "10.0.1.2", Connected: now.Add(-3 * time.Minute), ClientCount: 1},
+	}, now); errSnapshot != nil {
+		t.Fatalf("ReplaceCPANodeSnapshot(home-a) error = %v", errSnapshot)
+	}
+	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-b", 8328, []node.Node{
+		{NodeID: "cpa-b-1", IP: "10.0.2.1", Connected: now.Add(-2 * time.Minute), ClientCount: 1},
+		{NodeID: "cpa-b-2", IP: "10.0.2.2", Connected: now.Add(-1 * time.Minute), ClientCount: 1},
+	}, now); errSnapshot != nil {
+		t.Fatalf("ReplaceCPANodeSnapshot(home-b) error = %v", errSnapshot)
+	}
+
+	handler := NewHandler(repo, nil, "home-a", 8327)
+	engine := gin.New()
+	engine.GET("/nodes", handler.ListNodes)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/nodes", nil)
+	engine.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", resp.Code, resp.Body.String())
+	}
+	var body struct {
+		Nodes []struct {
+			NodeID      string `json:"node_id"`
+			IP          string `json:"ip"`
+			ClientCount int    `json:"client_count"`
+			Healthy     bool   `json:"healthy"`
+			HomeIP      string `json:"home_ip"`
+			HomePort    int    `json:"home_port"`
+		} `json:"nodes"`
+	}
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if len(body.Nodes) != 4 {
+		t.Fatalf("nodes len = %d, want 4: %+v", len(body.Nodes), body.Nodes)
+	}
+
+	got := make(map[string]struct {
+		HomeIP   string
+		HomePort int
+	})
+	for _, item := range body.Nodes {
+		if item.ClientCount != 1 || !item.Healthy {
+			t.Fatalf("node = %+v, want one healthy client", item)
+		}
+		got[item.NodeID] = struct {
+			HomeIP   string
+			HomePort int
+		}{HomeIP: item.HomeIP, HomePort: item.HomePort}
+	}
+	for nodeID, want := range map[string]struct {
+		HomeIP   string
+		HomePort int
+	}{
+		"cpa-a-1": {HomeIP: "home-a", HomePort: 8327},
+		"cpa-a-2": {HomeIP: "home-a", HomePort: 8327},
+		"cpa-b-1": {HomeIP: "home-b", HomePort: 8328},
+		"cpa-b-2": {HomeIP: "home-b", HomePort: 8328},
+	} {
+		if got[nodeID] != want {
+			t.Fatalf("node %s home = %+v, want %+v; all nodes = %+v", nodeID, got[nodeID], want, body.Nodes)
+		}
+	}
+}
+
 func TestListNodesIncludesPluginTaskHealth(t *testing.T) {
 	db, cleanup := openManagementLogTestDB(t)
 	defer cleanup()

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -298,6 +298,24 @@ func (ClusterNodeRecord) TableName() string {
 	return "cluster"
 }
 
+type CPANodeRecord struct {
+	HomeIP      string    `gorm:"column:home_ip;primaryKey;index:idx_cpa_node_home_live,priority:1;index:idx_cpa_node_live,priority:3"`
+	HomePort    int       `gorm:"column:home_port;primaryKey;index:idx_cpa_node_home_live,priority:2;index:idx_cpa_node_live,priority:4"`
+	NodeKey     string    `gorm:"column:node_key;primaryKey;size:256"`
+	NodeID      string    `gorm:"column:node_id;index"`
+	ClientIP    string    `gorm:"column:client_ip;index"`
+	ClientCount int       `gorm:"column:client_count"`
+	ConnectedAt time.Time `gorm:"column:connected_at"`
+	LastSeenAt  time.Time `gorm:"column:last_seen_at;index:idx_cpa_node_home_live,priority:3;index:idx_cpa_node_live,priority:1"`
+	CreatedAt   time.Time `gorm:"column:created_at"`
+	UpdatedAt   time.Time `gorm:"column:updated_at"`
+}
+
+// TableName returns the database table name.
+func (CPANodeRecord) TableName() string {
+	return "cpa_node"
+}
+
 type ClusterEventRecord struct {
 	ID         uint      `gorm:"column:id;primaryKey;autoIncrement"`
 	Scope      string    `gorm:"column:scope"`

--- a/internal/cluster/repository.go
+++ b/internal/cluster/repository.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -426,6 +427,102 @@ func (r *Repository) ListLiveClusterNodes(ctx context.Context, cutoff time.Time)
 		return nil, errFind
 	}
 	return records, nil
+}
+
+// ReplaceCPANodeSnapshot replaces the active CPA connection snapshot owned by one Home node.
+func (r *Repository) ReplaceCPANodeSnapshot(ctx context.Context, homeIP string, homePort int, nodes []node.Node, seenAt time.Time) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	homeIP = strings.TrimSpace(homeIP)
+	if homeIP == "" {
+		return fmt.Errorf("home ip is required")
+	}
+	if homePort <= 0 {
+		return fmt.Errorf("home port must be greater than 0")
+	}
+	if seenAt.IsZero() {
+		seenAt = time.Now().UTC()
+	} else {
+		seenAt = seenAt.UTC()
+	}
+
+	records := make([]CPANodeRecord, 0, len(nodes))
+	seenKeys := make(map[string]struct{}, len(nodes))
+	for _, item := range nodes {
+		key := cpaNodeKey(item)
+		if key == "" {
+			continue
+		}
+		if _, ok := seenKeys[key]; ok {
+			continue
+		}
+		seenKeys[key] = struct{}{}
+		clientCount := item.ClientCount
+		if clientCount <= 0 {
+			continue
+		}
+		connectedAt := item.Connected
+		if connectedAt.IsZero() {
+			connectedAt = seenAt
+		} else {
+			connectedAt = connectedAt.UTC()
+		}
+		records = append(records, CPANodeRecord{
+			HomeIP:      homeIP,
+			HomePort:    homePort,
+			NodeKey:     key,
+			NodeID:      strings.TrimSpace(item.NodeID),
+			ClientIP:    strings.TrimSpace(item.IP),
+			ClientCount: clientCount,
+			ConnectedAt: connectedAt,
+			LastSeenAt:  seenAt,
+		})
+	}
+
+	return db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		if errDelete := tx.Where("home_ip = ? AND home_port = ?", homeIP, homePort).Delete(&CPANodeRecord{}).Error; errDelete != nil {
+			return errDelete
+		}
+		if len(records) == 0 {
+			return nil
+		}
+		return tx.Create(&records).Error
+	})
+}
+
+// ListLiveCPANodes returns live CPA node snapshots reported by active Home nodes.
+func (r *Repository) ListLiveCPANodes(ctx context.Context, cutoff time.Time) ([]CPANodeRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	if cutoff.IsZero() {
+		cutoff = time.Now().UTC().Add(-defaultHeartbeatTimeout)
+	}
+
+	var records []CPANodeRecord
+	errFind := db.WithContext(contextOrBackground(ctx)).
+		Where("last_seen_at >= ?", cutoff).
+		Order("connected_at ASC, client_ip ASC, node_id ASC, home_ip ASC, home_port ASC").
+		Find(&records).Error
+	if errFind != nil {
+		return nil, errFind
+	}
+	return records, nil
+}
+
+func cpaNodeKey(item node.Node) string {
+	nodeID := strings.TrimSpace(item.NodeID)
+	if nodeID != "" {
+		return "node:" + nodeID
+	}
+	clientIP := strings.TrimSpace(item.IP)
+	if clientIP == "" {
+		return ""
+	}
+	return "ip:" + clientIP
 }
 
 // ListAuths returns an auths.


### PR DESCRIPTION
## Summary

Fixes the Management `/nodes` endpoint so it returns CPA nodes connected across all live Home nodes in a shared-database cluster, instead of only the in-process CPA connections on the Home node handling the request.

## Changes

  - Add DB-backed CPA connection snapshots owned by each Home node.
  - Sync each Home node's active CPA registry into the shared database during heartbeat/client-count updates.
  - Update `GET /nodes` to aggregate live CPA snapshots from the shared database.
  - Overlay the serving Home node's local registry state for fresher local connection data.
  - Add `home_ip`, `home_port`, and `last_seen_at` fields to node responses.
  - Add a focused test covering two Home nodes with four CPA nodes.
  - Update English and Chinese Management API docs.

## Validation

  - `gofmt -w ...`
  - `go test -run TestListNodesIncludesCPASnapshotsFromAllHomeNodes ./internal/cluster/management`
  - `go test ./internal/cluster/management`
  - `go build -o test-output ./cmd/home`
  - `git diff --check`