### PR TITLE
feat: add user period credit limits and unlimited balance mode

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -256,6 +256,8 @@ The table below is extracted from the final Home route registry built by `intern
 | `GET` | `/users` |
 | `POST` | `/users` |
 | `DELETE` | `/users/:id` |
+| `GET` | `/users/:id/period-limits` |
+| `POST` | `/users/:id/period-limits/reset` |
 | `GET` | `/users/:id` |
 | `PATCH` | `/users/:id` |
 | `PUT` | `/users/:id` |
@@ -819,6 +821,7 @@ Example response:
       "username": "alice",
       "password_set": true,
       "credits": 10.5,
+      "credits_unlimited": false,
       "mfa": { "enabled": true },
       "passkey": [{ "id": "credential-id" }],
       "created_at": "2026-05-27T10:00:00Z",
@@ -848,6 +851,7 @@ Example response:
     "username": "alice",
     "password_set": true,
     "credits": 10.5,
+    "credits_unlimited": false,
     "mfa": { "enabled": true },
     "passkey": [{ "id": "credential-id" }],
     "created_at": "2026-05-27T10:00:00Z",
@@ -878,6 +882,18 @@ Example request:
 | `username` | string | yes | Username. Aliases: `user_name`, `user-name`. |
 | `password` | string | no | Non-empty plaintext is stored as a bcrypt hash. Existing valid bcrypt hashes are preserved for migration. Responses do not return password material; they return `password_set`. |
 | `credits` | number | no | User credit balance. Defaults to `0`. When a client API key is bound to this user and credits are `<= 0`, RESP `RPOP auth` returns `user_credits_insufficient`. For billing workflows, prefer `/billing/balance-records/recharge` and `/billing/balance-records/deduct` so balance changes have ledger records. |
+| `credits_unlimited` | boolean | no | When `true`, dispatch ignores the total `credits` balance and billing charges do not deduct it. Period limits still apply. Defaults to `false`. |
+| `timezone` | string | no | IANA timezone for calendar windows; default `Asia/Shanghai`. |
+| `limit_5h_credits` | number/null | no | 5-hour credits limit. `null` clears/disables. `0` blocks immediately. |
+| `window_mode_5h` | string | no | `first_use` (default; alias `fixed`) or `sliding`. |
+| `limit_1d_credits` | number/null | no | 1-day credits limit. |
+| `window_mode_1d` | string | no | `first_use`, `sliding` (alias `rolling`), or `calendar` (default `first_use`). |
+| `limit_7d_credits` | number/null | no | 7-day credits limit. |
+| `window_mode_7d` | string | no | `first_use`, `sliding` (alias `rolling`), or `calendar` (default `first_use`). |
+| `week_reset_day` | integer | no | Calendar week start day, `1=Mon` .. `7=Sun` (default `1`). |
+| `week_reset_hour` | integer | no | Calendar week start hour `0-23` (default `0`). |
+| `limit_30d_credits` | number/null | no | 30-day / month credits limit. |
+| `window_mode_30d` | string | no | `first_use`, `sliding` (alias `rolling`), or `calendar` (default `first_use`). Calendar uses calendar months. |
 | `mfa` | any valid JSON | no | Stored in `user.mfa`. |
 | `passkey` | any valid JSON | no | Stored in `user.passkey`. |
 
@@ -900,8 +916,65 @@ Example request:
 ```
 
 All request fields are optional, but `username`, if present, must not be empty. `credits`, if present, replaces the user's current credit balance. For billing workflows, prefer `/billing/balance-records/recharge` and `/billing/balance-records/deduct` so balance changes have ledger records.
+Set `credits_unlimited` to `true` when the user should have unlimited total balance but still be constrained by configured period limits.
 
 Response: same shape as `GET /users/:id`.
+
+
+### GET `/users/:id/period-limits`
+
+Returns the user's period-limit configuration and current usage.
+
+Response fields include `timezone`, `credits`, `credits_unlimited`, and `windows[]` with:
+
+| Field | Description |
+| --- | --- |
+| `id` | `5h`, `1d`, `7d`, or `30d`. |
+| `enabled` | `true` when the limit is configured (`limit != null`). |
+| `limit` | Credits limit for the window; `null` means disabled. |
+| `used` | Credits spent in the current window (`SUM(billing_charge.amount)`). |
+| `remaining` | `max(limit - used, 0)` when enabled. |
+| `mode` | `first_use`, `sliding`, or `calendar` (`calendar` only for `1d`/`7d`/`30d`). |
+| `window_start` / `window_end` / `reset_at` | Current window bounds when active. |
+| `usage_epoch` | Soft-reset marker; usage only counts charges at/after this time. |
+
+`5h` supports `first_use` (default, **first billable charge** opens a 5h window; legacy alias `fixed`) or `sliding` (rolling 5h). `1d`/`7d`/`30d` support `first_use` (default, first-charge duration; legacy alias `fixed`), `sliding` (rolling duration), or `calendar` (natural day/week/month). Dispatch probes do not open `first_use` windows. Calendar mode uses `timezone` (default `Asia/Shanghai`). Calendar `7d` uses `week_reset_day` (1=Mon..7=Sun) and `week_reset_hour`. Calendar `30d` is a calendar month, not a rolling 30-day span.
+
+Product alignment (Claude Code / Codex):
+- Short window `5h` defaults to `first_use`: the first billable charge opens a 5-hour session; the limit is a credits budget inside that window, not five hours of continuous work.
+- Longer windows (`7d` / `30d`) stack independently; all enabled windows are enforced with AND.
+- Use `calendar` on `1d` / `7d` / `30d` for natural day / week / month resets.
+- Use `sliding` (alias `rolling`) when usage should recover continuously as older spend ages out.
+
+### POST `/users/:id/period-limits/reset`
+
+Soft-resets period counters without deleting billing history.
+
+Request body:
+
+```json
+{ "windows": ["5h", "1d"], "mode": "counter" }
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `windows` | string[] | no | Subset of `5h`/`1d`/`7d`/`30d`. Empty/omitted resets all windows. |
+| `mode` | string | no | `counter` (default): for each selected window set `usage_epoch_* = now` and clear the matching `period_window_start_*`. `window_only`: clear `period_window_start_*`; for `sliding`/`calendar` also set `usage_epoch_*` so used actually resets. |
+
+Response:
+
+```json
+{
+  "status": "ok",
+  "user_id": 1,
+  "reset": { "mode": "counter", "windows": ["5h", "1d"], "at": "2026-07-09T12:00:00Z" },
+  "limits": { "user_id": 1, "windows": [] }
+}
+```
+
+Period limits are enforced at dispatch for every API key owned by the user (`user_credits_insufficient` and `user_period_limit_exceeded`). When `credits_unlimited=true`, the total-balance check is skipped, but enabled period windows are still enforced.
+
+Enforcement is a **soft limit**: cost is known only after the request, so a final/in-flight request may push `used` past `limit`; the next dispatch is blocked. `first_use` opens on the first **billable charge**, not on dispatch probes.
 
 ### DELETE `/users/:id`
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -256,6 +256,8 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `GET` | `/users` |
 | `POST` | `/users` |
 | `DELETE` | `/users/:id` |
+| `GET` | `/users/:id/period-limits` |
+| `POST` | `/users/:id/period-limits/reset` |
 | `GET` | `/users/:id` |
 | `PATCH` | `/users/:id` |
 | `PUT` | `/users/:id` |
@@ -819,6 +821,7 @@ User records 存储在 cluster repository 中。
       "username": "alice",
       "password_set": true,
       "credits": 10.5,
+      "credits_unlimited": false,
       "mfa": { "enabled": true },
       "passkey": [{ "id": "credential-id" }],
       "created_at": "2026-05-27T10:00:00Z",
@@ -848,6 +851,7 @@ Path 参数：
     "username": "alice",
     "password_set": true,
     "credits": 10.5,
+    "credits_unlimited": false,
     "mfa": { "enabled": true },
     "passkey": [{ "id": "credential-id" }],
     "created_at": "2026-05-27T10:00:00Z",
@@ -878,6 +882,18 @@ Path 参数：
 | `username` | string | 是 | 用户名；也接受 `user_name`、`user-name`。 |
 | `password` | string | 否 | 非空明文会以 bcrypt hash 存储。已有合法 bcrypt hash 会原样保留，便于迁移。响应不返回密码材料，只返回 `password_set`。 |
 | `credits` | number | 否 | 用户点数余额；默认为 `0`。当客户端 API key 绑定到该用户且 credits `<= 0` 时，RESP `RPOP auth` 返回 `user_credits_insufficient`。对于计费工作流，优先使用 `/billing/balance-records/recharge` 和 `/billing/balance-records/deduct`，以便余额变更拥有分类账记录。 |
+| `credits_unlimited` | boolean | 否 | 为 `true` 时，派发忽略总 `credits` 余额，计费扣费也不减少余额；周期限额仍生效。默认 `false`。 |
+| `timezone` | string | 否 | 自然日/周/月使用的 IANA 时区；默认 `Asia/Shanghai`。 |
+| `limit_5h_credits` | number/null | 否 | 5 小时 credits 限额。`null` 清除/关闭。`0` 立即不可用。 |
+| `window_mode_5h` | string | 否 | `first_use`（默认；别名 `fixed`）或 `sliding`。 |
+| `limit_1d_credits` | number/null | 否 | 1 天 credits 限额。 |
+| `window_mode_1d` | string | 否 | `first_use`、`sliding`（别名 `rolling`）或 `calendar`（默认 `first_use`）。 |
+| `limit_7d_credits` | number/null | 否 | 7 天 credits 限额。 |
+| `window_mode_7d` | string | 否 | `first_use`、`sliding`（别名 `rolling`）或 `calendar`（默认 `first_use`）。 |
+| `week_reset_day` | integer | 否 | 自然周起点，`1=周一` .. `7=周日`（默认 `1`）。 |
+| `week_reset_hour` | integer | 否 | 自然周起点小时 `0-23`（默认 `0`）。 |
+| `limit_30d_credits` | number/null | 否 | 30 天/自然月 credits 限额。 |
+| `window_mode_30d` | string | 否 | `first_use`、`sliding`（别名 `rolling`）或 `calendar`（默认 `first_use`）。`calendar` 为自然月。 |
 | `mfa` | any valid JSON | 否 | 存入 `user.mfa`。 |
 | `passkey` | any valid JSON | 否 | 存入 `user.passkey`。 |
 
@@ -900,8 +916,65 @@ Path 参数：
 ```
 
 所有字段均可选；如果出现 `username`，则不能为空。`credits` 如果出现，会替换用户当前点数余额。对于计费工作流，优先使用 `/billing/balance-records/recharge` 和 `/billing/balance-records/deduct`，以便余额变更拥有分类账记录。
+当用户需要无限总余额、但仍受独立周期限额约束时，将 `credits_unlimited` 设为 `true`。
 
 输出：与 `GET /users/:id` 相同。
