### PR TITLE
feat: support advanced payload model matchers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -370,6 +370,17 @@ nonstream-keepalive-interval: 0
 #     - models:
 #         - name: "gemini-2.5-pro" # Supports wildcards (e.g., "gemini-*")
 #           protocol: "gemini" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex, antigravity
+#           from-protocol: "responses" # restricts the rule to the source protocol, options: openai, responses, gemini, claude
+#           headers: # all configured request headers must match; values support "*" wildcards
+#             X-Client-Tier: "tenant-*-region-*"
+#           match: # all payload JSON paths must equal the configured values
+#             - "metadata.client": "codex"
+#           not-match: # payload JSON paths must not equal the configured values
+#             - "metadata.mode": "dev"
+#           exist: # all payload JSON paths must exist and not be null
+#             - "tools.#(type==\"web_search\").type"
+#           not-exist: # all payload JSON paths must be missing or null
+#             - "metadata.disable_payload"
 #       params: # JSON path (gjson/sjson syntax) -> value
 #         "generationConfig.thinkingConfig.thinkingBudget": 32768
 #   default-raw: # Default raw rules set parameters using raw JSON when missing (must be valid JSON).

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -443,7 +443,20 @@ These routes write the corresponding config root into the cluster repository and
   "payload": {
     "default": [
       {
-        "models": [{ "name": "gpt-*", "protocol": "responses" }],
+        "models": [
+          {
+            "name": "gpt-*",
+            "protocol": "responses",
+            "from-protocol": "openai",
+            "headers": {
+              "X-Client-Tier": "tenant-*"
+            },
+            "match": [{ "metadata.client": "codex" }],
+            "not-match": [{ "metadata.mode": "dev" }],
+            "exist": ["tools.#(type==\"web_search\").type"],
+            "not-exist": ["metadata.disable_payload"]
+          }
+        ],
         "params": { "reasoning.effort": "high" }
       }
     ],
@@ -460,7 +473,11 @@ These routes write the corresponding config root into the cluster repository and
 }
 ```
 
-`PUT /payload` and `PATCH /payload` accept either a raw payload object, `{ "value": <payload> }`, or `{ "payload": <payload> }`.
+`GET /payload` returns the complete persisted payload root, including advanced model matcher fields that older frontends may not recognize.
+
+`PUT /payload` accepts either a raw payload object, `{ "value": <payload> }`, or `{ "payload": <payload> }`. It replaces the complete `payload` root and validates the full schema without dropping advanced matcher fields.
+
+`PATCH /payload` accepts the same body shapes and applies object merge-patch semantics to the existing `payload` root: submitted object fields are merged recursively, `null` removes a field, arrays are replaced as whole values, and sibling fields not present in the patch are preserved. This lets clients update one section, such as `filter`, without deleting `default`, `override`, or advanced matcher fields.
 
 `DELETE /payload` removes the root from the config snapshot.
 
@@ -3091,7 +3108,32 @@ Payload nested structure:
   },
   "PayloadModelRule": {
     "name": "model pattern or wildcard",
-    "protocol": "translator protocol"
+    "protocol": "translator protocol",
+    "from-protocol": "source protocol",
+    "headers": {
+      "Header-Name": "wildcard value"
+    },
+    "match": [
+      { "json.path": "required value" }
+    ],
+    "not-match": [
+      { "json.path": "disallowed value" }
+    ],
+    "exist": ["json.path"],
+    "not-exist": ["json.path"]
   }
 }
 ```