+
+
+### GET `/users/:id/period-limits`
+
+返回用户周期限额配置与当前用量。
+
+响应包含 `timezone`、`credits`、`credits_unlimited` 和 `windows[]`：
+
+| 字段 | 说明 |
+| --- | --- |
+| `id` | `5h`、`1d`、`7d` 或 `30d`。 |
+| `enabled` | 已配置限额时为 `true`（`limit != null`）。 |
+| `limit` | 窗口 credits 上限；`null` 表示关闭。 |
+| `used` | 当前窗口已消费 credits（`SUM(billing_charge.amount)`）。 |
+| `remaining` | 启用时为 `max(limit - used, 0)`。 |
+| `mode` | 规范值为 `first_use`、`sliding` 或 `calendar`（`calendar` 仅 `1d`/`7d`/`30d`）。别名 `fixed`→`first_use`，`rolling`→`sliding`。 |
+| `window_start` / `window_end` / `reset_at` | 活跃窗口边界。 |
+| `usage_epoch` | 软重置标记；只统计该时间之后的扣费。 |
+
+`5h` 支持 `first_use`（默认，**首次成功计费扣费**开 5h 窗；兼容别名 `fixed`）或 `sliding`（滚动 5h）。`1d`/`7d`/`30d` 支持 `first_use`（默认，首次计费起算时长；兼容别名 `fixed`）、`sliding`（滚动时长）或 `calendar`（自然日/周/月）。派发探测不会打开 `first_use` 窗口。自然周期使用 `timezone`（默认 `Asia/Shanghai`）。自然周使用 `week_reset_day`（1=周一..7=周日）和 `week_reset_hour`。自然 `30d` 按自然月计算。
+
+产品对齐（Claude Code / Codex）：
+- 短窗 `5h` 默认 `first_use`：首次成功计费开启 5 小时会话窗，窗内是 credits 预算（不是“能连续工作 5 小时”）。
+- 长窗 `7d`/`30d` 可独立叠加；两层同时生效（AND）。
+- 需要自然日/周/月刷新时，对 `1d`/`7d`/`30d` 选 `calendar`。
+- 需要“随时间滚动恢复”时选 `sliding`（别名 `rolling`）。
+
+### POST `/users/:id/period-limits/reset`
+
+软重置周期计数，不删除账单历史。
+
+请求体：
+
+```json
+{ "windows": ["5h", "1d"], "mode": "counter" }
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `windows` | string[] | 否 | `5h`/`1d`/`7d`/`30d` 子集。空/省略表示全部。 |
+| `mode` | string | 否 | `counter`（默认）：对选中窗口设置 `usage_epoch_* = now` 并清除对应 `period_window_start_*`。`window_only`：清除 `period_window_start_*`；对 `sliding`/`calendar` 窗口同时写 `usage_epoch_*`（否则无法真正清零 used）。 |
+
+响应：
+
+```json
+{
+  "status": "ok",
+  "user_id": 1,
+  "reset": { "mode": "counter", "windows": ["5h", "1d"], "at": "2026-07-09T12:00:00Z" },
+  "limits": { "user_id": 1, "windows": [] }
+}
+```
+
+周期限额在派发时对用户名下所有 API key 生效（`user_credits_insufficient` 与 `user_period_limit_exceeded`）。当 `credits_unlimited=true` 时跳过总余额检查，但已启用的周期窗口仍会拦截。
+
+执行模型为 **soft limit**：费用在请求完成后才记账，因此允许尾笔/并发 in-flight 请求把 used 顶过 limit；下一笔派发会被拦截。`first_use` 在首次 **billable charge** 开窗，不在 dispatch 探活时开窗。
 
 ### DELETE `/users/:id`
 

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	homeerrors "github.com/router-for-me/CLIProxyAPIHome/internal/errors"
 	"gorm.io/gorm"
 )
 
@@ -407,9 +406,9 @@ func (r *Repository) AllowedDispatchIDsForAPIKey(ctx context.Context, apiKey str
 	if errFirst != nil {
 		return nil, nil, errFirst
 	}
-	errCredits := ensureAPIKeyUserCreditsAvailable(ctx, db, &record)
-	if errCredits != nil {
-		return nil, nil, errCredits
+	errBilling := ensureAPIKeyUserBillingAllowed(ctx, db, &record)
+	if errBilling != nil {
+		return nil, nil, errBilling
 	}
 
 	authIDs, errAuthIDs := allowedAuthIDsForAPIKeyRecord(ctx, db, &record)
@@ -424,28 +423,7 @@ func (r *Repository) AllowedDispatchIDsForAPIKey(ctx context.Context, apiKey str
 }
 
 func ensureAPIKeyUserCreditsAvailable(ctx context.Context, db *gorm.DB, record *APIKeyRecord) error {
-	if db == nil {
-		return fmt.Errorf("database connection is nil")
-	}
-	if record == nil {
-		return fmt.Errorf("api key record is nil")
-	}
-	userID := normalizeOptionalUserID(record.UserID)
-	if userID == nil {
-		return nil
-	}
-	user := UserRecord{}
-	errFirst := db.WithContext(contextOrBackground(ctx)).
-		Select("id", "credits").
-		Where("id = ?", *userID).
-		First(&user).Error
-	if errFirst != nil {
-		return errFirst
-	}
-	if user.Credits <= 0 {
-		return fmt.Errorf("%s: %s", homeerrors.TypeUserCreditsInsufficient, homeerrors.MessageUserCreditsInsufficient)
-	}
-	return nil
+	return ensureAPIKeyUserBillingAllowed(ctx, db, record)
 }
 
 // AllowedAuthIDsForAPIKey returns auth IDs allowed by the API key channel bindings.

--- a/internal/cluster/billing.go
+++ b/internal/cluster/billing.go
@@ -586,6 +586,11 @@ func (r *Repository) createBillingChargeForUsageTx(ctx context.Context, tx *gorm
 		return nil
 	}
 
+	// Open first_use period windows on the first billable charge (not on dispatch probes).
+	if errOpen := openUserFirstUseWindowsOnChargeTx(ctx, tx, *userID, charge.CreatedAt); errOpen != nil {
+		return errOpen
+	}
+
 	balanceBefore, balanceAfter, errCredits := billingApplyUserCreditDeltaTx(ctx, tx, *userID, -amount)
 	if errCredits != nil {
 		return errCredits
@@ -699,13 +704,13 @@ func billingApplyUserCreditDeltaTx(ctx context.Context, tx *gorm.DB, userID uint
 	ctx = contextOrBackground(ctx)
 	for attempt := 0; attempt < billingCreditMaxRetries; attempt++ {
 		user := &UserRecord{}
-		if errFirst := tx.WithContext(ctx).Select("id", "credits").Where("id = ?", userID).First(user).Error; errFirst != nil {
+		if errFirst := tx.WithContext(ctx).Select("id", "credits", "credits_unlimited").Where("id = ?", userID).First(user).Error; errFirst != nil {
 			return 0, 0, errFirst
 		}
 		balanceBefore := user.Credits
 		balanceAfter := balanceBefore + delta
-		if delta == 0 {
-			return balanceBefore, balanceAfter, nil
+		if delta == 0 || user.CreditsUnlimited {
+			return balanceBefore, balanceBefore, nil
 		}
 		update := tx.WithContext(ctx).
 			Model(&UserRecord{}).

--- a/internal/cluster/billing_test.go
+++ b/internal/cluster/billing_test.go
@@ -382,6 +382,60 @@ func TestAppendUsageCreatesBillingChargeAndDeductsCredits(t *testing.T) {
 	}
 }
 
+func TestAppendUsageUnlimitedCreditsKeepsBalanceAndRecordsCharge(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	username := "unlimited@example.com"
+	unlimited := true
+	user, errCreateUser := repo.CreateUser(ctx, UserUpdate{Username: &username, CreditsUnlimited: &unlimited})
+	if errCreateUser != nil {
+		t.Fatalf("CreateUser() error = %v", errCreateUser)
+	}
+	clientKey := "client-key-unlimited"
+	if _, errCreateKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &clientKey}); errCreateKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errCreateKey)
+	}
+	if _, errCreatePrice := repo.CreateBillingModelPrice(ctx, BillingModelPriceUpdate{
+		Provider:     "openai",
+		Model:        "gpt-4.1-mini",
+		RequestPrice: 2,
+		Enabled:      true,
+	}); errCreatePrice != nil {
+		t.Fatalf("CreateBillingModelPrice() error = %v", errCreatePrice)
+	}
+
+	payload := `{"timestamp":"2026-06-10T01:02:03Z","provider":"openai","model":"gpt-4.1-mini","api_key":"client-key-unlimited","request_id":"req-unlimited","tokens":{"total_tokens":1}}`
+	if _, errUsage := repo.AppendUsage(ctx, payload, "192.0.2.10"); errUsage != nil {
+		t.Fatalf("AppendUsage() error = %v", errUsage)
+	}
+
+	charges, errCharges := repo.ListBillingCharges(ctx, BillingChargeQuery{UserID: &user.ID, Limit: 10})
+	if errCharges != nil {
+		t.Fatalf("ListBillingCharges() error = %v", errCharges)
+	}
+	if len(charges.Records) != 1 {
+		t.Fatalf("charge count = %d, want 1", len(charges.Records))
+	}
+	charge := charges.Records[0]
+	if charge.Amount != 2 {
+		t.Fatalf("charge amount = %v, want 2", charge.Amount)
+	}
+	if charge.BalanceBefore != 0 || charge.BalanceAfter != 0 {
+		t.Fatalf("charge balances = %v -> %v, want 0 -> 0", charge.BalanceBefore, charge.BalanceAfter)
+	}
+	updated, errUser := repo.GetUser(ctx, user.ID)
+	if errUser != nil {
+		t.Fatalf("GetUser() error = %v", errUser)
+	}
+	if updated.Credits != 0 {
+		t.Fatalf("credits = %v, want unchanged 0", updated.Credits)
+	}
+}
+
 func TestAppendUsageChargesCachedTokensWithCacheReadPrice(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cluster/management/users.go
+++ b/internal/cluster/management/users.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
@@ -13,14 +15,52 @@ import (
 	"gorm.io/gorm"
 )
 
+type optionalJSONFloat struct {
+	set   bool
+	clear bool
+	value float64
+}
+
+func (o *optionalJSONFloat) UnmarshalJSON(data []byte) error {
+	o.set = true
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "null" {
+		o.clear = true
+		return nil
+	}
+	var value float64
+	if errUnmarshal := json.Unmarshal(data, &value); errUnmarshal != nil {
+		return errUnmarshal
+	}
+	o.value = value
+	return nil
+}
+
 type userWriteRequest struct {
-	Username     *string         `json:"username"`
-	UserName     *string         `json:"user_name"`
-	UserNameDash *string         `json:"user-name"`
-	Password     *string         `json:"password"`
-	Credits      *float64        `json:"credits"`
-	MFA          json.RawMessage `json:"mfa"`
-	Passkey      json.RawMessage `json:"passkey"`
+	Username         *string           `json:"username"`
+	UserName         *string           `json:"user_name"`
+	UserNameDash     *string           `json:"user-name"`
+	Password         *string           `json:"password"`
+	Credits          *float64          `json:"credits"`
+	CreditsUnlimited *bool             `json:"credits_unlimited"`
+	Timezone         *string           `json:"timezone"`
+	Limit5h          optionalJSONFloat `json:"limit_5h_credits"`
+	WindowMode5h     *string           `json:"window_mode_5h"`
+	Limit1d          optionalJSONFloat `json:"limit_1d_credits"`
+	WindowMode1d     *string           `json:"window_mode_1d"`
+	Limit7d          optionalJSONFloat `json:"limit_7d_credits"`
+	WindowMode7d     *string           `json:"window_mode_7d"`
+	WeekResetDay     *int              `json:"week_reset_day"`
+	WeekResetHour    *int              `json:"week_reset_hour"`
+	Limit30d         optionalJSONFloat `json:"limit_30d_credits"`
+	WindowMode30d    *string           `json:"window_mode_30d"`
+	MFA              json.RawMessage   `json:"mfa"`
+	Passkey          json.RawMessage   `json:"passkey"`
+}
+
+type userPeriodLimitResetRequest struct {
+	Windows []string `json:"windows"`
+	Mode    string   `json:"mode"`
 }
 
 // ListUsers returns users.
@@ -77,6 +117,10 @@ func (h *Handler) CreateUser(c *gin.Context) {
 			respondError(c, http.StatusConflict, "user_exists", errCreate)
 			return
 		}
+		if isUserPeriodLimitValidationError(errCreate) {
+			respondError(c, http.StatusBadRequest, "invalid body", errCreate)
+			return
+		}
 		respondError(c, http.StatusInternalServerError, "user_create_failed", errCreate)
 		return
 	}
@@ -103,6 +147,10 @@ func (h *Handler) UpdateUser(c *gin.Context) {
 	defer cancel()
 	record, errUpdate := h.repo.UpdateUser(ctx, id, update)
 	if errUpdate != nil {
+		if isUserPeriodLimitValidationError(errUpdate) {
+			respondError(c, http.StatusBadRequest, "invalid body", errUpdate)
+			return
+		}
 		respondUserRecordError(c, "user_update_failed", errUpdate)
 		return
 	}
@@ -125,6 +173,59 @@ func (h *Handler) DeleteUser(c *gin.Context) {
 	respondOK(c)
 }
 
+// GetUserPeriodLimits returns period-limit configuration and current usage.
+func (h *Handler) GetUserPeriodLimits(c *gin.Context) {
+	id, ok := userIDFromParam(c)
+	if !ok {
+		return
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	status, errStatus := h.repo.BuildUserPeriodLimitsStatus(ctx, id, time.Now().UTC())
+	if errStatus != nil {
+		respondUserRecordError(c, "user_period_limits_load_failed", errStatus)
+		return
+	}
+	c.JSON(http.StatusOK, status)
+}
+
+// ResetUserPeriodLimits resets period-limit counters for a user.
+func (h *Handler) ResetUserPeriodLimits(c *gin.Context) {
+	id, ok := userIDFromParam(c)
+	if !ok {
+		return
+	}
+	var body userPeriodLimitResetRequest
+	if c.Request != nil && c.Request.Body != nil {
+		decoder := json.NewDecoder(c.Request.Body)
+		if errDecode := decoder.Decode(&body); errDecode != nil && !errors.Is(errDecode, io.EOF) {
+			respondError(c, http.StatusBadRequest, "invalid body", errDecode)
+			return
+		}
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	result, errReset := h.repo.ResetUserPeriodLimits(ctx, id, body.Windows, body.Mode, time.Now().UTC())
+	if errReset != nil {
+		if isUserPeriodLimitValidationError(errReset) {
+			respondError(c, http.StatusBadRequest, "invalid body", errReset)
+			return
+		}
+		respondUserRecordError(c, "user_period_limits_reset_failed", errReset)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "ok",
+		"user_id": result.UserID,
+		"reset": gin.H{
+			"mode":    result.Mode,
+			"windows": result.Windows,
+			"at":      result.At,
+		},
+		"limits": result.Limits,
+	})
+}
+
 func userUpdateFromRequest(c *gin.Context, body userWriteRequest, requireUsername bool) (cluster.UserUpdate, bool) {
 	update := cluster.UserUpdate{}
 	username := body.username()
@@ -145,6 +246,18 @@ func userUpdateFromRequest(c *gin.Context, body userWriteRequest, requireUsernam
 	}
 	update.Password = password
 	update.Credits = body.Credits
+	update.CreditsUnlimited = body.CreditsUnlimited
+	update.Timezone = body.Timezone
+	update.Limit5hCredits = optionalFloatToUpdate(body.Limit5h)
+	update.WindowMode5h = body.WindowMode5h
+	update.Limit1dCredits = optionalFloatToUpdate(body.Limit1d)
+	update.WindowMode1d = body.WindowMode1d
+	update.Limit7dCredits = optionalFloatToUpdate(body.Limit7d)
+	update.WindowMode7d = body.WindowMode7d
+	update.WeekResetDay = body.WeekResetDay
+	update.WeekResetHour = body.WeekResetHour
+	update.Limit30dCredits = optionalFloatToUpdate(body.Limit30d)
+	update.WindowMode30d = body.WindowMode30d
 	if len(body.MFA) > 0 {
 		mfa, errMFA := cluster.NormalizeJSONB(body.MFA)
 		if errMFA != nil {
@@ -162,6 +275,16 @@ func userUpdateFromRequest(c *gin.Context, body userWriteRequest, requireUsernam
 		update.Passkey = passkey
 	}
 	return update, true
+}
+
+func optionalFloatToUpdate(value optionalJSONFloat) cluster.OptionalFloatUpdate {
+	if !value.set {
+		return cluster.OptionalFloatUpdate{}
+	}
+	if value.clear {
+		return cluster.OptionalFloatUpdate{Set: true, Clear: true}
+	}
+	return cluster.OptionalFloatUpdate{Set: true, Value: value.value}
 }
 
 func (r userWriteRequest) username() *string {
@@ -220,19 +343,76 @@ func isBcryptPasswordHash(value string) bool {
 	return errCost == nil
 }
 
+func isUserPeriodLimitValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var configErr cluster.PeriodLimitConfigError
+	if errors.As(err, &configErr) {
+		return true
+	}
+	// Fallback for wrapped field-prefix errors from applyUserPeriodLimitUpdate.
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "limit_"),
+		strings.Contains(message, "window mode"),
+		strings.Contains(message, "window_mode"),
+		strings.Contains(message, "timezone"),
+		strings.Contains(message, "week_reset"),
+		strings.Contains(message, "period window"),
+		strings.Contains(message, "reset mode"),
+		strings.Contains(message, "non-negative"):
+		return true
+	default:
+		return false
+	}
+}
+
 func userRecordToMap(record *cluster.UserRecord) gin.H {
 	if record == nil {
 		return gin.H{}
 	}
+	timezone := strings.TrimSpace(record.Timezone)
+	if timezone == "" {
+		timezone = cluster.DefaultUserTimezone
+	}
+	windowMode5h := cluster.CanonicalPeriodWindowMode(record.WindowMode5h, false)
+	windowMode1d := cluster.CanonicalPeriodWindowMode(record.WindowMode1d, true)
+	windowMode7d := cluster.CanonicalPeriodWindowMode(record.WindowMode7d, true)
+	windowMode30d := cluster.CanonicalPeriodWindowMode(record.WindowMode30d, true)
+	weekResetDay := record.WeekResetDay
+	if weekResetDay == 0 {
+		weekResetDay = cluster.DefaultWeekResetDay
+	}
 	return gin.H{
-		"id":           record.ID,
-		"username":     record.Username,
-		"password_set": record.Password != "",
-		"credits":      record.Credits,
-		"mfa":          record.MFA,
-		"passkey":      record.Passkey,
-		"created_at":   record.CreatedAt,
-		"updated_at":   record.UpdatedAt,
-		"deleted_at":   deletedAtValue(record.DeletedAt),
+		"id":                      record.ID,
+		"username":                record.Username,
+		"password_set":            record.Password != "",
+		"credits":                 record.Credits,
+		"credits_unlimited":       record.CreditsUnlimited,
+		"timezone":                timezone,
+		"limit_5h_credits":        record.Limit5hCredits,
+		"window_mode_5h":          windowMode5h,
+		"limit_1d_credits":        record.Limit1dCredits,
+		"window_mode_1d":          windowMode1d,
+		"limit_7d_credits":        record.Limit7dCredits,
+		"window_mode_7d":          windowMode7d,
+		"week_reset_day":          weekResetDay,
+		"week_reset_hour":         record.WeekResetHour,
+		"limit_30d_credits":       record.Limit30dCredits,
+		"window_mode_30d":         windowMode30d,
+		"period_window_start_5h":  record.PeriodWindowStart5h,
+		"period_window_start_1d":  record.PeriodWindowStart1d,
+		"period_window_start_7d":  record.PeriodWindowStart7d,
+		"period_window_start_30d": record.PeriodWindowStart30d,
+		"usage_epoch_5h":          record.UsageEpoch5h,
+		"usage_epoch_1d":          record.UsageEpoch1d,
+		"usage_epoch_7d":          record.UsageEpoch7d,
+		"usage_epoch_30d":         record.UsageEpoch30d,
+		"mfa":                     record.MFA,
+		"passkey":                 record.Passkey,
+		"created_at":              record.CreatedAt,
+		"updated_at":              record.UpdatedAt,
+		"deleted_at":              deletedAtValue(record.DeletedAt),
 	}
 }

--- a/internal/cluster/management/users_test.go
+++ b/internal/cluster/management/users_test.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
@@ -65,4 +66,54 @@ func stringValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func TestOptionalJSONFloatNullAndValue(t *testing.T) {
+	t.Parallel()
+
+	var body userWriteRequest
+	if err := json.Unmarshal([]byte(`{"limit_1d_credits":null,"limit_5h_credits":12.5}`), &body); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !body.Limit1d.set || !body.Limit1d.clear {
+		t.Fatalf("limit_1d = %+v, want set+clear", body.Limit1d)
+	}
+	if !body.Limit5h.set || body.Limit5h.clear || body.Limit5h.value != 12.5 {
+		t.Fatalf("limit_5h = %+v, want value 12.5", body.Limit5h)
+	}
+	update, ok := userUpdateFromRequest(nil, body, false)
+	if !ok {
+		t.Fatal("userUpdateFromRequest failed")
+	}
+	if !update.Limit1dCredits.Set || !update.Limit1dCredits.Clear {
+		t.Fatalf("update.Limit1dCredits = %+v", update.Limit1dCredits)
+	}
+	if !update.Limit5hCredits.Set || update.Limit5hCredits.Clear || update.Limit5hCredits.Value != 12.5 {
+		t.Fatalf("update.Limit5hCredits = %+v", update.Limit5hCredits)
+	}
+}
+
+func TestUserRecordToMapIncludesPeriodLimitFields(t *testing.T) {
+	t.Parallel()
+
+	limit := 9.0
+	item := userRecordToMap(&cluster.UserRecord{
+		Username:         "alice",
+		CreditsUnlimited: true,
+		Limit5hCredits:   &limit,
+		// Legacy alias "rolling" must surface as canonical "sliding".
+		WindowMode1d: cluster.PeriodWindowModeRolling,
+	})
+	if item["limit_5h_credits"] == nil {
+		t.Fatalf("limit_5h_credits missing: %#v", item)
+	}
+	if item["window_mode_1d"] != cluster.PeriodWindowModeSliding {
+		t.Fatalf("window_mode_1d = %v, want sliding", item["window_mode_1d"])
+	}
+	if item["timezone"] != cluster.DefaultUserTimezone {
+		t.Fatalf("timezone = %v", item["timezone"])
+	}
+	if item["credits_unlimited"] != true {
+		t.Fatalf("credits_unlimited = %v, want true", item["credits_unlimited"])
+	}
 }

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -196,15 +196,41 @@ func (PluginTaskRecord) TableName() string {
 }
 
 type UserRecord struct {
-	ID        uint           `gorm:"column:id;primaryKey;autoIncrement;index:idx_user_active_order,priority:2"`
-	Username  string         `gorm:"column:username;not null;index;index:idx_user_username_active,priority:1"`
-	Password  string         `gorm:"column:password;type:text"`
-	Credits   float64        `gorm:"column:credits;not null;default:0"`
-	MFA       JSONB          `gorm:"column:mfa"`
-	Passkey   JSONB          `gorm:"column:passkey"`
-	CreatedAt time.Time      `gorm:"column:created_at"`
-	UpdatedAt time.Time      `gorm:"column:updated_at"`
-	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at;index;index:idx_user_active_order,priority:1;index:idx_user_username_active,priority:2"`
+	ID               uint    `gorm:"column:id;primaryKey;autoIncrement;index:idx_user_active_order,priority:2"`
+	Username         string  `gorm:"column:username;not null;index;index:idx_user_username_active,priority:1"`
+	Password         string  `gorm:"column:password;type:text"`
+	Credits          float64 `gorm:"column:credits;not null;default:0"`
+	CreditsUnlimited bool    `gorm:"column:credits_unlimited;not null;default:false"`
+	Timezone         string  `gorm:"column:timezone;not null;default:Asia/Shanghai"`
+	// Period cost limits (null = disabled). Subject is user; all API keys inherit.
+	// window_mode_*: first_use (default; first billable charge opens a duration
+	// window, Claude/Codex-style session), sliding (rolling last-N duration),
+	// calendar (natural day/week/month; 1d/7d/30d only). Legacy alias: fixed -> first_use.
+	Limit5hCredits  *float64 `gorm:"column:limit_5h_credits"`
+	WindowMode5h    string   `gorm:"column:window_mode_5h;not null;default:first_use"`
+	Limit1dCredits  *float64 `gorm:"column:limit_1d_credits"`
+	WindowMode1d    string   `gorm:"column:window_mode_1d;not null;default:first_use"`
+	Limit7dCredits  *float64 `gorm:"column:limit_7d_credits"`
+	WindowMode7d    string   `gorm:"column:window_mode_7d;not null;default:first_use"`
+	WeekResetDay    int      `gorm:"column:week_reset_day;not null;default:1"`
+	WeekResetHour   int      `gorm:"column:week_reset_hour;not null;default:0"`
+	Limit30dCredits *float64 `gorm:"column:limit_30d_credits"`
+	WindowMode30d   string   `gorm:"column:window_mode_30d;not null;default:first_use"`
+	// first_use window runtime state (first billable charge opens the window).
+	PeriodWindowStart5h  *time.Time `gorm:"column:period_window_start_5h"`
+	PeriodWindowStart1d  *time.Time `gorm:"column:period_window_start_1d"`
+	PeriodWindowStart7d  *time.Time `gorm:"column:period_window_start_7d"`
+	PeriodWindowStart30d *time.Time `gorm:"column:period_window_start_30d"`
+	// Soft reset markers: SUM only counts charges at/after max(window_lower, epoch).
+	UsageEpoch5h  *time.Time     `gorm:"column:usage_epoch_5h"`
+	UsageEpoch1d  *time.Time     `gorm:"column:usage_epoch_1d"`
+	UsageEpoch7d  *time.Time     `gorm:"column:usage_epoch_7d"`
+	UsageEpoch30d *time.Time     `gorm:"column:usage_epoch_30d"`
+	MFA           JSONB          `gorm:"column:mfa"`
+	Passkey       JSONB          `gorm:"column:passkey"`
+	CreatedAt     time.Time      `gorm:"column:created_at"`
+	UpdatedAt     time.Time      `gorm:"column:updated_at"`
+	DeletedAt     gorm.DeletedAt `gorm:"column:deleted_at;index;index:idx_user_active_order,priority:1;index:idx_user_username_active,priority:2"`
 }
 
 // TableName returns the database table name.