+
+`PayloadModelRule` fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Target model name or wildcard pattern. |
+| `protocol` | string | Current translator protocol/provider format matcher, such as `openai`, `responses`, `gemini`, `claude`, `codex`, or `antigravity`. |
+| `from-protocol` | string | Source protocol matcher used when a request was translated from another protocol. |
+| `headers` | object string to string | Request header matchers. Every configured header must be present and its value must match the configured wildcard pattern. |
+| `match` | array of object | Payload JSON path/value conditions that must match. Paths use the same gjson/sjson-style path syntax as payload params. |
+| `not-match` | array of object | Payload JSON path/value conditions that must not match. |
+| `exist` | array of string | Payload JSON paths that must exist and not be `null`. |
+| `not-exist` | array of string | Payload JSON paths that must be missing or `null`. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -443,7 +443,20 @@ openai-compatibility
   "payload": {
     "default": [
       {
-        "models": [{ "name": "gpt-*", "protocol": "responses" }],
+        "models": [
+          {
+            "name": "gpt-*",
+            "protocol": "responses",
+            "from-protocol": "openai",
+            "headers": {
+              "X-Client-Tier": "tenant-*"
+            },
+            "match": [{ "metadata.client": "codex" }],
+            "not-match": [{ "metadata.mode": "dev" }],
+            "exist": ["tools.#(type==\"web_search\").type"],
+            "not-exist": ["metadata.disable_payload"]
+          }
+        ],
         "params": { "reasoning.effort": "high" }
       }
     ],
@@ -460,7 +473,11 @@ openai-compatibility
 }
 ```
 
-`PUT /payload` 和 `PATCH /payload` 接受原始 payload object、`{ "value": <payload> }` 或 `{ "payload": <payload> }`。
+`GET /payload` 返回完整持久化 payload root，包括旧前端暂不识别的高级 model matcher 字段。
+
+`PUT /payload` 接受原始 payload object、`{ "value": <payload> }` 或 `{ "payload": <payload> }`。它会替换完整 `payload` root，并校验完整 schema，不会静默丢弃高级 matcher 字段。
+
+`PATCH /payload` 接受相同 body 形态，并对现有 `payload` root 应用 object merge-patch 语义：提交的 object 字段会递归合并，`null` 删除字段，array 作为整体替换，patch 中未出现的 sibling 字段会保留。这样前端只更新 `filter` 等单个 section 时，不会删除 `default`、`override` 或高级 matcher 字段。
 
 `DELETE /payload` 从 config snapshot 删除该 root。
 
@@ -3091,7 +3108,32 @@ Payload 嵌套结构：
   },
   "PayloadModelRule": {
     "name": "model pattern or wildcard",
-    "protocol": "translator protocol"
+    "protocol": "translator protocol",
+    "from-protocol": "source protocol",
+    "headers": {
+      "Header-Name": "wildcard value"
+    },
+    "match": [
+      { "json.path": "required value" }
+    ],
+    "not-match": [
+      { "json.path": "disallowed value" }
+    ],
+    "exist": ["json.path"],
+    "not-exist": ["json.path"]
   }
 }
 ```
+
+`PayloadModelRule` 字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `name` | string | 目标 model name 或通配模式。 |
+| `protocol` | string | 当前 translator protocol/provider format 匹配条件，例如 `openai`、`responses`、`gemini`、`claude`、`codex` 或 `antigravity`。 |
+| `from-protocol` | string | 来源协议匹配条件，用于请求从其他协议转换而来的场景。 |
+| `headers` | object string to string | 请求 header 匹配条件；配置的每个 header 都必须存在，且值需要匹配对应通配模式。 |
+| `match` | array of object | payload JSON path/value 必须匹配的条件；path 使用与 payload params 相同的 gjson/sjson 风格路径语法。 |
+| `not-match` | array of object | payload JSON path/value 必须不匹配的条件。 |
+| `exist` | array of string | 指定 payload JSON path 必须存在且不是 `null`。 |
+| `not-exist` | array of string | 指定 payload JSON path 必须不存在或为 `null`。 |

--- a/internal/cluster/config_snapshot_test.go
+++ b/internal/cluster/config_snapshot_test.go
@@ -86,3 +86,67 @@ func TestRuntimeConfigFromRootPreservesPluginConfig(t *testing.T) {
 		t.Fatalf("runtime payload lost plugin config:\n%s", string(payload))
 	}
 }
+
+func TestRuntimeConfigFromRootPreservesAdvancedPayloadModelMatchers(t *testing.T) {
+	root := map[string]any{
+		"payload": map[string]any{
+			"default": []any{
+				map[string]any{
+					"models": []any{
+						map[string]any{
+							"name":          "gemini-*",
+							"protocol":      "gemini",
+							"from-protocol": "responses",
+							"headers": map[string]any{
+								"X-Client-Tier": "tenant-*",
+							},
+							"match": []any{
+								map[string]any{"metadata.client": "codex"},
+							},
+							"not-match": []any{
+								map[string]any{"metadata.mode": "dev"},
+							},
+							"exist":     []any{"tools.#(type==\"web_search\").type"},
+							"not-exist": []any{"metadata.disable_payload"},
+						},
+					},
+					"params": map[string]any{
+						"generationConfig.thinkingConfig.thinkingBudget": 32768,
+					},
+				},
+			},
+		},
+	}
+
+	cfg, payload, errConfig := RuntimeConfigFromRoot(root)
+	if errConfig != nil {
+		t.Fatalf("RuntimeConfigFromRoot() error = %v", errConfig)
+	}
+	if len(cfg.Payload.Default) != 1 || len(cfg.Payload.Default[0].Models) != 1 {
+		t.Fatalf("payload default models = %#v, want one advanced matcher", cfg.Payload.Default)
+	}
+	model := cfg.Payload.Default[0].Models[0]
+	if model.FromProtocol != "responses" {
+		t.Fatalf("FromProtocol = %q, want responses", model.FromProtocol)
+	}
+	if model.Headers["X-Client-Tier"] != "tenant-*" {
+		t.Fatalf("Headers = %#v, want X-Client-Tier matcher", model.Headers)
+	}
+	if len(model.Match) != 1 || model.Match[0]["metadata.client"] != "codex" {
+		t.Fatalf("Match = %#v, want metadata.client matcher", model.Match)
+	}
+	if len(model.NotMatch) != 1 || model.NotMatch[0]["metadata.mode"] != "dev" {
+		t.Fatalf("NotMatch = %#v, want metadata.mode matcher", model.NotMatch)
+	}
+	if len(model.Exist) != 1 || model.Exist[0] != "tools.#(type==\"web_search\").type" {
+		t.Fatalf("Exist = %#v, want web_search path", model.Exist)
+	}
+	if len(model.NotExist) != 1 || model.NotExist[0] != "metadata.disable_payload" {
+		t.Fatalf("NotExist = %#v, want disable payload path", model.NotExist)
+	}
+	for _, want := range []string{"from-protocol: responses", "X-Client-Tier: tenant-*", "not-exist:"} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("runtime payload missing %q:\n%s", want, string(payload))
+		}
+	}
+}

--- a/internal/cluster/management/config.go
+++ b/internal/cluster/management/config.go
@@ -205,6 +205,46 @@ func (h *Handler) PutConfigRoot(route string) gin.HandlerFunc {
 	}
 }
 