--- a/internal/cluster/user_period_limit.go
+++ b/internal/cluster/user_period_limit.go
@@ -1,0 +1,924 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	homeerrors "github.com/router-for-me/CLIProxyAPIHome/internal/errors"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	PeriodWindow5h  = "5h"
+	PeriodWindow1d  = "1d"
+	PeriodWindow7d  = "7d"
+	PeriodWindow30d = "30d"
+
+	// Period window modes (canonical values stored and returned by APIs).
+	// first_use: first billable charge opens a wall-clock duration window.
+	//   Aligns with Claude Code / Codex "5h session" + optional weekly layers:
+	//   quota is a spend budget inside the window, not wall-clock working time.
+	// sliding: rolling last-N duration (API also accepts "rolling").
+	// calendar: natural day / week / month (1d/7d/30d only).
+	// "fixed" is a deprecated alias of first_use (name was ambiguous).
+	PeriodWindowModeFirstUse = "first_use"
+	PeriodWindowModeFixed    = "fixed" // deprecated alias of first_use
+	PeriodWindowModeSliding  = "sliding"
+	PeriodWindowModeRolling  = "rolling" // alias of sliding
+	PeriodWindowModeCalendar = "calendar"
+
+	PeriodResetModeCounter    = "counter"
+	PeriodResetModeWindowOnly = "window_only"
+
+	DefaultUserTimezone     = "Asia/Shanghai"
+	DefaultPeriodWindowMode = PeriodWindowModeFirstUse
+	DefaultWeekResetDay     = 1
+	DefaultWeekResetHour    = 0
+
+	periodLimit5hDuration  = 5 * time.Hour
+	periodLimit1dDuration  = 24 * time.Hour
+	periodLimit7dDuration  = 7 * 24 * time.Hour
+	periodLimit30dDuration = 30 * 24 * time.Hour
+)
+
+// OptionalFloatUpdate captures a three-state float patch: absent / null / value.
+
+// PeriodLimitConfigError is returned for invalid period-limit configuration inputs.
+type PeriodLimitConfigError struct {
+	Message string
+}
+
+func (e PeriodLimitConfigError) Error() string {
+	if e.Message == "" {
+		return "invalid period limit configuration"
+	}
+	return e.Message
+}
+
+func periodLimitConfigErrorf(format string, args ...any) error {
+	return PeriodLimitConfigError{Message: fmt.Sprintf(format, args...)}
+}
+
+type OptionalFloatUpdate struct {
+	Set   bool
+	Clear bool
+	Value float64
+}
+
+// UserPeriodWindowStatus is the management-facing status for one window.
+type UserPeriodWindowStatus struct {
+	ID            string     `json:"id"`
+	Enabled       bool       `json:"enabled"`
+	Limit         *float64   `json:"limit"`
+	Used          float64    `json:"used"`
+	Remaining     *float64   `json:"remaining"`
+	Mode          string     `json:"mode"`
+	Active        bool       `json:"active"`
+	WindowStart   *time.Time `json:"window_start"`
+	WindowEnd     *time.Time `json:"window_end"`
+	ResetAt       *time.Time `json:"reset_at"`
+	UsageEpoch    *time.Time `json:"usage_epoch"`
+	WeekResetDay  *int       `json:"week_reset_day,omitempty"`
+	WeekResetHour *int       `json:"week_reset_hour,omitempty"`
+}
+
+// UserPeriodLimitsStatus is the management-facing aggregate status.
+type UserPeriodLimitsStatus struct {
+	UserID           uint                     `json:"user_id"`
+	Timezone         string                   `json:"timezone"`
+	Credits          float64                  `json:"credits"`
+	CreditsUnlimited bool                     `json:"credits_unlimited"`
+	Windows          []UserPeriodWindowStatus `json:"windows"`
+}
+
+// UserPeriodLimitResetResult is returned by ResetUserPeriodLimits.
+type UserPeriodLimitResetResult struct {
+	UserID  uint                   `json:"user_id"`
+	Mode    string                 `json:"mode"`
+	Windows []string               `json:"windows"`
+	At      time.Time              `json:"at"`
+	Limits  UserPeriodLimitsStatus `json:"limits"`
+}
+
+func defaultUserPeriodLimitFields(record *UserRecord) {
+	if record == nil {
+		return
+	}
+	if strings.TrimSpace(record.Timezone) == "" {
+		record.Timezone = DefaultUserTimezone
+	}
+	if strings.TrimSpace(record.WindowMode5h) == "" {
+		record.WindowMode5h = DefaultPeriodWindowMode
+	} else if mode, errMode := normalizePeriodWindowMode(record.WindowMode5h, false); errMode == nil {
+		record.WindowMode5h = mode
+	}
+	if strings.TrimSpace(record.WindowMode1d) == "" {
+		record.WindowMode1d = DefaultPeriodWindowMode
+	} else if mode, errMode := normalizePeriodWindowMode(record.WindowMode1d, true); errMode == nil {
+		record.WindowMode1d = mode
+	}
+	if strings.TrimSpace(record.WindowMode7d) == "" {
+		record.WindowMode7d = DefaultPeriodWindowMode
+	} else if mode, errMode := normalizePeriodWindowMode(record.WindowMode7d, true); errMode == nil {
+		record.WindowMode7d = mode
+	}
+	if strings.TrimSpace(record.WindowMode30d) == "" {
+		record.WindowMode30d = DefaultPeriodWindowMode
+	} else if mode, errMode := normalizePeriodWindowMode(record.WindowMode30d, true); errMode == nil {
+		record.WindowMode30d = mode
+	}
+	if record.WeekResetDay == 0 {
+		record.WeekResetDay = DefaultWeekResetDay
+	}
+	if record.WeekResetHour < 0 || record.WeekResetHour > 23 {
+		record.WeekResetHour = DefaultWeekResetHour
+	}
+}
+
+func applyOptionalFloat(update OptionalFloatUpdate, dest **float64) error {
+	if !update.Set {
+		return nil
+	}
+	if update.Clear {
+		*dest = nil
+		return nil
+	}
+	if update.Value < 0 || math.IsNaN(update.Value) || math.IsInf(update.Value, 0) {
+		return periodLimitConfigErrorf("limit must be a non-negative number")
+	}
+	value := update.Value
+	*dest = &value
+	return nil
+}
+
+// CanonicalPeriodWindowMode returns the stored/API mode for display.
+// Unknown values fall back to the default first_use mode.
+func CanonicalPeriodWindowMode(mode string, allowCalendar bool) string {
+	normalized, errMode := normalizePeriodWindowMode(mode, allowCalendar)
+	if errMode != nil {
+		return DefaultPeriodWindowMode
+	}
+	return normalized
+}
+
+// normalizePeriodWindowMode normalizes API/storage mode values.
+// allowCalendar enables calendar mode (1d/7d/30d). 5h must pass false.
+func normalizePeriodWindowMode(mode string, allowCalendar bool) (string, error) {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		return DefaultPeriodWindowMode, nil
+	}
+	switch mode {
+	case PeriodWindowModeFirstUse, PeriodWindowModeFixed:
+		// "fixed" kept as alias; canonical storage is first_use.
+		return PeriodWindowModeFirstUse, nil
+	case PeriodWindowModeSliding, PeriodWindowModeRolling:
+		return PeriodWindowModeSliding, nil
+	case PeriodWindowModeCalendar:
+		if !allowCalendar {
+			return "", periodLimitConfigErrorf("window mode %q is not supported for this window", mode)
+		}
+		return PeriodWindowModeCalendar, nil
+	default:
+		if allowCalendar {
+			return "", periodLimitConfigErrorf("window mode must be %q, %q, or %q", PeriodWindowModeFirstUse, PeriodWindowModeSliding, PeriodWindowModeCalendar)
+		}
+		return "", periodLimitConfigErrorf("window mode must be %q or %q", PeriodWindowModeFirstUse, PeriodWindowModeSliding)
+	}
+}
+
+func normalizeUserTimezone(timezone string) (string, error) {
+	timezone = strings.TrimSpace(timezone)
+	if timezone == "" {
+		return DefaultUserTimezone, nil
+	}
+	if _, errLoad := time.LoadLocation(timezone); errLoad != nil {
+		return "", periodLimitConfigErrorf("invalid timezone %q", timezone)
+	}
+	return timezone, nil
+}
+
+func normalizeWeekResetDay(day int) (int, error) {
+	if day < 1 || day > 7 {
+		return 0, periodLimitConfigErrorf("week_reset_day must be between 1 and 7")
+	}
+	return day, nil
+}
+
+func normalizeWeekResetHour(hour int) (int, error) {
+	if hour < 0 || hour > 23 {
+		return 0, periodLimitConfigErrorf("week_reset_hour must be between 0 and 23")
+	}
+	return hour, nil
+}
+
+func loadUserLocation(timezone string) *time.Location {
+	timezone = strings.TrimSpace(timezone)
+	if timezone == "" {
+		timezone = DefaultUserTimezone
+	}
+	loc, errLoad := time.LoadLocation(timezone)
+	if errLoad != nil {
+		loc, _ = time.LoadLocation(DefaultUserTimezone)
+	}
+	if loc == nil {
+		return time.UTC
+	}
+	return loc
+}
+
+func startOfDayInLocation(now time.Time, loc *time.Location) time.Time {
+	local := now.In(loc)
+	return time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, loc)
+}
+
+func startOfMonthInLocation(now time.Time, loc *time.Location) time.Time {
+	local := now.In(loc)
+	return time.Date(local.Year(), local.Month(), 1, 0, 0, 0, 0, loc)
+}
+
+// startOfCalendarWeek returns the start of the current billing week in loc.
+// resetDay uses 1=Monday ... 7=Sunday; resetHour is 0-23 in loc.
+func startOfCalendarWeek(now time.Time, loc *time.Location, resetDay, resetHour int) time.Time {
+	if resetDay < 1 || resetDay > 7 {
+		resetDay = DefaultWeekResetDay
+	}
+	if resetHour < 0 || resetHour > 23 {
+		resetHour = DefaultWeekResetHour
+	}
+	local := now.In(loc)
+	ourWeekday := int(local.Weekday())
+	if ourWeekday == 0 {
+		ourWeekday = 7
+	}
+	daysSince := (ourWeekday - resetDay + 7) % 7
+	candidate := time.Date(local.Year(), local.Month(), local.Day(), resetHour, 0, 0, 0, loc).AddDate(0, 0, -daysSince)
+	if local.Before(candidate) {
+		candidate = candidate.AddDate(0, 0, -7)
+	}
+	return candidate
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copied := value.UTC()
+	return &copied
+}
+
+func timePtr(value time.Time) *time.Time {
+	copied := value.UTC()
+	return &copied
+}
+
+func remainingCredits(limit *float64, used float64) *float64 {
+	if limit == nil {
+		return nil
+	}
+	remaining := *limit - used
+	if remaining < 0 {
+		remaining = 0
+	}
+	return &remaining
+}
+
+func periodDuration(id string) time.Duration {
+	switch id {
+	case PeriodWindow5h:
+		return periodLimit5hDuration
+	case PeriodWindow1d:
+		return periodLimit1dDuration
+	case PeriodWindow7d:
+		return periodLimit7dDuration
+	case PeriodWindow30d:
+		return periodLimit30dDuration
+	default:
+		return 0
+	}
+}
+
+func userWindowMode(user *UserRecord, id string) string {
+	if user == nil {
+		return DefaultPeriodWindowMode
+	}
+	switch id {
+	case PeriodWindow5h:
+		return user.WindowMode5h
+	case PeriodWindow1d:
+		return user.WindowMode1d
+	case PeriodWindow7d:
+		return user.WindowMode7d
+	case PeriodWindow30d:
+		return user.WindowMode30d
+	default:
+		return DefaultPeriodWindowMode
+	}
+}
+
+func userWindowStart(user *UserRecord, id string) *time.Time {
+	if user == nil {
+		return nil
+	}
+	switch id {
+	case PeriodWindow5h:
+		return user.PeriodWindowStart5h
+	case PeriodWindow1d:
+		return user.PeriodWindowStart1d
+	case PeriodWindow7d:
+		return user.PeriodWindowStart7d
+	case PeriodWindow30d:
+		return user.PeriodWindowStart30d
+	default:
+		return nil
+	}
+}
+
+func userUsageEpoch(user *UserRecord, id string) *time.Time {
+	if user == nil {
+		return nil
+	}
+	switch id {
+	case PeriodWindow5h:
+		return user.UsageEpoch5h
+	case PeriodWindow1d:
+		return user.UsageEpoch1d
+	case PeriodWindow7d:
+		return user.UsageEpoch7d
+	case PeriodWindow30d:
+		return user.UsageEpoch30d
+	default:
+		return nil
+	}
+}
+
+func windowStartColumn(id string) string {
+	switch id {
+	case PeriodWindow5h:
+		return "period_window_start_5h"
+	case PeriodWindow1d:
+		return "period_window_start_1d"
+	case PeriodWindow7d:
+		return "period_window_start_7d"
+	case PeriodWindow30d:
+		return "period_window_start_30d"
+	default:
+		return ""
+	}
+}
+
+func usageEpochColumn(id string) string {
+	switch id {
+	case PeriodWindow5h:
+		return "usage_epoch_5h"
+	case PeriodWindow1d:
+		return "usage_epoch_1d"
+	case PeriodWindow7d:
+		return "usage_epoch_7d"
+	case PeriodWindow30d:
+		return "usage_epoch_30d"
+	default:
+		return ""
+	}
+}
+
+// SumUserChargeAmountSince sums billing_charge.amount for a user since the given timestamp.
+func (r *Repository) SumUserChargeAmountSince(ctx context.Context, userID uint, since time.Time) (float64, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return 0, errDB
+	}
+	return sumUserChargeAmountSinceDB(ctx, db, userID, since)
+}
+
+func sumUserChargeAmountSinceDB(ctx context.Context, db *gorm.DB, userID uint, since time.Time) (float64, error) {
+	totals, errSum := sumUserPeriodWindowChargesDB(ctx, db, userID, map[string]*time.Time{
+		PeriodWindow5h: timePtr(since.UTC()),
+	})
+	if errSum != nil {
+		return 0, errSum
+	}
+	return totals[PeriodWindow5h], nil
+}
+
+// sumUserPeriodWindowChargesDB aggregates enabled windows in a single SQL scan.
+// A nil since for a window contributes 0 without scanning extra rows for that bucket.
+func sumUserPeriodWindowChargesDB(ctx context.Context, db *gorm.DB, userID uint, sinceByWindow map[string]*time.Time) (map[string]float64, error) {
+	out := map[string]float64{
+		PeriodWindow5h:  0,
+		PeriodWindow1d:  0,
+		PeriodWindow7d:  0,
+		PeriodWindow30d: 0,
+	}
+	if db == nil {
+		return nil, fmt.Errorf("database connection is nil")
+	}
+	if userID == 0 {
+		return nil, fmt.Errorf("user id is required")
+	}
+
+	farFuture := time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+	sinceOrFar := func(id string) time.Time {
+		if sinceByWindow == nil || sinceByWindow[id] == nil {
+			return farFuture
+		}
+		return sinceByWindow[id].UTC()
+	}
+	s5h := sinceOrFar(PeriodWindow5h)
+	s1d := sinceOrFar(PeriodWindow1d)
+	s7d := sinceOrFar(PeriodWindow7d)
+	s30d := sinceOrFar(PeriodWindow30d)
+	minSince := s5h
+	for _, candidate := range []time.Time{s1d, s7d, s30d} {
+		if candidate.Before(minSince) {
+			minSince = candidate
+		}
+	}
+	if !minSince.Before(farFuture) {
+		return out, nil
+	}
+
+	var row struct {
+		Sum5h  float64 `gorm:"column:sum_5h"`
+		Sum1d  float64 `gorm:"column:sum_1d"`
+		Sum7d  float64 `gorm:"column:sum_7d"`
+		Sum30d float64 `gorm:"column:sum_30d"`
+	}
+	errScan := db.WithContext(contextOrBackground(ctx)).Raw(`
+SELECT
+	COALESCE(SUM(CASE WHEN "billing_charge"."created_at" >= ? THEN "billing_charge"."amount" ELSE 0 END), 0) AS sum_5h,
+	COALESCE(SUM(CASE WHEN "billing_charge"."created_at" >= ? THEN "billing_charge"."amount" ELSE 0 END), 0) AS sum_1d,
+	COALESCE(SUM(CASE WHEN "billing_charge"."created_at" >= ? THEN "billing_charge"."amount" ELSE 0 END), 0) AS sum_7d,
+	COALESCE(SUM(CASE WHEN "billing_charge"."created_at" >= ? THEN "billing_charge"."amount" ELSE 0 END), 0) AS sum_30d
+FROM "billing_charge"
+WHERE "billing_charge"."user_id" = ?
+	AND "billing_charge"."created_at" >= ?
+`, s5h, s1d, s7d, s30d, userID, minSince).Scan(&row).Error
+	if errScan != nil {
+		return nil, errScan
+	}
+	out[PeriodWindow5h] = row.Sum5h
+	out[PeriodWindow1d] = row.Sum1d
+	out[PeriodWindow7d] = row.Sum7d
+	out[PeriodWindow30d] = row.Sum30d
+	return out, nil
+}
+
+type periodWindowEval struct {
+	ID         string
+	Enabled    bool
+	Limit      *float64
+	Mode       string
+	Used       float64
+	Active     bool
+	Lower      *time.Time
+	Upper      *time.Time
+	ResetAt    *time.Time
+	UsageEpoch *time.Time
+	// NeedOpen is true when first_use should open on the next billable charge.
+	NeedOpen  bool
+	OpenStart time.Time
+	Exceeded  bool
+}
+
+func evaluateUserPeriodWindows(ctx context.Context, db *gorm.DB, user *UserRecord, now time.Time) ([]periodWindowEval, error) {
+	if user == nil {
+		return nil, fmt.Errorf("user is nil")
+	}
+	defaultUserPeriodLimitFields(user)
+	now = now.UTC()
+	loc := loadUserLocation(user.Timezone)
+
+	type windowDef struct {
+		id           string
+		limit        *float64
+		allowCal     bool
+		configured   string
+		start        *time.Time
+		epoch        *time.Time
+		duration     time.Duration
+		calendarSpan func() (lower, upper time.Time)
+	}
+
+	defs := []windowDef{
+		{
+			id: PeriodWindow5h, limit: user.Limit5hCredits, allowCal: false,
+			configured: user.WindowMode5h, start: user.PeriodWindowStart5h, epoch: user.UsageEpoch5h,
+			duration: periodLimit5hDuration,
+		},
+		{
+			id: PeriodWindow1d, limit: user.Limit1dCredits, allowCal: true,
+			configured: user.WindowMode1d, start: user.PeriodWindowStart1d, epoch: user.UsageEpoch1d,
+			duration: periodLimit1dDuration,
+			calendarSpan: func() (time.Time, time.Time) {
+				lower := startOfDayInLocation(now, loc)
+				return lower, lower.AddDate(0, 0, 1)
+			},
+		},
+		{
+			id: PeriodWindow7d, limit: user.Limit7dCredits, allowCal: true,
+			configured: user.WindowMode7d, start: user.PeriodWindowStart7d, epoch: user.UsageEpoch7d,
+			duration: periodLimit7dDuration,
+			calendarSpan: func() (time.Time, time.Time) {
+				lower := startOfCalendarWeek(now, loc, user.WeekResetDay, user.WeekResetHour)
+				return lower, lower.AddDate(0, 0, 7)
+			},
+		},
+		{
+			id: PeriodWindow30d, limit: user.Limit30dCredits, allowCal: true,
+			configured: user.WindowMode30d, start: user.PeriodWindowStart30d, epoch: user.UsageEpoch30d,
+			duration: periodLimit30dDuration,
+			calendarSpan: func() (time.Time, time.Time) {
+				lower := startOfMonthInLocation(now, loc)
+				return lower, lower.AddDate(0, 1, 0)
+			},
+		},
+	}
+
+	out := make([]periodWindowEval, 0, len(defs))
+	sinceByWindow := make(map[string]*time.Time, len(defs))
+
+	for _, def := range defs {
+		mode, errMode := normalizePeriodWindowMode(def.configured, def.allowCal)
+		if errMode != nil {
+			// Invalid stored mode fails closed to first_use rather than skipping enforcement.
+			mode = DefaultPeriodWindowMode
+		}
+		eval := periodWindowEval{
+			ID:         def.id,
+			Enabled:    def.limit != nil,
+			Limit:      def.limit,
+			Mode:       mode,
+			UsageEpoch: cloneTimePtr(def.epoch),
+		}
+
+		switch mode {
+		case PeriodWindowModeSliding:
+			lower := now.Add(-def.duration)
+			eval.Active = true
+			eval.Lower = timePtr(lower)
+			eval.Upper = timePtr(now)
+			// Sliding has no discrete reset instant; capacity recovers continuously.
+		case PeriodWindowModeCalendar:
+			if def.calendarSpan == nil {
+				return nil, fmt.Errorf("calendar mode is not supported for window %s", def.id)
+			}
+			lower, upper := def.calendarSpan()
+			eval.Active = true
+			eval.Lower = timePtr(lower)
+			eval.Upper = timePtr(upper)
+			eval.ResetAt = timePtr(upper)
+		default: // first_use
+			start := def.start
+			if start == nil || !now.Before(start.UTC().Add(def.duration)) {
+				// No active first_use window. used=0 until a billable charge opens one.
+				eval.Active = false
+				eval.NeedOpen = def.limit != nil
+				eval.OpenStart = now
+			} else {
+				lower := start.UTC()
+				upper := lower.Add(def.duration)
+				eval.Active = true
+				eval.Lower = &lower
+				eval.Upper = &upper
+				eval.ResetAt = &upper
+			}
+		}
+
+		if eval.Lower != nil {
+			since := eval.Lower.UTC()
+			if def.epoch != nil && def.epoch.UTC().After(since) {
+				since = def.epoch.UTC()
+			}
+			sinceCopy := since
+			sinceByWindow[def.id] = &sinceCopy
+		}
+
+		out = append(out, eval)
+	}
+
+	totals, errSum := sumUserPeriodWindowChargesDB(ctx, db, user.ID, sinceByWindow)
+	if errSum != nil {
+		return nil, errSum
+	}
+
+	for i := range out {
+		eval := &out[i]
+		if sinceByWindow[eval.ID] != nil {
+			eval.Used = totals[eval.ID]
+		}
+		if eval.Enabled && eval.Limit != nil {
+			if eval.Used >= *eval.Limit {
+				eval.Exceeded = true
+			}
+			// Explicit zero limit blocks even with no usage/window.
+			if *eval.Limit == 0 {
+				eval.Exceeded = true
+			}
+		}
+	}
+	return out, nil
+}
+
+func periodLimitExceededError(eval periodWindowEval) error {
+	parts := []string{
+		fmt.Sprintf("window=%s", eval.ID),
+		fmt.Sprintf("mode=%s", eval.Mode),
+		fmt.Sprintf("used=%g", eval.Used),
+	}
+	if eval.Limit != nil {
+		parts = append(parts, fmt.Sprintf("limit=%g", *eval.Limit))
+	}
+	if eval.ResetAt != nil {
+		parts = append(parts, fmt.Sprintf("reset_at=%s", eval.ResetAt.UTC().Format(time.RFC3339)))
+	}
+	return fmt.Errorf("%s: %s (%s)", homeerrors.TypeUserPeriodLimitExceeded, homeerrors.MessageUserPeriodLimitExceeded, strings.Join(parts, " "))
+}
+
+// BuildUserPeriodLimitsStatus computes used/remaining for management APIs.
+func (r *Repository) BuildUserPeriodLimitsStatus(ctx context.Context, userID uint, now time.Time) (UserPeriodLimitsStatus, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return UserPeriodLimitsStatus{}, errDB
+	}
+	user, errUser := r.GetUser(ctx, userID)
+	if errUser != nil {
+		return UserPeriodLimitsStatus{}, errUser
+	}
+	return buildUserPeriodLimitsStatusDB(ctx, db, user, now)
+}
+
+func buildUserPeriodLimitsStatusDB(ctx context.Context, db *gorm.DB, user *UserRecord, now time.Time) (UserPeriodLimitsStatus, error) {
+	if user == nil {
+		return UserPeriodLimitsStatus{}, fmt.Errorf("user is nil")
+	}
+	defaultUserPeriodLimitFields(user)
+	evals, errEval := evaluateUserPeriodWindows(ctx, db, user, now)
+	if errEval != nil {
+		return UserPeriodLimitsStatus{}, errEval
+	}
+	status := UserPeriodLimitsStatus{
+		UserID:           user.ID,
+		Timezone:         user.Timezone,
+		Credits:          user.Credits,
+		CreditsUnlimited: user.CreditsUnlimited,
+		Windows:          make([]UserPeriodWindowStatus, 0, len(evals)),
+	}
+	for _, eval := range evals {
+		item := UserPeriodWindowStatus{
+			ID:          eval.ID,
+			Enabled:     eval.Enabled,
+			Limit:       eval.Limit,
+			Used:        eval.Used,
+			Remaining:   remainingCredits(eval.Limit, eval.Used),
+			Mode:        eval.Mode,
+			Active:      eval.Active,
+			WindowStart: cloneTimePtr(eval.Lower),
+			WindowEnd:   cloneTimePtr(eval.Upper),
+			ResetAt:     cloneTimePtr(eval.ResetAt),
+			UsageEpoch:  cloneTimePtr(eval.UsageEpoch),
+		}
+		if eval.ID == PeriodWindow7d {
+			day := user.WeekResetDay
+			hour := user.WeekResetHour
+			item.WeekResetDay = &day
+			item.WeekResetHour = &hour
+		}
+		status.Windows = append(status.Windows, item)
+	}
+	return status, nil
+}
+
+// ResetUserPeriodLimits soft-resets period counters for the selected windows.
+func (r *Repository) ResetUserPeriodLimits(ctx context.Context, userID uint, windows []string, mode string, now time.Time) (UserPeriodLimitResetResult, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return UserPeriodLimitResetResult{}, errDB
+	}
+	if userID == 0 {
+		return UserPeriodLimitResetResult{}, fmt.Errorf("user id is required")
+	}
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		mode = PeriodResetModeCounter
+	}
+	if mode != PeriodResetModeCounter && mode != PeriodResetModeWindowOnly {
+		return UserPeriodLimitResetResult{}, periodLimitConfigErrorf("reset mode must be %q or %q", PeriodResetModeCounter, PeriodResetModeWindowOnly)
+	}
+	now = now.UTC()
+
+	normalized, errWindows := normalizeResetWindows(windows)
+	if errWindows != nil {
+		return UserPeriodLimitResetResult{}, errWindows
+	}
+
+	var result UserPeriodLimitResetResult
+	errTx := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		user := &UserRecord{}
+		if errFirst := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", userID).First(user).Error; errFirst != nil {
+			return errFirst
+		}
+		defaultUserPeriodLimitFields(user)
+
+		target := normalized
+		if len(target) == 0 {
+			for _, id := range []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d} {
+				if userLimitForWindow(user, id) != nil || userWindowStart(user, id) != nil {
+					target = append(target, id)
+				}
+			}
+			if len(target) == 0 {
+				target = []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d}
+			}
+		}
+
+		updates := map[string]any{}
+		for _, id := range target {
+			if col := windowStartColumn(id); col != "" {
+				updates[col] = nil
+			}
+			windowMode, errMode := normalizePeriodWindowMode(userWindowMode(user, id), id != PeriodWindow5h)
+			if errMode != nil {
+				windowMode = DefaultPeriodWindowMode
+			}
+			// counter always moves usage_epoch.
+			// window_only clears first_use starts; for sliding/calendar it also moves
+			// usage_epoch so the reset actually zeroes used (starts alone are no-ops).
+			needEpoch := mode == PeriodResetModeCounter ||
+				windowMode == PeriodWindowModeSliding ||
+				windowMode == PeriodWindowModeCalendar
+			if needEpoch {
+				if col := usageEpochColumn(id); col != "" {
+					updates[col] = now
+				}
+			}
+		}
+		if len(updates) > 0 {
+			if errUpdate := tx.Model(&UserRecord{}).Where("id = ?", userID).Updates(updates).Error; errUpdate != nil {
+				return errUpdate
+			}
+		}
+		if errReload := tx.Where("id = ?", userID).First(user).Error; errReload != nil {
+			return errReload
+		}
+		status, errStatus := buildUserPeriodLimitsStatusDB(ctx, tx, user, now)
+		if errStatus != nil {
+			return errStatus
+		}
+		result = UserPeriodLimitResetResult{
+			UserID:  userID,
+			Mode:    mode,
+			Windows: target,
+			At:      now,
+			Limits:  status,
+		}
+		return nil
+	})
+	if errTx != nil {
+		return UserPeriodLimitResetResult{}, errTx
+	}
+	return result, nil
+}
+
+func userLimitForWindow(user *UserRecord, id string) *float64 {
+	if user == nil {
+		return nil
+	}
+	switch id {
+	case PeriodWindow5h:
+		return user.Limit5hCredits
+	case PeriodWindow1d:
+		return user.Limit1dCredits
+	case PeriodWindow7d:
+		return user.Limit7dCredits
+	case PeriodWindow30d:
+		return user.Limit30dCredits
+	default:
+		return nil
+	}
+}
+
+func normalizeResetWindows(windows []string) ([]string, error) {
+	if len(windows) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(windows))
+	out := make([]string, 0, len(windows))
+	for _, raw := range windows {
+		id := strings.ToLower(strings.TrimSpace(raw))
+		switch id {
+		case PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d:
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, id)
+		case "":
+			continue
+		default:
+			return nil, periodLimitConfigErrorf("unknown period window %q", raw)
+		}
+	}
+	return out, nil
+}
+
+// ensureAPIKeyUserBillingAllowed enforces credits and period limits for a user-owned API key.
+// first_use windows open on the first billable charge, not on dispatch probes.
+func ensureAPIKeyUserBillingAllowed(ctx context.Context, db *gorm.DB, record *APIKeyRecord) error {
+	if db == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	if record == nil {
+		return fmt.Errorf("api key record is nil")
+	}
+	userID := normalizeOptionalUserID(record.UserID)
+	if userID == nil {
+		return nil
+	}
+
+	user := UserRecord{}
+	errFirst := db.WithContext(contextOrBackground(ctx)).
+		Where("id = ?", *userID).
+		First(&user).Error
+	if errFirst != nil {
+		return errFirst
+	}
+	defaultUserPeriodLimitFields(&user)
+	if !user.CreditsUnlimited && user.Credits <= 0 {
+		return fmt.Errorf("%s: %s", homeerrors.TypeUserCreditsInsufficient, homeerrors.MessageUserCreditsInsufficient)
+	}
+	if !userPeriodLimitsEnabled(&user) {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	evals, errEval := evaluateUserPeriodWindows(ctx, db, &user, now)
+	if errEval != nil {
+		return errEval
+	}
+	for _, eval := range evals {
+		if eval.Exceeded {
+			return periodLimitExceededError(eval)
+		}
+	}
+	return nil
+}
+
+func userPeriodLimitsEnabled(user *UserRecord) bool {
+	if user == nil {
+		return false
+	}
+	return user.Limit5hCredits != nil ||
+		user.Limit1dCredits != nil ||
+		user.Limit7dCredits != nil ||
+		user.Limit30dCredits != nil
+}
+
+// openUserFirstUseWindowsOnChargeTx opens inactive first_use windows when a billable charge lands.
+// chargeTime becomes the window start so the charge itself is included in used.
+func openUserFirstUseWindowsOnChargeTx(ctx context.Context, tx *gorm.DB, userID uint, chargeTime time.Time) error {
+	if tx == nil {
+		return fmt.Errorf("database transaction is nil")
+	}
+	if userID == 0 {
+		return fmt.Errorf("user id is required")
+	}
+	chargeTime = chargeTime.UTC()
+
+	user := UserRecord{}
+	errFirst := tx.WithContext(contextOrBackground(ctx)).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", userID).
+		First(&user).Error
+	if errFirst != nil {
+		return errFirst
+	}
+	defaultUserPeriodLimitFields(&user)
+
+	evals, errEval := evaluateUserPeriodWindows(ctx, tx, &user, chargeTime)
+	if errEval != nil {
+		return errEval
+	}
+
+	updates := map[string]any{}
+	for _, eval := range evals {
+		if eval.Mode != PeriodWindowModeFirstUse || !eval.NeedOpen {
+			continue
+		}
+		if col := windowStartColumn(eval.ID); col != "" {
+			// Bound the session by the charge timestamp so this charge counts inside the window.
+			updates[col] = chargeTime
+		}
+	}
+	if len(updates) == 0 {
+		return nil
+	}
+	return tx.WithContext(contextOrBackground(ctx)).
+		Model(&UserRecord{}).
+		Where("id = ?", userID).
+		Updates(updates).Error
+}

--- a/internal/cluster/user_period_limit_test.go
+++ b/internal/cluster/user_period_limit_test.go
@@ -1,0 +1,486 @@
+package cluster
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	homeerrors "github.com/router-for-me/CLIProxyAPIHome/internal/errors"
+
+	"gorm.io/gorm"
+)
+
+func newPeriodLimitTestRepo(t *testing.T) (*Repository, context.Context, func()) {
+	t.Helper()
+	ctx := context.Background()
+	db, errOpen := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	closeRepo := func() {
+		_ = sqlDB.Close()
+	}
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		closeRepo()
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	return NewRepository(db), ctx, closeRepo
+}
+
+func createPeriodLimitUser(t *testing.T, repo *Repository, ctx context.Context, name string, credits float64) *UserRecord {
+	t.Helper()
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &name, Credits: &credits})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	return user
+}
+
+func createCharge(t *testing.T, repo *Repository, ctx context.Context, userID uint, amount float64, at time.Time) {
+	t.Helper()
+	db, errDB := repo.database()
+	if errDB != nil {
+		t.Fatalf("database() error = %v", errDB)
+	}
+	uid := userID
+	record := &BillingChargeRecord{
+		ID:            billingID("charge"),
+		UsageID:       uint(at.UnixNano()%1_000_000_000) + uint(amount*1000) + userID,
+		PayloadHash:   billingID("hash"),
+		UserID:        &uid,
+		Provider:      "test",
+		Model:         "test-model",
+		Amount:        amount,
+		PriceSnapshot: JSONB(`{}`),
+		CreatedAt:     at.UTC(),
+	}
+	errTx := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errCreate := tx.Create(record).Error; errCreate != nil {
+			record.UsageID = uint(time.Now().UnixNano())
+			record.ID = billingID("charge")
+			record.PayloadHash = billingID("hash")
+			if errRetry := tx.Create(record).Error; errRetry != nil {
+				return errRetry
+			}
+		}
+		// Mirror production: first_use windows open on billable charge.
+		return openUserFirstUseWindowsOnChargeTx(ctx, tx, userID, at.UTC())
+	})
+	if errTx != nil {
+		t.Fatalf("Create BillingChargeRecord error = %v", errTx)
+	}
+}
+
+func TestUserPeriodLimit5hFirstUseWindow(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-5h", 100)
+	limit := 10.0
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{Limit5hCredits: OptionalFloatUpdate{Set: true, Value: limit}}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key := "key-5h"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+
+	// Dispatch probes must not open first_use windows.
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("first dispatch error = %v", errDispatch)
+	}
+	reloaded, errGet := repo.GetUser(ctx, user.ID)
+	if errGet != nil {
+		t.Fatalf("GetUser() error = %v", errGet)
+	}
+	if reloaded.PeriodWindowStart5h != nil {
+		t.Fatal("dispatch must not set period_window_start_5h")
+	}
+
+	// First billable charge opens the window and counts toward the limit.
+	chargeAt := time.Now().UTC()
+	createCharge(t, repo, ctx, user.ID, 10, chargeAt)
+	reloaded, errGet = repo.GetUser(ctx, user.ID)
+	if errGet != nil {
+		t.Fatalf("GetUser() after charge error = %v", errGet)
+	}
+	if reloaded.PeriodWindowStart5h == nil {
+		t.Fatal("expected period_window_start_5h after billable charge")
+	}
+
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), homeerrors.TypeUserPeriodLimitExceeded) {
+		t.Fatalf("expected period limit exceeded, got %v", errBlocked)
+	}
+
+	// Expire window and ensure a new session can start after the next charge.
+	db, _ := repo.database()
+	expired := time.Now().UTC().Add(-6 * time.Hour)
+	if errUpdate := db.Model(&UserRecord{}).Where("id = ?", user.ID).Update("period_window_start_5h", expired).Error; errUpdate != nil {
+		t.Fatalf("expire window error = %v", errUpdate)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch after expiry error = %v", errDispatch)
+	}
+}
+
+func TestUserPeriodLimit1dCalendarAndRolling(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-1d", 100)
+	limit := 5.0
+	mode := PeriodWindowModeCalendar
+	tz := "Asia/Shanghai"
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Timezone:       &tz,
+		Limit1dCredits: OptionalFloatUpdate{Set: true, Value: limit},
+		WindowMode1d:   &mode,
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser(calendar) error = %v", errUpdate)
+	}
+
+	loc := loadUserLocation(tz)
+	now := time.Now().In(loc)
+	today := startOfDayInLocation(now, loc)
+	createCharge(t, repo, ctx, user.ID, 5, today.Add(2*time.Hour))
+
+	key := "key-1d"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), "window=1d") {
+		t.Fatalf("expected 1d calendar block, got %v", errBlocked)
+	}
+
+	// Switch to rolling and put spend just outside 24h so it should pass.
+	rolling := PeriodWindowModeRolling
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{WindowMode1d: &rolling}); errUpdate != nil {
+		t.Fatalf("UpdateUser(rolling) error = %v", errUpdate)
+	}
+	// Existing charge is within 24h still, still blocked.
+	_, _, errStill := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errStill == nil {
+		t.Fatal("expected rolling 1d still blocked for recent charge")
+	}
+
+	// Reset counters and ensure pass.
+	if _, errReset := repo.ResetUserPeriodLimits(ctx, user.ID, []string{PeriodWindow1d}, PeriodResetModeCounter, time.Now().UTC()); errReset != nil {
+		t.Fatalf("ResetUserPeriodLimits() error = %v", errReset)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch after reset error = %v", errDispatch)
+	}
+}
+
+func TestUserPeriodLimitResetSubsetAndMultiKey(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-multi", 50)
+	limit5h := 1.0
+	limit1d := 100.0
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Limit5hCredits: OptionalFloatUpdate{Set: true, Value: limit5h},
+		Limit1dCredits: OptionalFloatUpdate{Set: true, Value: limit1d},
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key1 := "key-a"
+	key2 := "key-b"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key1}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser(a) error = %v", errKey)
+	}
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key2}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser(b) error = %v", errKey)
+	}
+
+	// Charge opens shared user 5h window; both keys inherit the limit.
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key1); errDispatch != nil {
+		t.Fatalf("dispatch before charge error = %v", errDispatch)
+	}
+	createCharge(t, repo, ctx, user.ID, 1, time.Now().UTC())
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key2)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), "window=5h") {
+		t.Fatalf("expected shared user 5h limit, got %v", errBlocked)
+	}
+
+	// Reset only 5h.
+	result, errReset := repo.ResetUserPeriodLimits(ctx, user.ID, []string{PeriodWindow5h}, PeriodResetModeCounter, time.Now().UTC())
+	if errReset != nil {
+		t.Fatalf("reset error = %v", errReset)
+	}
+	if len(result.Windows) != 1 || result.Windows[0] != PeriodWindow5h {
+		t.Fatalf("reset windows = %v, want [5h]", result.Windows)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key2); errDispatch != nil {
+		t.Fatalf("dispatch after 5h reset error = %v", errDispatch)
+	}
+}
+
+func TestUserPeriodLimitNullDisabledAndZeroBlocks(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-zero", 10)
+	key := "key-zero"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	// No limits: pass.
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch without limits error = %v", errDispatch)
+	}
+	// limit=0 blocks.
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{Limit1dCredits: OptionalFloatUpdate{Set: true, Value: 0}}); errUpdate != nil {
+		t.Fatalf("UpdateUser(0) error = %v", errUpdate)
+	}
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), homeerrors.TypeUserPeriodLimitExceeded) {
+		t.Fatalf("expected zero limit block, got %v", errBlocked)
+	}
+	// clear limit.
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{Limit1dCredits: OptionalFloatUpdate{Set: true, Clear: true}}); errUpdate != nil {
+		t.Fatalf("UpdateUser(clear) error = %v", errUpdate)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch after clear error = %v", errDispatch)
+	}
+}
+
+func TestUserPeriodLimitCreditsStillEnforced(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-credits", 0)
+	key := "key-credits"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), homeerrors.TypeUserCreditsInsufficient) {
+		t.Fatalf("expected credits insufficient, got %v", errBlocked)
+	}
+}
+
+func TestUserUnlimitedCreditsStillEnforcesPeriodLimits(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-unlimited", 0)
+	unlimited := true
+	limit := 1.0
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		CreditsUnlimited: &unlimited,
+		Limit5hCredits:   OptionalFloatUpdate{Set: true, Value: limit},
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key := "key-unlimited"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch before period spend error = %v", errDispatch)
+	}
+	createCharge(t, repo, ctx, user.ID, 1, time.Now().UTC())
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), homeerrors.TypeUserPeriodLimitExceeded) {
+		t.Fatalf("expected period limit exceeded, got %v", errBlocked)
+	}
+}
+
+func TestUserPeriodLimitsEnabled(t *testing.T) {
+	t.Parallel()
+
+	if userPeriodLimitsEnabled(&UserRecord{}) {
+		t.Fatal("empty user should not have period limits enabled")
+	}
+	limit := 1.0
+	if !userPeriodLimitsEnabled(&UserRecord{Limit7dCredits: &limit}) {
+		t.Fatal("configured limit should enable period limit evaluation")
+	}
+}
+
+func TestStartOfCalendarWeek(t *testing.T) {
+	t.Parallel()
+	loc := loadUserLocation("Asia/Shanghai")
+	// Wednesday 2026-07-08 15:00 +08
+	now := time.Date(2026, 7, 8, 15, 0, 0, 0, loc)
+	start := startOfCalendarWeek(now, loc, 1, 0) // Monday 00:00
+	want := time.Date(2026, 7, 6, 0, 0, 0, 0, loc)
+	if !start.Equal(want) {
+		t.Fatalf("start = %v, want %v", start, want)
+	}
+}
+
+func TestUserPeriodLimit5hSliding(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-5h-slide", 100)
+	limit := 10.0
+	mode := PeriodWindowModeSliding
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Limit5hCredits: OptionalFloatUpdate{Set: true, Value: limit},
+		WindowMode5h:   &mode,
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key := "key-5h-slide"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	// Sliding does not open first_use window_start.
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch error = %v", errDispatch)
+	}
+	reloaded, _ := repo.GetUser(ctx, user.ID)
+	if reloaded.PeriodWindowStart5h != nil {
+		t.Fatal("sliding mode should not set period_window_start_5h")
+	}
+	createCharge(t, repo, ctx, user.ID, 10, time.Now().UTC().Add(-time.Hour))
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), "window=5h") {
+		t.Fatalf("expected sliding 5h block, got %v", errBlocked)
+	}
+	// Charge outside 5h should not block after reset... better: old charge beyond 5h
+	// Move by inserting only old charge: first clear via epoch
+	if _, errReset := repo.ResetUserPeriodLimits(ctx, user.ID, []string{PeriodWindow5h}, PeriodResetModeCounter, time.Now().UTC()); errReset != nil {
+		t.Fatalf("reset error = %v", errReset)
+	}
+	createCharge(t, repo, ctx, user.ID, 10, time.Now().UTC().Add(-6*time.Hour))
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch with aged charge error = %v", errDispatch)
+	}
+}
+
+func TestUserPeriodLimit1dFirstUseFirstCharge(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-1d-first-use", 100)
+	limit := 3.0
+	mode := PeriodWindowModeFirstUse
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Limit1dCredits: OptionalFloatUpdate{Set: true, Value: limit},
+		WindowMode1d:   &mode,
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key := "key-1d-first-use"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("first dispatch error = %v", errDispatch)
+	}
+	reloaded, _ := repo.GetUser(ctx, user.ID)
+	if reloaded.PeriodWindowStart1d != nil {
+		t.Fatal("dispatch must not open period_window_start_1d")
+	}
+	chargeAt := time.Now().UTC()
+	createCharge(t, repo, ctx, user.ID, 3, chargeAt)
+	reloaded, _ = repo.GetUser(ctx, user.ID)
+	if reloaded.PeriodWindowStart1d == nil {
+		t.Fatal("expected period_window_start_1d after charge")
+	}
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil || !strings.Contains(errBlocked.Error(), "window=1d") {
+		t.Fatalf("expected first_use 1d block, got %v", errBlocked)
+	}
+}
+
+func TestNormalizePeriodWindowModeAliases(t *testing.T) {
+	t.Parallel()
+	mode, err := normalizePeriodWindowMode("rolling", false)
+	if err != nil || mode != PeriodWindowModeSliding {
+		t.Fatalf("rolling alias = %q %v", mode, err)
+	}
+	if _, err := normalizePeriodWindowMode("calendar", false); err == nil {
+		t.Fatal("expected calendar rejected for 5h")
+	}
+	mode, err = normalizePeriodWindowMode("calendar", true)
+	if err != nil || mode != PeriodWindowModeCalendar {
+		t.Fatalf("calendar = %q %v", mode, err)
+	}
+}
+
+func TestNormalizeFixedAliasToFirstUse(t *testing.T) {
+	t.Parallel()
+	mode, err := normalizePeriodWindowMode("fixed", true)
+	if err != nil || mode != PeriodWindowModeFirstUse {
+		t.Fatalf("fixed alias = %q %v, want first_use", mode, err)
+	}
+	mode, err = normalizePeriodWindowMode("first_use", false)
+	if err != nil || mode != PeriodWindowModeFirstUse {
+		t.Fatalf("first_use = %q %v", mode, err)
+	}
+}
+
+func TestCalendarDayAndWeekUseAddDate(t *testing.T) {
+	t.Parallel()
+	// America/New_York observes DST; AddDate day boundaries stay on local midnights.
+	loc := loadUserLocation("America/New_York")
+	// 2026-03-08 is spring-forward day in US.
+	now := time.Date(2026, 3, 8, 12, 0, 0, 0, loc)
+	dayStart := startOfDayInLocation(now, loc)
+	dayEnd := dayStart.AddDate(0, 0, 1)
+	if dayEnd.Location().String() != loc.String() {
+		t.Fatalf("day end loc = %v", dayEnd.Location())
+	}
+	if dayEnd.Hour() != 0 || dayEnd.Day() != 9 {
+		t.Fatalf("day end = %v, want next local midnight", dayEnd)
+	}
+	weekStart := startOfCalendarWeek(now, loc, 1, 0)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+	if weekEnd.Weekday() != weekStart.Weekday() || weekEnd.Hour() != weekStart.Hour() {
+		t.Fatalf("week end = %v start = %v", weekEnd, weekStart)
+	}
+}
+
+func TestWindowOnlyResetClearsSlidingUsage(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-slide-reset", 100)
+	limit := 5.0
+	mode := PeriodWindowModeSliding
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Limit1dCredits: OptionalFloatUpdate{Set: true, Value: limit},
+		WindowMode1d:   &mode,
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+	key := "key-slide-reset"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	createCharge(t, repo, ctx, user.ID, 5, time.Now().UTC().Add(-time.Hour))
+	_, _, errBlocked := repo.AllowedDispatchIDsForAPIKey(ctx, key)
+	if errBlocked == nil {
+		t.Fatal("expected sliding block before reset")
+	}
+	if _, errReset := repo.ResetUserPeriodLimits(ctx, user.ID, []string{PeriodWindow1d}, PeriodResetModeWindowOnly, time.Now().UTC()); errReset != nil {
+		t.Fatalf("window_only reset error = %v", errReset)
+	}
+	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
+		t.Fatalf("dispatch after window_only sliding reset error = %v", errDispatch)
+	}
+}