+// PatchConfigRoot merges a config root object.
+func (h *Handler) PatchConfigRoot(route string) gin.HandlerFunc {
+	// Normalize source data before building the derived payload.
+	key := strings.Trim(strings.TrimSpace(route), "/")
+	return func(c *gin.Context) {
+		value, errValue := readConfigValue(c, key)
+		if errValue != nil {
+			respondError(c, http.StatusBadRequest, "invalid body", errValue)
+			return
+		}
+		ctx, cancel := h.requestContext(c)
+		defer cancel()
+		root, errSnapshot := h.configRoot(ctx)
+		if errSnapshot != nil {
+			respondError(c, http.StatusInternalServerError, "config_load_failed", errSnapshot)
+			return
+		}
+		current, _ := root[key].(map[string]any)
+		patch, ok := value.(map[string]any)
+		if !ok {
+			root[key] = value
+		} else {
+			root[key] = mergeConfigPatch(current, patch)
+		}
+		if _, errConfig := configFromRoot(root); errConfig != nil {
+			respondError(c, http.StatusUnprocessableEntity, "invalid_config", errConfig)
+			return
+		}
+		if errUpsert := h.repo.UpsertConfigValue(ctx, key, root[key]); errUpsert != nil {
+			respondError(c, http.StatusInternalServerError, "write_failed", errUpsert)
+			return
+		}
+		if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+			respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+			return
+		}
+		respondOK(c)
+	}
+}
+
 // DeleteConfigRoot deletes a config root.
 func (h *Handler) DeleteConfigRoot(route string) gin.HandlerFunc {
 	// Normalize source data before building the derived payload.
@@ -336,6 +376,27 @@ func readConfigValue(c *gin.Context, key string) (any, error) {
 		}
 	}
 	return value, nil
+}
+
+func mergeConfigPatch(current map[string]any, patch map[string]any) map[string]any {
+	merged := make(map[string]any, len(current)+len(patch))
+	for key, value := range current {
+		merged[key] = value
+	}
+	for key, value := range patch {
+		if value == nil {
+			delete(merged, key)
+			continue
+		}
+		currentObject, currentOK := merged[key].(map[string]any)
+		patchObject, patchOK := value.(map[string]any)
+		if currentOK && patchOK {
+			merged[key] = mergeConfigPatch(currentObject, patchObject)
+			continue
+		}
+		merged[key] = value
+	}
+	return merged
 }
 
 // isCredentialConfigKey reports whether credential config key.

--- a/internal/cluster/management/config_test.go
+++ b/internal/cluster/management/config_test.go
@@ -219,6 +219,111 @@ func TestOAuthModelAliasForceMappingRoundTrip(t *testing.T) {
 	}
 }
 
+func TestPayloadAdvancedMatchersRoundTrip(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	handler := NewHandler(repo, nil, "127.0.0.1", 0)
+	engine := gin.New()
+	engine.PUT("/payload", handler.PutConfigRoot("/payload"))
+	engine.GET("/payload", handler.GetConfigRoot("/payload"))
+	engine.GET("/config", handler.GetConfig)
+	engine.PATCH("/payload", handler.PatchConfigRoot("/payload"))
+
+	payload := `{
+  "default": [
+    {
+      "models": [
+        {
+          "name": "gemini-*",
+          "protocol": "gemini",
+          "from-protocol": "responses",
+          "headers": {
+            "X-Client-Tier": "tenant-*"
+          },
+          "match": [
+            { "metadata.client": "codex" }
+          ],
+          "not-match": [
+            { "metadata.mode": "dev" }
+          ],
+          "exist": [
+            "tools.#(type==\"web_search\").type"
+          ],
+          "not-exist": [
+            "metadata.disable_payload"
+          ]
+        }
+      ],
+      "params": {
+        "generationConfig.thinkingConfig.thinkingBudget": 32768
+      }
+    }
+  ],
+  "override": [
+    {
+      "models": [
+        { "name": "gpt-*", "protocol": "responses" }
+      ],
+      "params": {
+        "reasoning.effort": "high"
+      }
+    }
+  ]
+}`
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/payload", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("put status = %d, body = %s", resp.Code, resp.Body.String())
+	}
+
+	getResp := httptest.NewRecorder()
+	getReq := httptest.NewRequest(http.MethodGet, "/payload", nil)
+	engine.ServeHTTP(getResp, getReq)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getResp.Code, getResp.Body.String())
+	}
+	assertAdvancedPayloadMatcher(t, getResp.Body.Bytes())
+
+	configResp := httptest.NewRecorder()
+	configReq := httptest.NewRequest(http.MethodGet, "/config", nil)
+	engine.ServeHTTP(configResp, configReq)
+	if configResp.Code != http.StatusOK {
+		t.Fatalf("config status = %d, body = %s", configResp.Code, configResp.Body.String())
+	}
+	assertAdvancedPayloadMatcher(t, configResp.Body.Bytes())
+
+	patchResp := httptest.NewRecorder()
+	patchReq := httptest.NewRequest(http.MethodPatch, "/payload", strings.NewReader(`{
+  "filter": [
+    {
+      "models": [
+        { "name": "gemini-*", "protocol": "gemini" }
+      ],
+      "params": ["generationConfig.responseJsonSchema"]
+    }
+  ]
+}`))
+	patchReq.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(patchResp, patchReq)
+	if patchResp.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", patchResp.Code, patchResp.Body.String())
+	}
+
+	patchedResp := httptest.NewRecorder()
+	patchedReq := httptest.NewRequest(http.MethodGet, "/payload", nil)
+	engine.ServeHTTP(patchedResp, patchedReq)
+	if patchedResp.Code != http.StatusOK {
+		t.Fatalf("patched get status = %d, body = %s", patchedResp.Code, patchedResp.Body.String())
+	}
+	assertAdvancedPayloadMatcher(t, patchedResp.Body.Bytes())
+	assertPayloadHasSections(t, patchedResp.Body.Bytes(), "default", "override", "filter")
+}
+
 func providerKeyFirstModel(t *testing.T, raw []byte, key string) map[string]any {
 	t.Helper()
 
@@ -239,6 +344,84 @@ func providerKeyFirstModel(t *testing.T, raw []byte, key string) map[string]any 
 		t.Fatalf("%s first model = %+v, want object", key, rawModels[0])
 	}
 	return model
+}
+
+func assertAdvancedPayloadMatcher(t *testing.T, raw []byte) {
+	t.Helper()
+
+	var root map[string]any
+	if errDecode := json.Unmarshal(raw, &root); errDecode != nil {
+		t.Fatalf("decode payload response: %v; body = %s", errDecode, string(raw))
+	}
+	payloadRoot, ok := root["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload root = %#v, want object; body = %s", root["payload"], string(raw))
+	}
+	defaultRules, ok := payloadRoot["default"].([]any)
+	if !ok || len(defaultRules) != 1 {
+		t.Fatalf("payload.default = %#v, want one rule; body = %s", payloadRoot["default"], string(raw))
+	}
+	defaultRule, ok := defaultRules[0].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.default[0] = %#v, want object", defaultRules[0])
+	}
+	models, ok := defaultRule["models"].([]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("payload.default[0].models = %#v, want one model", defaultRule["models"])
+	}
+	model, ok := models[0].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.default[0].models[0] = %#v, want object", models[0])
+	}
+	if model["from-protocol"] != "responses" {
+		t.Fatalf("from-protocol = %#v, want responses; model = %#v", model["from-protocol"], model)
+	}
+	headers, ok := model["headers"].(map[string]any)
+	if !ok || headers["X-Client-Tier"] != "tenant-*" {
+		t.Fatalf("headers = %#v, want X-Client-Tier matcher", model["headers"])
+	}
+	match, ok := model["match"].([]any)
+	if !ok || len(match) != 1 {
+		t.Fatalf("match = %#v, want one matcher", model["match"])
+	}
+	matchMap, ok := match[0].(map[string]any)
+	if !ok || matchMap["metadata.client"] != "codex" {
+		t.Fatalf("match[0] = %#v, want metadata.client matcher", match[0])
+	}
+	notMatch, ok := model["not-match"].([]any)
+	if !ok || len(notMatch) != 1 {
+		t.Fatalf("not-match = %#v, want one matcher", model["not-match"])
+	}
+	notMatchMap, ok := notMatch[0].(map[string]any)
+	if !ok || notMatchMap["metadata.mode"] != "dev" {
+		t.Fatalf("not-match[0] = %#v, want metadata.mode matcher", notMatch[0])
+	}
+	exist, ok := model["exist"].([]any)
+	if !ok || len(exist) != 1 || exist[0] != `tools.#(type=="web_search").type` {
+		t.Fatalf("exist = %#v, want web_search path", model["exist"])
+	}
+	notExist, ok := model["not-exist"].([]any)
+	if !ok || len(notExist) != 1 || notExist[0] != "metadata.disable_payload" {
+		t.Fatalf("not-exist = %#v, want disable_payload path", model["not-exist"])
+	}
+}
+
+func assertPayloadHasSections(t *testing.T, raw []byte, sections ...string) {
+	t.Helper()
+
+	var root map[string]any
+	if errDecode := json.Unmarshal(raw, &root); errDecode != nil {
+		t.Fatalf("decode payload response: %v; body = %s", errDecode, string(raw))
+	}
+	payloadRoot, ok := root["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload root = %#v, want object; body = %s", root["payload"], string(raw))
+	}
+	for _, section := range sections {
+		if _, exists := payloadRoot[section]; !exists {
+			t.Fatalf("payload missing section %q after patch: %#v", section, payloadRoot)
+		}
+	}
 }
 
 func assertOAuthModelAliasForceMapping(t *testing.T, raw []byte) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,18 @@ type PayloadModelRule struct {
 	Name string `yaml:"name" json:"name"`
 	// Protocol restricts the rule to a specific translator format (e.g., "gemini", "responses").
 	Protocol string `yaml:"protocol" json:"protocol"`
+	// Headers restricts the rule to requests whose headers match all configured wildcard patterns.
+	Headers map[string]string `yaml:"headers" json:"headers"`
+	// FromProtocol restricts the rule to a specific source protocol (e.g., "gemini", "responses").
+	FromProtocol string `yaml:"from-protocol" json:"from-protocol"`
+	// Match requires payload JSON paths to equal the configured values.
+	Match []map[string]any `yaml:"match" json:"match"`
+	// NotMatch requires payload JSON paths to not equal the configured values.
+	NotMatch []map[string]any `yaml:"not-match" json:"not-match"`
+	// Exist requires payload JSON paths to exist and not be null.
+	Exist []string `yaml:"exist" json:"exist"`
+	// NotExist requires payload JSON paths to be missing or null.
+	NotExist []string `yaml:"not-exist" json:"not-exist"`
 }
 
 // CloakConfig configures request cloaking for non-Claude-Code clients.

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -284,7 +284,7 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodDelete, "/oauth-model-alias", handler.DeleteOAuthModelAlias)
 	r.Set(http.MethodGet, "/payload", handler.GetConfigRoot("/payload"))
 	r.Set(http.MethodPut, "/payload", handler.PutConfigRoot("/payload"))
-	r.Set(http.MethodPatch, "/payload", handler.PutConfigRoot("/payload"))
+	r.Set(http.MethodPatch, "/payload", handler.PatchConfigRoot("/payload"))
 	r.Set(http.MethodDelete, "/payload", handler.DeleteConfigRoot("/payload"))
 
 	r.Set(http.MethodGet, "/auth-files", handler.ListAuthFiles)


### PR DESCRIPTION
## Summary

- Extend `PayloadModelRule` to support advanced matcher fields aligned with CPA:
  - `from-protocol`
  - `headers`
  - `match`
  - `not-match`
  - `exist`
  - `not-exist`
- Preserve advanced payload matcher fields across DB-backed config runtime conversion and Management API round-trips.
- Change `PATCH /payload` to merge-patch semantics so partial updates keep sibling sections and advanced matcher fields.
- Update Management API docs and example config for the expanded payload schema.

## Verification

- `go test -run 'TestRuntimeConfigFromRootPreservesAdvancedPayloadModelMatchers' ./internal/cluster`
- `go test -run 'TestPayloadAdvancedMatchersRoundTrip' ./internal/cluster/management`
- `go build -o test-output ./cmd/home`
- `git diff --check`
- `git diff --cached --check`