--- a/internal/cluster/users.go
+++ b/internal/cluster/users.go
@@ -30,11 +30,24 @@ func IsUserConflictError(err error) bool {
 }
 
 type UserUpdate struct {
-	Username *string
-	Password *string
-	Credits  *float64
-	MFA      *JSONB
-	Passkey  *JSONB
+	Username         *string
+	Password         *string
+	Credits          *float64
+	CreditsUnlimited *bool
+	MFA              *JSONB
+	Passkey          *JSONB
+
+	Timezone        *string
+	Limit5hCredits  OptionalFloatUpdate
+	WindowMode5h    *string
+	Limit1dCredits  OptionalFloatUpdate
+	WindowMode1d    *string
+	Limit7dCredits  OptionalFloatUpdate
+	WindowMode7d    *string
+	WeekResetDay    *int
+	WeekResetHour   *int
+	Limit30dCredits OptionalFloatUpdate
+	WindowMode30d   *string
 }
 
 // ListUsers returns users.
@@ -103,11 +116,18 @@ func (r *Repository) CreateUser(ctx context.Context, update UserUpdate) (*UserRe
 	record := &UserRecord{
 		Username: username,
 	}
+	defaultUserPeriodLimitFields(record)
 	if update.Password != nil {
 		record.Password = *update.Password
 	}
 	if update.Credits != nil {
 		record.Credits = *update.Credits
+	}
+	if update.CreditsUnlimited != nil {
+		record.CreditsUnlimited = *update.CreditsUnlimited
+	}
+	if errApply := applyUserPeriodLimitUpdate(record, update); errApply != nil {
+		return nil, errApply
 	}
 	if update.MFA != nil {
 		record.MFA = cloneJSONB(*update.MFA)
@@ -149,6 +169,12 @@ func (r *Repository) UpdateUser(ctx context.Context, id uint, update UserUpdate)
 		}
 		if update.Credits != nil {
 			record.Credits = *update.Credits
+		}
+		if update.CreditsUnlimited != nil {
+			record.CreditsUnlimited = *update.CreditsUnlimited
+		}
+		if errApply := applyUserPeriodLimitUpdate(record, update); errApply != nil {
+			return errApply
 		}
 		if update.MFA != nil {
 			record.MFA = cloneJSONB(*update.MFA)
@@ -242,4 +268,73 @@ func NormalizeJSONB(raw json.RawMessage) (*JSONB, error) {
 	}
 	value := JSONB(append([]byte(nil), raw...))
 	return &value, nil
+}
+
+func applyUserPeriodLimitUpdate(record *UserRecord, update UserUpdate) error {
+	if record == nil {
+		return fmt.Errorf("user record is nil")
+	}
+	defaultUserPeriodLimitFields(record)
+	if update.Timezone != nil {
+		timezone, errTZ := normalizeUserTimezone(*update.Timezone)
+		if errTZ != nil {
+			return errTZ
+		}
+		record.Timezone = timezone
+	}
+	if errLimit := applyOptionalFloat(update.Limit5hCredits, &record.Limit5hCredits); errLimit != nil {
+		return fmt.Errorf("limit_5h_credits: %w", errLimit)
+	}
+	if update.WindowMode5h != nil {
+		mode, errMode := normalizePeriodWindowMode(*update.WindowMode5h, false)
+		if errMode != nil {
+			return fmt.Errorf("window_mode_5h: %w", errMode)
+		}
+		record.WindowMode5h = mode
+	}
+	if errLimit := applyOptionalFloat(update.Limit1dCredits, &record.Limit1dCredits); errLimit != nil {
+		return fmt.Errorf("limit_1d_credits: %w", errLimit)
+	}
+	if update.WindowMode1d != nil {
+		mode, errMode := normalizePeriodWindowMode(*update.WindowMode1d, true)
+		if errMode != nil {
+			return fmt.Errorf("window_mode_1d: %w", errMode)
+		}
+		record.WindowMode1d = mode
+	}
+	if errLimit := applyOptionalFloat(update.Limit7dCredits, &record.Limit7dCredits); errLimit != nil {
+		return fmt.Errorf("limit_7d_credits: %w", errLimit)
+	}
+	if update.WindowMode7d != nil {
+		mode, errMode := normalizePeriodWindowMode(*update.WindowMode7d, true)
+		if errMode != nil {
+			return fmt.Errorf("window_mode_7d: %w", errMode)
+		}
+		record.WindowMode7d = mode
+	}
+	if update.WeekResetDay != nil {
+		day, errDay := normalizeWeekResetDay(*update.WeekResetDay)
+		if errDay != nil {
+			return errDay
+		}
+		record.WeekResetDay = day
+	}
+	if update.WeekResetHour != nil {
+		hour, errHour := normalizeWeekResetHour(*update.WeekResetHour)
+		if errHour != nil {
+			return errHour
+		}
+		record.WeekResetHour = hour
+	}
+	if errLimit := applyOptionalFloat(update.Limit30dCredits, &record.Limit30dCredits); errLimit != nil {
+		return fmt.Errorf("limit_30d_credits: %w", errLimit)
+	}
+	if update.WindowMode30d != nil {
+		mode, errMode := normalizePeriodWindowMode(*update.WindowMode30d, true)
+		if errMode != nil {
+			return fmt.Errorf("window_mode_30d: %w", errMode)
+		}
+		record.WindowMode30d = mode
+	}
+	return nil
 }

--- a/internal/errors/messages.go
+++ b/internal/errors/messages.go
@@ -5,6 +5,7 @@ const (
 	TypeModelNotFound           = "model_not_found"
 	TypeRequestRetryExceeded    = "request_retry_exceeded"
 	TypeUserCreditsInsufficient = "user_credits_insufficient"
+	TypeUserPeriodLimitExceeded = "user_period_limit_exceeded"
 )
 
 const (
@@ -23,6 +24,7 @@ const (
 	MessageInvalidAPIKey                    = "invalid api key"
 	MessageRequestRetryExceeded             = "request retry limit exceeded"
 	MessageUserCreditsInsufficient          = "insufficient user credits"
+	MessageUserPeriodLimitExceeded          = "period limit exceeded"
 
 	MessageModelDoesNotExistFmt = "model %s does not exist"
 )

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -211,6 +211,8 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodPut, "/users/:id", handler.UpdateUser)
 	r.Set(http.MethodPatch, "/users/:id", handler.UpdateUser)
 	r.Set(http.MethodDelete, "/users/:id", handler.DeleteUser)
+	r.Set(http.MethodGet, "/users/:id/period-limits", handler.GetUserPeriodLimits)
+	r.Set(http.MethodPost, "/users/:id/period-limits/reset", handler.ResetUserPeriodLimits)
 	r.Set(http.MethodGet, "/channel-groups", handler.ListChannelGroups)
 	r.Set(http.MethodPost, "/channel-groups", handler.CreateChannelGroup)
 	r.Set(http.MethodGet, "/channel-groups/:id", handler.GetChannelGroup)


### PR DESCRIPTION
## Summary
- add user-level 5h, 1d, 7d, and 30d credit limit windows with first_use, sliding, and calendar modes
- expose Management API fields and period-limit status/reset endpoints
- enforce configured period limits during API-key dispatch while preserving the lightweight path for users without limits
- add credits_unlimited so total balance can be bypassed while period-limit accounting still uses billing charges
- update English and Chinese Management API docs

## Verification
- go test ./internal/cluster -run 'TestUserPeriodLimit|TestStartOfCalendarWeek|TestNormalize|TestCalendarDayAndWeek|TestWindowOnly|TestAppendUsageUnlimitedCreditsKeepsBalanceAndRecordsCharge|TestAppendUsageCreatesBillingChargeAndDeductsCredits' -count=1
- go test ./internal/cluster/management -run 'TestOptionalJSONFloat|TestUserRecordToMap|TestUserUpdateFromRequest' -count=1
- go test ./internal/cluster ./internal/cluster/management ./internal/managementhttp -count=1
- go build -o test-output ./cmd/home && rm test-output