### PR TITLE
feat: expose request events management API

### DIFF
--- a/cmd/home/main.go
+++ b/cmd/home/main.go
@@ -245,6 +245,9 @@ func run() int {
 		log.Errorf("failed to resolve database node port: listen port must be greater than 0")
 		return 1
 	}
+	if clusterAdapter != nil {
+		clusterAdapter.SetHomePort(clusterAdvertisedPort)
+	}
 
 	if clusterRepo != nil {
 		coordinator = cluster.NewCoordinator(clusterRepo, cluster.NodeIdentity{

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -126,6 +126,10 @@ The table below is extracted from the final Home route registry built by `intern
 | `GET` | `/usage/realtime` |
 | `GET` | `/usage/health/providers` |
 | `GET` | `/usage/health/credentials` |
+| `GET` | `/request-events` |
+| `GET` | `/request-events/export` |
+| `GET` | `/request-events/filter-options` |
+| `GET` | `/request-events/:id` |
 | `GET` | `/request-logs` |
 | `GET` | `/proxy/proxy-pools` |
 | `POST` | `/proxy/proxy-pools` |
@@ -2099,194 +2103,278 @@ Example response:
 
 ### GET `/capabilities`
 
-返回当前 Home Management API 暴露的前端能力开关和构建信息。该接口用于管理面板判断是否可以启用用量总览、请求明细、聚合排行、导出、实时诊断、健康归因和 request log index。
+Returns the frontend capability flags and build metadata exposed by the current Home Management API. The management panel uses this endpoint to decide whether to enable usage overview, request records, aggregate rankings, export, realtime diagnostics, health attribution, request events, and request log indexes.
 
-输出字段：
+Response fields:
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 | --- | --- | --- |
-| `capabilities.usage` | boolean | 是否支持旧版 `GET /api-key-usage` 能力。 |
-| `capabilities.usage_overview` | boolean | 是否支持 `GET /usage/overview`。 |
-| `capabilities.usage_records` | boolean | 是否支持 `GET /usage/records`。 |
-| `capabilities.usage_record_details` | boolean | 是否支持 `GET /usage/records/:id`。 |
-| `capabilities.usage_aggregates` | boolean | 是否支持 `GET /usage/aggregates`。 |
-| `capabilities.usage_export` | boolean | 是否支持 `GET /usage/export`。 |
-| `capabilities.usage_provider_health` | boolean | 是否支持 `GET /usage/health/providers`。 |
-| `capabilities.usage_credential_health` | boolean | 是否支持 `GET /usage/health/credentials`。 |
-| `capabilities.usage_realtime` | boolean | 是否支持 `GET /usage/realtime`。 |
-| `capabilities.request_log_index` | boolean | 是否支持 `GET /request-logs`。 |
-| `capabilities.oauth_usage` | boolean | OAuth/file-backed credential usage 归因是否可靠。 |
-| `capabilities.logs` | boolean | 是否支持应用日志接口。 |
-| `capabilities.request_error_logs` | boolean | 是否支持 request error log file list/download。 |
-| `server_info.home_version` | string | Home 构建版本。 |
-| `server_info.home_commit` | string | Home 构建 commit。 |
-| `server_info.home_build_date` | string | Home 构建时间。 |
+| `capabilities.usage` | boolean | Whether the legacy `GET /api-key-usage` capability is available. |
+| `capabilities.usage_overview` | boolean | Whether `GET /usage/overview` is available. |
+| `capabilities.usage_records` | boolean | Whether `GET /usage/records` is available. |
+| `capabilities.usage_record_details` | boolean | Whether `GET /usage/records/:id` is available. |
+| `capabilities.usage_aggregates` | boolean | Whether `GET /usage/aggregates` is available. |
+| `capabilities.usage_export` | boolean | Whether `GET /usage/export` is available. |
+| `capabilities.usage_provider_health` | boolean | Whether `GET /usage/health/providers` is available. |
+| `capabilities.usage_credential_health` | boolean | Whether `GET /usage/health/credentials` is available. |
+| `capabilities.usage_realtime` | boolean | Whether `GET /usage/realtime` is available. |
+| `capabilities.request_log_index` | boolean | Whether `GET /request-logs` is available. |
+| `capabilities.request_events` / `capabilities.requestEvents` | boolean | Whether `GET /request-events` is available. |
+| `capabilities.request_event_details` / `capabilities.requestEventDetails` | boolean | Whether `GET /request-events/:id` is available. |
+| `capabilities.request_event_export` / `capabilities.requestEventExport` | boolean | Whether `GET /request-events/export` is available. |
+| `capabilities.request_event_filters` / `capabilities.requestEventFilters` | boolean | Whether `GET /request-events/filter-options` is available. |
+| `capabilities.oauth_usage` | boolean | Whether OAuth/file-backed credential usage attribution is reliable. |
+| `capabilities.logs` | boolean | Whether application log APIs are available. |
+| `capabilities.request_error_logs` | boolean | Whether request error log file list/download APIs are available. |
+| `server_info.home_version` | string | Home build version. |
+| `server_info.home_commit` | string | Home build commit. |
+| `server_info.home_build_date` | string | Home build time. |
 
-### 用量观测接口通用约定
+### Usage Observability Conventions
 
-这些接口读取持久化 `usage`、`billing_charge`、`api_key`、`user` 和 `auth` 数据。响应不会返回 raw client access key、provider API key、OAuth token、cookie、authorization header、完整 payload 或完整失败 body。允许返回 `api_key_masked`、脱敏 `body_preview` 和 payload summary。
+These endpoints read persisted `usage`, `billing_charge`, `api_key`, `user`, and `auth` data. Responses never return raw client access keys, provider API keys, OAuth tokens, cookies, authorization headers, complete payloads, or complete failure bodies. They may return `api_key_masked`, redacted `body_preview`, and payload summaries.
 
-汇总范围参数适用于 `/usage/overview`、`/usage/aggregates`、`/usage/realtime`、`/usage/health/providers`、`/usage/health/credentials`，也作为 `/usage/records` 和 `/usage/export` 的基础范围。`/usage/overview` 和 `/usage/aggregates` 在缺少 `from` 或 `to` 时会自动补齐最近 24 小时窗口；`/usage/records` 和 `/usage/export` 不自动补齐时间范围。
+The aggregate range parameters apply to `/usage/overview`, `/usage/aggregates`, `/usage/realtime`, `/usage/health/providers`, and `/usage/health/credentials`, and they also act as the base range for `/usage/records` and `/usage/export`. `/usage/overview` and `/usage/aggregates` automatically fill a recent 24-hour window when `from` or `to` is missing; `/usage/records` and `/usage/export` do not fill a time range automatically.
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `from` | string | `/usage/overview` 和 `/usage/aggregates` 默认为 `to - 24h`；其他接口无 | 起始时间，支持 `YYYY-MM-DD`、RFC3339 或 Unix 秒；只有日期时按 `timezone` 解释为当天 00:00:00。 |
-| `to` | string | `/usage/overview` 和 `/usage/aggregates` 默认为当前时间；其他接口无 | 结束时间，支持 `YYYY-MM-DD`、RFC3339 或 Unix 秒；只有日期时按 `timezone` 解释并包含当天完整一天。 |
-| `timezone` | string | `UTC` | 用于日期型 `from`/`to` 和 `day`/`week` 趋势桶的统计时区。 |
-| `provider` | string | 无 | Provider 精确筛选。 |
-| `model` | string | 无 | 模型模糊筛选。 |
-| `credential_type` | string | 无 | 执行凭证类型：`provider_api_key`、`oauth`、`file_auth`、`vertex`、`unknown`。 |
-| `home_ip` | string | 无 | Home 节点 IP。 |
-| `endpoint` | string | 无 | endpoint 模糊筛选。 |
+| `from` | string | `to - 24h` for `/usage/overview` and `/usage/aggregates`; none for other endpoints | Start time. Supports `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values are interpreted as 00:00:00 in `timezone`. |
+| `to` | string | current time for `/usage/overview` and `/usage/aggregates`; none for other endpoints | End time. Supports `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values include the full day in `timezone`. |
+| `timezone` | string | `UTC` | Statistics timezone for date-only `from`/`to` and `day`/`week` trend buckets. |
+| `provider` | string | none | Exact provider filter. |
+| `model` | string | none | Fuzzy model filter. |
+| `credential_type` | string | none | Execution credential type: `provider_api_key`, `oauth`, `file_auth`, `vertex`, or `unknown`. |
+| `home_ip` | string | none | Home node IP. |
+| `endpoint` | string | none | Fuzzy endpoint filter. |
 
-金额字段使用当前 Home billing 系统中的 credits/points 口径。启用 billing 且 usage 可归因到 `billing_charge` 时，`amount` 或 `total_amount` 返回数值，`currency` 返回 `credits`，`billing_basis` 返回 `billing_charge`；无法可靠归因时金额返回 `null`，不会伪造估算金额。
+Amount fields use the current Home billing credit/point unit. When billing is enabled and usage can be attributed to `billing_charge`, `amount` or `total_amount` returns a number, `currency` returns `credits`, and `billing_basis` returns `billing_charge`. When attribution is not reliable, amount fields return `null`; the API does not fabricate estimated charges.
 
-`UsageRecordSummary` 关键字段：
+Key `UsageRecordSummary` fields:
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 | --- | --- | --- |
-| `upstream_request_id` | string/null | payload 中可解析到的上游 request ID。 |
-| `source` | string/null | usage payload 的来源。 |
-| `service_tier` | string/null | usage payload 的 service tier。 |
-| `reasoning_effort` | string/null | usage payload 的 reasoning effort。 |
-| `client.client_ip` | string/null | payload 中可关联的调用方 IP。 |
-| `credential.api_key_preview` | string/null | 仅 provider API key 可用时返回脱敏 preview；不会返回 raw key。 |
-| `billing.balance_before` / `billing.balance_after` | number/null | 关联 `billing_charge` 时的扣款前后余额。 |
-| `runtime.request_log_available` | boolean | 当前 Home 节点是否能找到可下载的本地 request log 文件。 |
-| `runtime.log_home_ip_required` | boolean | 下载 request log 时是否必须带上 Home IP。 |
+| `upstream_request_id` | string/null | Upstream request ID parsed from the payload. |
+| `event_type` | string/null | Normalized event type, parsed from payload fields or derived from the endpoint. |
+| `upstream_status_code` | integer/null | Upstream status code parsed from structured usage columns or payload fields. |
+| `source` | string/null | Usage payload source. |
+| `service_tier` | string/null | Usage payload service tier. |
+| `reasoning_effort` | string/null | Usage payload reasoning effort. |
+| `client.client_ip` | string/null | Caller IP associated with the usage payload. This is not treated as the CPA node IP. |
+| `credential.api_key_preview` | string/null | Redacted provider API key preview when available; raw keys are never returned. |
+| `billing.balance_before` / `billing.balance_after` | number/null | Balance before and after the charge when linked to `billing_charge`. |
+| `runtime.home_ip` / `runtime.home_port` | string/integer/null | Home node identity that persisted the usage record. |
+| `runtime.cpa_node_id` / `runtime.cpa_ip` / `runtime.cpa_port` / `runtime.cpa_label` | mixed | CPA ownership fields. Home fills missing CPA node ID/IP from the trusted RESP/mTLS runtime identity when the CPA payload does not report them. |
+| `runtime.request_log_available` | boolean | Whether the current Home node can find a downloadable local request log file. |
+| `runtime.log_home_ip_required` | boolean | Whether request log download requires the Home IP. |
 
 ### GET `/usage/overview`
 
-返回请求用量总览，包括范围、短窗口 live snapshot、总量、趋势、默认 top groups 和 activity 桶。
+Returns a usage overview with the applied range, short-window live snapshot, totals, trends, default top groups, and activity buckets.
 
-Query 参数除汇总范围参数外还支持：
+Query parameters in addition to aggregate range parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `interval` | string | `auto` | `minute`、`hour`、`day`、`week` 或 `auto`。`day` 和 `week` 会按 `timezone` 切桶，响应时间仍为 UTC RFC3339。 |
+| `interval` | string | `auto` | `minute`, `hour`, `day`, `week`, or `auto`. `day` and `week` buckets use `timezone`; response timestamps remain UTC RFC3339. |
 
-输出顶层字段：
+Top-level response fields:
 
-| 字段 | 类型 | 说明 |
+| Field | Type | Description |
 | --- | --- | --- |
-| `range` | object | 应用后的时间范围、timezone 和 interval。 |
-| `live` | object | 最近短窗口 RPM、TPM、错误率和延迟。 |
-| `totals` | object | 请求数、成功/失败数、token、金额、延迟和活跃主体数量。 |
-| `trend` | array | 按 `interval` 聚合的趋势桶。 |
-| `cost_breakdown` | array | 当前不伪造不可拆分的费用明细，无法可靠拆分时为空数组。 |
-| `model_efficiency` | array | 按总 token 排序的模型效率列表。 |
-| `top` | object | `users`、`client_keys`、`credentials`、`providers`、`models`、`endpoints` 和 `errors`。 |
-| `activity` | array | 与趋势桶一致的健康活动序列。 |
+| `range` | object | Applied time range, timezone, and interval. |
+| `live` | object | Recent short-window RPM, TPM, error rate, and latency. |
+| `totals` | object | Request counts, success/failure counts, tokens, amount, latency, and active subject counts. |
+| `trend` | array | Trend buckets aggregated by `interval`. |
+| `cost_breakdown` | array | Empty when reliable cost splitting is unavailable; the API does not fabricate indivisible cost details. |
+| `model_efficiency` | array | Model efficiency list sorted by total tokens. |
+| `top` | object | `users`, `client_keys`, `credentials`, `providers`, `models`, `endpoints`, and `errors`. |
+| `activity` | array | Health activity series aligned with the trend buckets. |
 
 ### GET `/usage/records`
 
-返回请求明细表，服务端分页、筛选和排序。
+Returns the request record table with server-side pagination, filters, and sorting.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `limit` | integer | `50` | 最大 `200`。 |
-| `offset` | integer | `0` | page offset。 |
-| `sort` | string | `timestamp_desc` | 支持 `timestamp_desc`、`timestamp_asc`、`tokens_desc`、`tokens_asc`、`cost_desc`、`cost_asc`、`latency_desc`、`latency_asc`、`failed_first`。 |
-| `search` | string | 无 | request ID、provider、model、endpoint、Home IP、username、masked key、credential label 的宽松搜索。 |
-| `status` | string | 无 | `success` 或 `failed`。 |
-| `status_code` | integer | 无 | HTTP/失败状态码；2xx/3xx 会匹配成功请求，其他值匹配 `fail_status_code`。 |
-| `request_id` | string | 无 | request ID 精确筛选。 |
-| `user` / `user_id` | string / integer | 无 | 用户名或用户 ID。 |
-| `client_key` / `client_key_id` | string / integer | 无 | client access key 的 masked/label/ID 筛选。 |
-| `credential_id` / `auth_index` | string | 无 | 执行凭证筛选。 |
-| `executor_type` | string | 无 | executor type 精确筛选。 |
-| `min_latency_ms` / `max_latency_ms` | integer | 无 | 延迟范围。 |
-| `min_amount` / `max_amount` | number | 无 | billing amount 范围。 |
+| `limit` | integer | `50` | Maximum `200`. |
+| `offset` | integer | `0` | Page offset. |
+| `sort` | string | `timestamp_desc` | Supports `timestamp_desc`, `timestamp_asc`, `tokens_desc`, `tokens_asc`, `cost_desc`, `cost_asc`, `latency_desc`, `latency_asc`, and `failed_first`. |
+| `search` | string | none | Fuzzy search across request ID, provider, model, endpoint, Home IP, CPA node ID/IP/label, username, masked key, and credential label. |
+| `status` | string | none | `success` or `failed`. |
+| `status_code` | integer | none | HTTP/failure status code. 2xx/3xx values match successful requests; other values match `fail_status_code`. |
+| `request_id` | string | none | Exact request ID filter. |
+| `event_type` | string | none | Normalized event type filter. Common values include `completion`, `response`, `message`, `embedding`, and `stream`. |
+| `cpa_node` | string | none | Fuzzy filter across structured CPA node ID, CPA IP, CPA label, and CPA port. |
+| `user` / `user_id` | string / integer | none | Username or user ID. |
+| `client_key` / `client_key_id` | string / integer | none | Client access key masked value, label, or ID. |
+| `credential_id` / `auth_index` | string | none | Execution credential filter. |
+| `executor_type` | string | none | Exact executor type filter. |
+| `min_latency_ms` / `max_latency_ms` | integer | none | Latency range. |
+| `min_amount` / `max_amount` | number | none | Billing amount range. |
 
-响应包含 `items`、`total`、`limit`、`offset`、`sort` 和 `sortable_fields`。`items[]` 为脱敏后的请求摘要，包含 `tokens`、`performance`、`client`、`credential`、`billing`、`runtime` 和可选 `error`。
+The response contains `items`, `total`, `limit`, `offset`, `sort`, and `sortable_fields`. `items[]` is a redacted request summary with `tokens`, `performance`, `client`, `credential`, `billing`, `runtime`, and optional `error`.
 
 ### GET `/usage/records/:id`
 
-返回单条 usage 详情。`id` 为 usage ID。
+Returns one usage detail. `id` is the usage ID.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `include_payload` | boolean | `false` | 返回脱敏 payload summary。 |
-| `include_logs` | boolean | `false` | 找到本地 request log 时返回最多 20 行脱敏日志片段；远端节点或文件不存在时返回空数组。 |
+| `include_payload` | boolean | `false` | Return a redacted payload summary. |
+| `include_logs` | boolean | `false` | Return up to 20 redacted log lines when a local request log is found. Remote nodes or missing files return an empty array. |
 
-响应包含 `record`、`payload_summary`、`log_excerpt` 和 `related`。`payload_summary` 只包含 `method`、`stream`、`message_count`、`tool_count`，不会返回原始 payload。
+The response contains `record`, `payload_summary`, `log_excerpt`, and `related`. `payload_summary` only contains `method`, `stream`, `message_count`, and `tool_count`; raw payloads are never returned.
 
 ### GET `/usage/aggregates`
 
-返回服务端全量排序后的聚合排行。
+Returns server-side aggregate rankings after full-result sorting.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `group_by` | string | 必填 | `user`、`client_key`、`credential`、`provider`、`model`、`endpoint`、`home_ip`、`executor_type`、`status_code`。 |
+| `group_by` | string | required | `user`, `client_key`, `credential`, `provider`, `model`, `endpoint`, `home_ip`, `executor_type`, or `status_code`. |
 | `metric` | string | `request_count` | `request_count`、`total_tokens`、`total_amount`、`failed_count`、`avg_latency_ms`、`p95_latency_ms`。 |
-| `direction` | string | `desc` | `desc` 或 `asc`。 |
-| `limit` | integer | `20` | 最大 `100`。 |
-| `offset` | integer | `0` | page offset。 |
+| `direction` | string | `desc` | `desc` or `asc`. |
+| `limit` | integer | `20` | Maximum `100`. |
+| `offset` | integer | `0` | Page offset. |
 
-响应包含 `group_by`、`metric`、`direction`、`items`、`total`、`limit`、`offset` 和 `sortable_metrics`。
+The response contains `group_by`, `metric`, `direction`, `items`, `total`, `limit`, `offset`, and `sortable_metrics`.
 
 ### GET `/usage/export`
 
-按当前 records 筛选导出脱敏后的请求记录。
+Exports redacted request records for the current records filters.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `format` | string | `csv` | `csv` 或 `jsonl`。 |
-| records filters | mixed | 无 | 与 `GET /usage/records` 相同。未显式传 `limit` 时默认最多导出 `10000` 条；显式 `limit` 也最多 `10000` 条。 |
+| `format` | string | `csv` | `csv` or `jsonl`. |
+| records filters | mixed | none | Same as `GET /usage/records`. When `limit` is omitted, the endpoint exports at most `10000` rows by default; explicit `limit` values are also capped at `10000`. |
 
-响应为 attachment。CSV 使用 `text/csv; charset=utf-8`，JSONL 使用 `application/x-ndjson`。
+Responses are attachments. CSV uses `text/csv; charset=utf-8`; JSONL uses `application/x-ndjson`.
 
-导出字段是展平后的脱敏摘要，除 records 响应中的核心字段外，还包含 `error_status_code`、`error_message`、`error_body_preview`、`request_log_available` 和 `log_home_ip_required`。
+Export fields are flattened redacted summaries. In addition to core record response fields, they include `error_status_code`, `error_message`, `error_body_preview`, `request_log_available`, and `log_home_ip_required`.
+
+### GET `/request-events`
+
+Returns the request event list for the management UI. This endpoint is DB-backed and read-only. It reads persisted usage observability records and does not read or consume `/usage-queue`.
+
+Query parameters:
+
+| Query | Type | Default | Description |
+| --- | --- | --- | --- |
+| `from` / `to` / `timezone` | string | none / `UTC` | Same as `/usage/records`. |
+| `limit` / `offset` | integer | `50` / `0` | Server-side pagination. `limit` is capped at `200`. |
+| `sort` | string | `timestamp_desc` | Supports `timestamp_desc`, `timestamp_asc`, `latency_desc`, `latency_asc`, `tokens_desc`, `tokens_asc`, `cost_desc`, `cost_asc`, and `failed_first`. |
+| `search` | string | none | Fuzzy search across request ID, provider, model, endpoint, Home IP, CPA node ID/IP/label, username, masked key, and credential label. |
+| `request_id` | string | none | Exact request ID filter. |
+| `event_type` | string | none | Event type filter. The value is parsed from `event_type`/`type` payload fields or derived from the endpoint. Common values are `completion`, `response`, `message`, `embedding`, and `stream`. |
+| `status` / `status_code` | string / integer | none | `success`, `failed`, or status code filter. |
+| `provider` / `model` | string | none | Exact provider filter and fuzzy model filter. |
+| `home_ip` | string | none | Home node filter. |
+| `cpa_node` | string | none | Fuzzy filter across structured CPA node ID, CPA IP, CPA label, and CPA port. Home fills missing CPA node ID/IP from the trusted RESP/mTLS runtime identity when available. |
+| `credential_id` / `auth_index` | string | none | Execution credential filter. |
+| `user` | string | none | Username or user ID search. |
+| `client_key` | string | none | Client access key masked value, label, or ID search. |
+| `min_latency_ms` / `max_latency_ms` | integer | none | Latency range. |
+
+The response contains `items`, `total`, `limit`, `offset`, and `sort`. `items[]` is a request event object with these key fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | Stable event ID in the `evt_<usage_id>` format. |
+| `event_type` | string | Event type, parsed from the payload first and derived from the endpoint when absent. |
+| `status` / `failed` / `status_code` / `upstream_status_code` | mixed | Request success/failure state and HTTP status. Successful requests default to `status_code=200` when no explicit status is available. |
+| `provider` / `model` / `original_model` / `model_alias` / `endpoint` | mixed | Model and routing metadata. |
+| `runtime.home_ip` / `runtime.home_port` / `runtime.home_id` | mixed | Home node that persisted the usage record. `home_id` is `home_ip:home_port` when the port is available. |
+| `runtime.cpa_node_id` / `runtime.cpa_ip` / `runtime.cpa_port` / `runtime.cpa_label` | mixed | CPA ownership metadata. Home fills missing CPA node ID/IP from the trusted RESP/mTLS runtime identity when the CPA payload does not report them. |
+| `credential` | object | Execution credential type, ID, auth index, provider, label, source, and redacted `api_key_preview`. |
+| `client` | object | User, client key ID/label, redacted `client_key_masked`, and caller client IP. |
+| `error` | object | Redacted error status, upstream status, reason, message, and body preview. |
+| `tokens` / `performance` / `billing` | object | Token, latency/TTFT/TPS, and billing metadata. |
+| `related.request_log` | object | Request log link metadata. `available=true` and `download_url` are returned only when the current Home can find the local log file. |
+
+### GET `/request-events/filter-options`
+
+Returns compact option lists for the request event filter UI. It accepts the same filters as `GET /request-events`, ignores pagination parameters, and returns distinct values from the filtered result set.
+
+Response fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `event_types` | array | Distinct normalized event types. |
+| `providers` | array | Distinct providers. |
+| `models` | array | Distinct models. |
+| `home_ips` | array | Distinct Home IPs. |
+| `cpa_nodes` | array | Distinct CPA labels, node IDs, or IPs. |
+| `status_codes` | array | Distinct HTTP/upstream status codes encoded as strings for UI select controls. |
+
+### GET `/request-events/:id`
+
+Returns a single request event. `id` accepts either `evt_<usage_id>` or the raw usage ID.
+
+Query parameters:
+
+| Query | Type | Default | Description |
+| --- | --- | --- | --- |
+| `include_payload` | boolean | `false` | Return a redacted payload summary. Raw payloads are never returned. |
+| `include_logs` | boolean | `false` | Return up to 20 redacted log lines when a local request log is found. |
+| `include_related` | boolean | `false` | Compatibility parameter. The event object always includes `related`. |
+
+The response contains `event`, `payload_summary`, and `log_excerpt`. `event` has the same shape as list items. `payload_summary.body_preview` is always `null` to avoid exposing request bodies.
+
+### GET `/request-events/export`
+
+Exports request events for the current filters. Supports `format=csv` and `format=jsonl`; responses are attachments named `request-events.csv` or `request-events.jsonl`.
+
+This endpoint accepts the same filters and sort parameter as `GET /request-events`, ignores pagination parameters, and exports at most `10000` rows. Export fields are flattened redacted summaries of list event objects, including Home/CPA, credential, client, error, token, performance, billing, and request log link fields.
 
 ### GET `/usage/realtime`
 
-返回短窗口实时快照，适合管理面板短轮询。
+Returns a short-window realtime snapshot suitable for management panel polling.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `window_seconds` | integer | `900` | 统计窗口。 |
-| `bucket_seconds` | integer | `60` | velocity bucket 大小。 |
+| `window_seconds` | integer | `900` | Statistics window. |
+| `bucket_seconds` | integer | `60` | Velocity bucket size. |
 | `group_by` | string | `model` | `model`、`provider`、`client_key`、`credential`。 |
 
-除上述参数外支持汇总范围参数。响应包含 `velocity`、`latency_distribution` 和按 `group_by` 聚合的 `current_usage`。
+Aggregate range parameters are also supported. The response contains `velocity`, `latency_distribution`, and `current_usage` grouped by `group_by`.
 
 ### GET `/usage/health/providers`
 
-返回 provider 维度最近窗口健康状态。支持 `window_seconds` 和汇总范围参数。
+Returns recent-window health status by provider. Supports `window_seconds` and aggregate range parameters.
 
-`items[]` 包含 `id`、`label`、`status`、`provider`、`recent_success_count`、`recent_failed_count`、`recent_error_rate`、`last_error_at`、`last_error_status`、`last_error_message`、`next_retry_at`、`avg_latency_ms` 和 `p95_latency_ms`。`next_retry_at` 来自执行凭证的 retry/cooldown 元数据，无法归因时为 `null`。`status` 为 `healthy`、`degraded`、`unavailable` 或 `unknown`。
+`items[]` contains `id`, `label`, `status`, `provider`, `recent_success_count`, `recent_failed_count`, `recent_error_rate`, `last_error_at`, `last_error_status`, `last_error_message`, `next_retry_at`, `avg_latency_ms`, and `p95_latency_ms`. `next_retry_at` comes from execution credential retry/cooldown metadata and is `null` when attribution is unavailable. `status` is `healthy`, `degraded`, `unavailable`, or `unknown`.
 
 ### GET `/usage/health/credentials`
 
-返回执行凭证维度最近窗口健康状态。参数与 provider health 相同，响应 `subject` 为 `credential`，`items[].credential_type` 来自 usage/auth 元数据。凭证 metadata 标记为 `disabled` 或 `unavailable` 时，`status` 优先返回该状态。
+Returns recent-window health status by execution credential. Parameters are the same as provider health. The response `subject` is `credential`, and `items[].credential_type` comes from usage/auth metadata. When credential metadata marks a credential as `disabled` or `unavailable`, `status` returns that state first.
 
 ### GET `/request-logs`
 
-返回 request log index。索引基于 usage 记录生成，并在当前 Home 节点本地查找匹配 request log 文件。
+Returns the request log index. The index is generated from usage records and checks the current Home node for matching local request log files.
 
-Query 参数：
+Query parameters:
 
-| Query | 类型 | 默认值 | 说明 |
+| Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `request_id` | string | 无 | request ID 筛选。 |
-| `home_ip` | string | 无 | Home 节点筛选。 |
-| `from` / `to` | string | 无 | 时间范围。 |
-| `provider` / `model` | string | 无 | Provider/model 筛选。 |
-| `status` / `status_code` | string / integer | 无 | 状态筛选。 |
-| `limit` / `offset` | integer | `50` / `0` | 分页。 |
-| `search` | string | 无 | 对 request ID、model、provider 和 status 做 DB 侧宽松搜索；纯数字时间戳或 `.log` 文件名搜索会在最多 `10000` 条基础记录内匹配本地文件名。 |
+| `request_id` | string | none | Request ID filter. |
+| `home_ip` | string | none | Home node filter. |
+| `from` / `to` | string | none | Time range. |
+| `provider` / `model` | string | none | Provider/model filter. |
+| `status` / `status_code` | string / integer | none | Status filter. |
+| `limit` / `offset` | integer | `50` / `0` | Pagination. |
+| `search` | string | none | DB-side fuzzy search across request ID, model, provider, and status. Numeric timestamps or `.log` file name searches are matched against local file names within at most `10000` base records. |
 
-`items[]` 包含 `id`、`request_id`、`timestamp`、`home_ip`、`file_name`、`size_bytes`、`available`、`provider`、`model`、`status` 和 `download_url`。只有当前节点能找到本地文件时，`available=true` 且 `download_url` 非空；文件不存在或属于远端节点时返回 `available=false`。实际下载仍使用已有 `GET /request-log-by-id/:id`。
+`items[]` contains `id`, `request_id`, `timestamp`, `home_ip`, `file_name`, `size_bytes`, `available`, `provider`, `model`, `status`, and `download_url`. `available=true` and a non-empty `download_url` are returned only when the current node can find the local file. Missing files or files owned by remote nodes return `available=false`. Actual downloads still use the existing `GET /request-log-by-id/:id`.
 
 ### GET `/usage-queue`
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -126,6 +126,10 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `GET` | `/usage/realtime` |
 | `GET` | `/usage/health/providers` |
 | `GET` | `/usage/health/credentials` |
+| `GET` | `/request-events` |
+| `GET` | `/request-events/export` |
+| `GET` | `/request-events/filter-options` |
+| `GET` | `/request-events/:id` |
 | `GET` | `/request-logs` |
 | `GET` | `/proxy/proxy-pools` |
 | `POST` | `/proxy/proxy-pools` |
@@ -2115,6 +2119,10 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 | `capabilities.usage_credential_health` | boolean | 是否支持 `GET /usage/health/credentials`。 |
 | `capabilities.usage_realtime` | boolean | 是否支持 `GET /usage/realtime`。 |
 | `capabilities.request_log_index` | boolean | 是否支持 `GET /request-logs`。 |
+| `capabilities.request_events` / `capabilities.requestEvents` | boolean | 是否支持 `GET /request-events`。 |
+| `capabilities.request_event_details` / `capabilities.requestEventDetails` | boolean | 是否支持 `GET /request-events/:id`。 |
+| `capabilities.request_event_export` / `capabilities.requestEventExport` | boolean | 是否支持 `GET /request-events/export`。 |
+| `capabilities.request_event_filters` / `capabilities.requestEventFilters` | boolean | 是否支持 `GET /request-events/filter-options`。 |
 | `capabilities.oauth_usage` | boolean | OAuth/file-backed credential usage 归因是否可靠。 |
 | `capabilities.logs` | boolean | 是否支持应用日志接口。 |
 | `capabilities.request_error_logs` | boolean | 是否支持 request error log file list/download。 |
@@ -2146,12 +2154,16 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
 | `upstream_request_id` | string/null | payload 中可解析到的上游 request ID。 |
+| `event_type` | string/null | 事件类型，来自 payload 字段或由 endpoint 派生。 |
+| `upstream_status_code` | integer/null | 从结构化 usage 列或 payload 字段解析出的上游状态码。 |
 | `source` | string/null | usage payload 的来源。 |
 | `service_tier` | string/null | usage payload 的 service tier。 |
 | `reasoning_effort` | string/null | usage payload 的 reasoning effort。 |
-| `client.client_ip` | string/null | payload 中可关联的调用方 IP。 |
+| `client.client_ip` | string/null | payload 中可关联的调用方 IP；不会被当作 CPA 节点 IP。 |
 | `credential.api_key_preview` | string/null | 仅 provider API key 可用时返回脱敏 preview；不会返回 raw key。 |
 | `billing.balance_before` / `billing.balance_after` | number/null | 关联 `billing_charge` 时的扣款前后余额。 |
+| `runtime.home_ip` / `runtime.home_port` | string/integer/null | 写入 usage 的 Home 节点标识。 |
+| `runtime.cpa_node_id` / `runtime.cpa_ip` / `runtime.cpa_port` / `runtime.cpa_label` | mixed | CPA 归属信息；CPA payload 未上报时，Home 会从可信 RESP/mTLS 运行时身份补齐 CPA node ID/IP。 |
 | `runtime.request_log_available` | boolean | 当前 Home 节点是否能找到可下载的本地 request log 文件。 |
 | `runtime.log_home_ip_required` | boolean | 下载 request log 时是否必须带上 Home IP。 |
 
@@ -2189,10 +2201,12 @@ Query 参数：
 | `limit` | integer | `50` | 最大 `200`。 |
 | `offset` | integer | `0` | page offset。 |
 | `sort` | string | `timestamp_desc` | 支持 `timestamp_desc`、`timestamp_asc`、`tokens_desc`、`tokens_asc`、`cost_desc`、`cost_asc`、`latency_desc`、`latency_asc`、`failed_first`。 |
-| `search` | string | 无 | request ID、provider、model、endpoint、Home IP、username、masked key、credential label 的宽松搜索。 |
+| `search` | string | 无 | request ID、provider、model、endpoint、Home IP、CPA node ID/IP/label、username、masked key、credential label 的宽松搜索。 |
 | `status` | string | 无 | `success` 或 `failed`。 |
 | `status_code` | integer | 无 | HTTP/失败状态码；2xx/3xx 会匹配成功请求，其他值匹配 `fail_status_code`。 |
 | `request_id` | string | 无 | request ID 精确筛选。 |
+| `event_type` | string | 无 | 事件类型筛选，常见值为 `completion`、`response`、`message`、`embedding`、`stream`。 |
+| `cpa_node` | string | 无 | 按结构化 CPA node ID、CPA IP、CPA label、CPA port 做模糊筛选。 |
 | `user` / `user_id` | string / integer | 无 | 用户名或用户 ID。 |
 | `client_key` / `client_key_id` | string / integer | 无 | client access key 的 masked/label/ID 筛选。 |
 | `credential_id` / `auth_index` | string | 无 | 执行凭证筛选。 |
@@ -2245,6 +2259,80 @@ Query 参数：
 响应为 attachment。CSV 使用 `text/csv; charset=utf-8`，JSONL 使用 `application/x-ndjson`。
 
 导出字段是展平后的脱敏摘要，除 records 响应中的核心字段外，还包含 `error_status_code`、`error_message`、`error_body_preview`、`request_log_available` 和 `log_home_ip_required`。
+
+### GET `/request-events`
+
+返回面向管理界面的请求事件列表。该接口是 DB-backed、非破坏性只读接口，数据来源为持久化 usage observability records，不读取也不消费 `/usage-queue`。
+
+Query 参数：
+
+| Query | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `from` / `to` / `timezone` | string | 无 / `UTC` | 与 `/usage/records` 相同。 |
+| `limit` / `offset` | integer | `50` / `0` | 服务端分页，`limit` 最大 `200`。 |
+| `sort` | string | `timestamp_desc` | 支持 `timestamp_desc`、`timestamp_asc`、`latency_desc`、`latency_asc`、`tokens_desc`、`tokens_asc`、`cost_desc`、`cost_asc`、`failed_first`。 |
+| `search` | string | 无 | request ID、provider、model、endpoint、Home IP、username、masked key、credential label 的宽松搜索。 |
+| `request_id` | string | 无 | request ID 精确筛选。 |
+| `event_type` | string | 无 | 事件类型筛选。当前由 payload 中的 `event_type`/`type` 或 endpoint 派生，常见值为 `completion`、`response`、`message`、`embedding`、`stream`。 |
+| `status` / `status_code` | string / integer | 无 | `success`、`failed` 或状态码筛选。 |
+| `provider` / `model` | string | 无 | Provider 精确筛选，model 模糊筛选。 |
+| `home_ip` | string | 无 | Home 节点筛选。 |
+| `cpa_node` | string | 无 | 按结构化 CPA node ID、CPA IP、CPA label、CPA port 做模糊筛选；CPA payload 未上报时，Home 会尽量从可信 RESP/mTLS 运行时身份补齐。 |
+| `credential_id` / `auth_index` | string | 无 | 执行凭证筛选。 |
+| `user` | string | 无 | 用户名或用户 ID 搜索。 |
+| `client_key` | string | 无 | client access key 的 masked/label/ID 搜索。 |
+| `min_latency_ms` / `max_latency_ms` | integer | 无 | 延迟范围。 |
+
+响应包含 `items`、`total`、`limit`、`offset` 和 `sort`。`items[]` 为请求事件对象，关键字段包括：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | string | 稳定事件 ID，格式为 `evt_<usage_id>`。 |
+| `event_type` | string | 事件类型，优先来自 payload，缺失时由 endpoint 派生。 |
+| `status` / `failed` / `status_code` / `upstream_status_code` | mixed | 请求成功/失败和 HTTP 状态。成功请求默认 `status_code=200`。 |
+| `provider` / `model` / `original_model` / `model_alias` / `endpoint` | mixed | 模型和路由信息。 |
+| `runtime.home_ip` / `runtime.home_port` / `runtime.home_id` | mixed | 写入 usage 的 Home 节点；有端口时 `home_id` 为 `home_ip:home_port`。 |
+| `runtime.cpa_node_id` / `runtime.cpa_ip` / `runtime.cpa_port` / `runtime.cpa_label` | mixed | CPA 归属信息；CPA payload 未上报时，Home 会从可信 RESP/mTLS 运行时身份补齐 CPA node ID/IP。 |
+| `credential` | object | 执行凭证类型、ID、auth index、provider、label、source 和脱敏 `api_key_preview`。 |
+| `client` | object | 用户、client key ID/label、脱敏 `client_key_masked` 和 client IP。 |
+| `error` | object | 脱敏错误状态、上游状态、原因、消息和 body preview。 |
+| `tokens` / `performance` / `billing` | object | token、latency/TTFT/TPS 和 billing 关联信息。 |
+| `related.request_log` | object | request log 关联信息；只有当前 Home 能找到本地日志文件时 `available=true` 并返回 download URL。 |
+
+### GET `/request-events/filter-options`
+
+返回请求事件筛选 UI 所需的紧凑选项列表。该接口接受与 `GET /request-events` 相同的筛选参数，忽略分页参数，并从筛选后的结果集中返回去重值。
+
+响应字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `event_types` | array | 去重后的事件类型。 |
+| `providers` | array | 去重后的 provider。 |
+| `models` | array | 去重后的 model。 |
+| `home_ips` | array | 去重后的 Home IP。 |
+| `cpa_nodes` | array | 去重后的 CPA label、node ID 或 IP。 |
+| `status_codes` | array | 去重后的 HTTP/上游状态码，以字符串返回，便于前端 select 控件使用。 |
+
+### GET `/request-events/:id`
+
+返回单条请求事件详情。`id` 接受 `evt_<usage_id>` 或原始 usage ID。
+
+Query 参数：
+
+| Query | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `include_payload` | boolean | `false` | 返回脱敏 payload summary；不会返回原始 payload。 |
+| `include_logs` | boolean | `false` | 找到本地 request log 时返回最多 20 行脱敏日志片段。 |
+| `include_related` | boolean | `false` | 兼容参数；事件对象始终包含 `related`。 |
+
+响应包含 `event`、`payload_summary` 和 `log_excerpt`。`event` 与列表项同形；`payload_summary.body_preview` 当前固定为 `null`，避免暴露 request body。
+
+### GET `/request-events/export`
+
+按当前筛选条件导出请求事件。支持 `format=csv` 和 `format=jsonl`，响应为 attachment，文件名分别为 `request-events.csv` 或 `request-events.jsonl`。
+
+该接口接受与 `GET /request-events` 相同的筛选和排序参数，但忽略分页参数，最多导出 `10000` 条。导出字段是列表事件对象的展平脱敏摘要，包含 Home/CPA、credential、client、error、tokens、performance、billing 和 request log 关联字段。
 
 ### GET `/usage/realtime`
 

--- a/internal/cluster/db.go
+++ b/internal/cluster/db.go
@@ -124,6 +124,9 @@ func AutoMigrate(db *gorm.DB) error {
 	if errMigrate := migrateUsageObservabilityIndexes(db); errMigrate != nil {
 		return errMigrate
 	}
+	if errMigrate := migrateUsageDerivedColumns(db); errMigrate != nil {
+		return errMigrate
+	}
 	return migrateLegacyAPIKeys(db)
 }
 
@@ -134,6 +137,9 @@ func migrateUsageObservabilityIndexes(db *gorm.DB) error {
 	statements := []string{
 		`CREATE INDEX IF NOT EXISTS idx_usage_provider_lower_time ON "usage" (LOWER("provider"), "timestamp" DESC)`,
 		`CREATE INDEX IF NOT EXISTS idx_usage_auth_type_normalized_time ON "usage" (LOWER(REPLACE("auth_type", '-', '_')), "timestamp" DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_usage_event_type_time ON "usage" ("event_type", "timestamp" DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_usage_cpa_node_time ON "usage" ("cpa_node_id", "timestamp" DESC)`,
+		`CREATE INDEX IF NOT EXISTS idx_usage_home_port_time ON "usage" ("home_ip", "home_port", "timestamp" DESC)`,
 	}
 	for _, statement := range statements {
 		if errExec := db.Exec(statement).Error; errExec != nil {
@@ -141,6 +147,171 @@ func migrateUsageObservabilityIndexes(db *gorm.DB) error {
 		}
 	}
 	return nil
+}
+
+func migrateUsageDerivedColumns(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	var records []UsageRecord
+	where, args := usageDerivedColumnBackfillWhere()
+	return db.
+		Select("id", "payload", "home_ip", "home_port", "event_type", "upstream_request_id", "upstream_status_code", "cpa_node_id", "cpa_ip", "cpa_port", "cpa_label").
+		Where(where, args...).
+		FindInBatches(&records, 500, func(tx *gorm.DB, _ int) error {
+			for _, record := range records {
+				derived, errRecord := UsageRecordFromPayloadWithRuntime(string(record.PayloadJSON), UsageRuntimeMetadata{
+					HomeIP:   record.HomeIP,
+					HomePort: record.HomePort,
+				})
+				if errRecord != nil {
+					continue
+				}
+				updates := map[string]any{}
+				if strings.TrimSpace(record.EventType) == "" && strings.TrimSpace(derived.EventType) != "" {
+					updates["event_type"] = derived.EventType
+				}
+				if strings.TrimSpace(record.UpstreamRequestID) == "" && strings.TrimSpace(derived.UpstreamRequestID) != "" {
+					updates["upstream_request_id"] = derived.UpstreamRequestID
+				}
+				if record.UpstreamStatusCode == 0 && derived.UpstreamStatusCode > 0 {
+					updates["upstream_status_code"] = derived.UpstreamStatusCode
+				}
+				if record.HomePort == 0 && derived.HomePort > 0 {
+					updates["home_port"] = derived.HomePort
+				}
+				if strings.TrimSpace(record.CPANodeID) == "" && strings.TrimSpace(derived.CPANodeID) != "" {
+					updates["cpa_node_id"] = derived.CPANodeID
+				}
+				if strings.TrimSpace(record.CPAIP) == "" && strings.TrimSpace(derived.CPAIP) != "" {
+					updates["cpa_ip"] = derived.CPAIP
+				}
+				if record.CPAPort == 0 && derived.CPAPort > 0 {
+					updates["cpa_port"] = derived.CPAPort
+				}
+				if strings.TrimSpace(record.CPALabel) == "" && strings.TrimSpace(derived.CPALabel) != "" {
+					updates["cpa_label"] = derived.CPALabel
+				}
+				if len(updates) == 0 {
+					continue
+				}
+				if errUpdate := tx.Model(&UsageRecord{}).Where("id = ?", record.ID).Updates(updates).Error; errUpdate != nil {
+					return errUpdate
+				}
+			}
+			return nil
+		}).Error
+}
+
+func usageDerivedColumnBackfillWhere() (string, []any) {
+	upstreamRequestID := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"upstream_request_id"`),
+		usagePayloadTextContainsAll(`"upstream"`, `"request_id"`),
+		usagePayloadTextContainsAll(`"response"`, `"request_id"`),
+		usagePayloadTextContainsAll(`"response"`, `"id"`),
+	)
+	upstreamStatusCode := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"upstream_status_code"`),
+		usagePayloadTextContainsAll(`"upstream"`, `"status_code"`),
+		usagePayloadTextContainsAll(`"response"`, `"status_code"`),
+	)
+	homePort := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"home_port"`),
+		usagePayloadTextContainsAll(`"home"`, `"port"`),
+	)
+	cpaNodeID := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"cpa_node_id"`, `"node_id"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"node_id"`),
+	)
+	cpaIP := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"cpa_ip"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"ip"`),
+	)
+	cpaPort := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"cpa_port"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"port"`),
+	)
+	cpaLabel := usagePayloadTextAnyCondition(
+		usagePayloadTextContainsAny(`"cpa_label"`, `"cpa_node_id"`, `"node_id"`, `"cpa_ip"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"label"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"node_id"`),
+		usagePayloadTextContainsAll(`"cpa"`, `"ip"`),
+	)
+
+	clauses := []string{
+		`event_type = '' OR event_type IS NULL`,
+		`((upstream_request_id = '' OR upstream_request_id IS NULL) AND ` + upstreamRequestID.clause + `)`,
+		`(upstream_status_code = 0 AND ` + upstreamStatusCode.clause + `)`,
+		`(home_port = 0 AND ` + homePort.clause + `)`,
+		`((cpa_node_id = '' OR cpa_node_id IS NULL) AND ` + cpaNodeID.clause + `)`,
+		`((cpa_ip = '' OR cpa_ip IS NULL) AND ` + cpaIP.clause + `)`,
+		`(cpa_port = 0 AND ` + cpaPort.clause + `)`,
+		`((cpa_label = '' OR cpa_label IS NULL) AND ` + cpaLabel.clause + `)`,
+	}
+	args := make([]any, 0, upstreamRequestID.argCount()+upstreamStatusCode.argCount()+homePort.argCount()+cpaNodeID.argCount()+cpaIP.argCount()+cpaPort.argCount()+cpaLabel.argCount())
+	for _, condition := range []usagePayloadTextCondition{upstreamRequestID, upstreamStatusCode, homePort, cpaNodeID, cpaIP, cpaPort, cpaLabel} {
+		args = append(args, condition.args...)
+	}
+	return strings.Join(clauses, " OR "), args
+}
+
+type usagePayloadTextCondition struct {
+	clause string
+	args   []any
+}
+
+func (c usagePayloadTextCondition) argCount() int {
+	return len(c.args)
+}
+
+func usagePayloadTextContainsAny(markers ...string) usagePayloadTextCondition {
+	conditions := make([]string, 0, len(markers))
+	args := make([]any, 0, len(markers))
+	for _, marker := range markers {
+		marker = strings.TrimSpace(marker)
+		if marker == "" {
+			continue
+		}
+		conditions = append(conditions, `CAST("payload" AS TEXT) LIKE ?`)
+		args = append(args, "%"+marker+"%")
+	}
+	if len(conditions) == 0 {
+		return usagePayloadTextCondition{clause: "1 = 0"}
+	}
+	return usagePayloadTextCondition{clause: "(" + strings.Join(conditions, " OR ") + ")", args: args}
+}
+
+func usagePayloadTextContainsAll(markers ...string) usagePayloadTextCondition {
+	conditions := make([]string, 0, len(markers))
+	args := make([]any, 0, len(markers))
+	for _, marker := range markers {
+		marker = strings.TrimSpace(marker)
+		if marker == "" {
+			continue
+		}
+		conditions = append(conditions, `CAST("payload" AS TEXT) LIKE ?`)
+		args = append(args, "%"+marker+"%")
+	}
+	if len(conditions) == 0 {
+		return usagePayloadTextCondition{clause: "1 = 0"}
+	}
+	return usagePayloadTextCondition{clause: "(" + strings.Join(conditions, " AND ") + ")", args: args}
+}
+
+func usagePayloadTextAnyCondition(conditions ...usagePayloadTextCondition) usagePayloadTextCondition {
+	clauses := make([]string, 0, len(conditions))
+	args := []any{}
+	for _, condition := range conditions {
+		if strings.TrimSpace(condition.clause) == "" {
+			continue
+		}
+		clauses = append(clauses, condition.clause)
+		args = append(args, condition.args...)
+	}
+	if len(clauses) == 0 {
+		return usagePayloadTextCondition{clause: "1 = 0"}
+	}
+	return usagePayloadTextCondition{clause: "(" + strings.Join(clauses, " OR ") + ")", args: args}
 }
 
 func migrateAuthNextRetryAfter(db *gorm.DB) error {

--- a/internal/cluster/management/request_events.go
+++ b/internal/cluster/management/request_events.go
@@ -1,0 +1,490 @@
+package management
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"gorm.io/gorm"
+)
+
+const requestEventsExportDefaultLimit = usageExportDefaultLimit
+
+func (h *Handler) ListRequestEvents(c *gin.Context) {
+	query, errParse := parseUsageRecordHTTPQuery(c)
+	if errParse != nil {
+		respondUsageHTTPError(c, errParse)
+		return
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+
+	result, errRecords := h.repo.ListUsageObservabilityRecords(ctx, usageObservabilityRecordQueryFromHTTP(query))
+	if errRecords != nil {
+		respondError(c, http.StatusInternalServerError, "request_events_load_failed", errRecords)
+		return
+	}
+	items := make([]gin.H, 0, len(result.Records))
+	for index := range result.Records {
+		items = append(items, h.requestEventResponse(&result.Records[index]))
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"items":  items,
+		"total":  result.Total,
+		"limit":  query.Limit,
+		"offset": query.Offset,
+		"sort":   query.Sort,
+	})
+}
+
+func (h *Handler) GetRequestEvent(c *gin.Context) {
+	id := requestEventUsageIDFromParam(c.Param("id"))
+	includePayload := parseUsageBool(c.Query("include_payload"))
+	includeLogs := parseUsageBool(c.Query("include_logs"))
+
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	record, errRecord := h.repo.GetUsageObservabilityRecord(ctx, id)
+	if errRecord != nil {
+		if errors.Is(errRecord, gorm.ErrRecordNotFound) {
+			respondError(c, http.StatusNotFound, "request_event_not_found", errRecord)
+			return
+		}
+		respondError(c, http.StatusInternalServerError, "request_event_load_failed", errRecord)
+		return
+	}
+
+	var payloadSummary any
+	if includePayload {
+		summary, errSummary := h.repo.GetUsageObservabilityPayloadSummary(ctx, id)
+		if errSummary != nil {
+			respondError(c, http.StatusInternalServerError, "request_event_payload_summary_load_failed", errSummary)
+			return
+		}
+		payloadSummary = requestEventPayloadSummaryResponse(summary)
+	}
+	logExcerpt := []string{}
+	if includeLogs {
+		logExcerpt = h.usageRequestLogExcerpt(record)
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"event":           h.requestEventResponse(record),
+		"payload_summary": payloadSummary,
+		"log_excerpt":     logExcerpt,
+	})
+}
+
+func (h *Handler) ExportRequestEvents(c *gin.Context) {
+	format := strings.ToLower(strings.TrimSpace(c.Query("format")))
+	if format == "" {
+		format = "csv"
+	}
+	if format != "csv" && format != "jsonl" {
+		respondError(c, http.StatusBadRequest, "invalid_format", fmt.Errorf("format must be csv or jsonl"))
+		return
+	}
+	query, errParse := parseUsageRecordHTTPQueryWithoutPagination(c)
+	if errParse != nil {
+		respondUsageHTTPError(c, errParse)
+		return
+	}
+	query.Limit = requestEventsExportDefaultLimit
+	query.Offset = 0
+
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	repoQuery := usageObservabilityRecordQueryFromHTTP(query)
+	repoQuery.MaxLimit = requestEventsExportDefaultLimit
+	result, errRecords := h.repo.ListUsageObservabilityRecords(ctx, repoQuery)
+	if errRecords != nil {
+		respondError(c, http.StatusInternalServerError, "request_events_export_load_failed", errRecords)
+		return
+	}
+
+	filename := "request-events." + format
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	if format == "jsonl" {
+		c.Header("Content-Type", "application/x-ndjson")
+		c.Status(http.StatusOK)
+		encoder := json.NewEncoder(c.Writer)
+		for index := range result.Records {
+			if errEncode := encoder.Encode(h.requestEventExportRecordMap(&result.Records[index])); errEncode != nil {
+				return
+			}
+		}
+		return
+	}
+
+	c.Header("Content-Type", "text/csv; charset=utf-8")
+	c.Status(http.StatusOK)
+	writer := csv.NewWriter(c.Writer)
+	_ = writer.Write(requestEventExportCSVHeader())
+	for index := range result.Records {
+		_ = writer.Write(h.requestEventExportCSVRow(&result.Records[index]))
+	}
+	writer.Flush()
+}
+
+func (h *Handler) GetRequestEventFilterOptions(c *gin.Context) {
+	query, errParse := parseUsageRecordHTTPQueryWithoutPagination(c)
+	if errParse != nil {
+		respondUsageHTTPError(c, errParse)
+		return
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	options, errOptions := h.repo.UsageObservabilityFilterOptions(ctx, usageObservabilityRecordQueryFromHTTP(query))
+	if errOptions != nil {
+		respondError(c, http.StatusInternalServerError, "request_event_filter_options_load_failed", errOptions)
+		return
+	}
+	c.JSON(http.StatusOK, requestEventFilterOptionsResponse(options))
+}
+
+func (h *Handler) requestEventResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	if record == nil {
+		return gin.H{}
+	}
+	recordCopy := *record
+	available, _, _ := h.usageRequestLogAvailability(recordCopy.Runtime.HomeIP, recordCopy.RequestID)
+	recordCopy.Runtime.RequestLogAvailable = available
+	return requestEventResponse(&recordCopy)
+}
+
+func requestEventResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	if record == nil {
+		return gin.H{}
+	}
+	statusCode := requestEventHTTPStatusCode(record)
+	upstreamStatusCode := requestEventUpstreamStatusCode(record)
+	return gin.H{
+		"id":                   "evt_" + record.ID,
+		"timestamp":            record.Timestamp.UTC().Format(time.RFC3339Nano),
+		"request_id":           record.RequestID,
+		"upstream_request_id":  emptyStringAsNil(record.UpstreamRequestID),
+		"event_type":           requestEventType(record),
+		"status":               record.Status,
+		"failed":               record.Failed,
+		"status_code":          statusCode,
+		"upstream_status_code": upstreamStatusCode,
+		"provider":             record.Provider,
+		"model":                record.Model,
+		"original_model":       record.OriginalModel,
+		"model_alias":          requestEventModelAlias(record),
+		"endpoint":             record.Endpoint,
+		"source":               emptyStringAsNil(record.Source),
+		"executor_type":        record.ExecutorType,
+		"service_tier":         emptyStringAsNil(record.ServiceTier),
+		"reasoning_effort":     emptyStringAsNil(record.ReasoningEffort),
+		"runtime":              requestEventRuntimeResponse(record),
+		"credential":           requestEventCredentialResponse(record),
+		"client":               requestEventClientResponse(record),
+		"error":                requestEventErrorResponse(record),
+		"tokens":               requestEventTokensResponse(record),
+		"performance":          requestEventPerformanceResponse(record),
+		"billing":              requestEventBillingResponse(record),
+		"related":              requestEventRelatedResponse(record),
+	}
+}
+
+func requestEventType(record *cluster.UsageObservabilityRecord) string {
+	if record == nil {
+		return "completion"
+	}
+	if eventType := strings.TrimSpace(record.EventType); eventType != "" {
+		return eventType
+	}
+	return "completion"
+}
+
+func requestEventHTTPStatusCode(record *cluster.UsageObservabilityRecord) any {
+	if record == nil {
+		return nil
+	}
+	if record.StatusCode > 0 {
+		return record.StatusCode
+	}
+	if !record.Failed {
+		return http.StatusOK
+	}
+	return nil
+}
+
+func requestEventUpstreamStatusCode(record *cluster.UsageObservabilityRecord) any {
+	if record == nil {
+		return nil
+	}
+	if record.UpstreamStatusCode > 0 {
+		return record.UpstreamStatusCode
+	}
+	if record.Error == nil || record.Error.UpstreamStatusCode <= 0 {
+		return requestEventHTTPStatusCode(record)
+	}
+	return record.Error.UpstreamStatusCode
+}
+
+func requestEventModelAlias(record *cluster.UsageObservabilityRecord) any {
+	if record == nil {
+		return nil
+	}
+	alias := strings.TrimSpace(record.OriginalModel)
+	if alias == "" || alias == strings.TrimSpace(record.Model) {
+		return nil
+	}
+	return alias
+}
+
+func requestEventRuntimeResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	homeIP := strings.TrimSpace(record.Runtime.HomeIP)
+	homeID := any(nil)
+	if homeIP != "" {
+		homeID = homeIP
+		if record.Runtime.HomePort > 0 {
+			homeID = fmt.Sprintf("%s:%d", homeIP, record.Runtime.HomePort)
+		}
+	}
+	cpaLabel := strings.TrimSpace(record.Runtime.CPALabel)
+	if cpaLabel == "" && strings.TrimSpace(record.Runtime.CPAIP) != "" {
+		cpaLabel = record.Runtime.CPAIP
+		if record.Runtime.CPAPort > 0 {
+			cpaLabel = fmt.Sprintf("%s:%d", record.Runtime.CPAIP, record.Runtime.CPAPort)
+		}
+	}
+	return gin.H{
+		"home_ip":     emptyStringAsNil(homeIP),
+		"home_port":   optionalPositiveIntValue(record.Runtime.HomePort),
+		"home_id":     homeID,
+		"cpa_node_id": emptyStringAsNil(record.Runtime.CPANodeID),
+		"cpa_ip":      emptyStringAsNil(record.Runtime.CPAIP),
+		"cpa_port":    optionalPositiveIntValue(record.Runtime.CPAPort),
+		"cpa_label":   emptyStringAsNil(cpaLabel),
+	}
+}
+
+func requestEventCredentialResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"credential_type": record.Credential.CredentialType,
+		"credential_id":   record.Credential.CredentialID,
+		"auth_index":      record.Credential.AuthIndex,
+		"provider":        record.Credential.Provider,
+		"label":           record.Credential.Label,
+		"source":          record.Credential.Source,
+		"api_key_preview": emptyStringAsNil(record.Credential.APIKeyPreview),
+	}
+}
+
+func requestEventClientResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"user_id":           optionalUintValue(record.Client.UserID),
+		"username":          record.Client.Username,
+		"client_key_id":     optionalUintValue(record.Client.APIKeyID),
+		"client_key_label":  record.Client.APIKeyLabel,
+		"client_key_masked": record.Client.APIKeyMasked,
+		"client_ip":         emptyStringAsNil(record.Client.ClientIP),
+	}
+}
+
+func requestEventErrorResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	var statusCode any
+	var upstreamStatusCode any
+	var reason any
+	var message any
+	var bodyPreview any
+	if record != nil && record.Error != nil {
+		if record.Error.StatusCode > 0 {
+			statusCode = record.Error.StatusCode
+		}
+		if record.Error.UpstreamStatusCode > 0 {
+			upstreamStatusCode = record.Error.UpstreamStatusCode
+		}
+		reason = emptyStringAsNil(record.Error.Reason)
+		message = emptyStringAsNil(record.Error.Message)
+		bodyPreview = emptyStringAsNil(record.Error.BodyPreview)
+	}
+	return gin.H{
+		"status_code":          statusCode,
+		"upstream_status_code": upstreamStatusCode,
+		"reason":               reason,
+		"message":              message,
+		"body_preview":         bodyPreview,
+	}
+}
+
+func requestEventTokensResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"input_tokens":          record.Tokens.InputTokens,
+		"output_tokens":         record.Tokens.OutputTokens,
+		"reasoning_tokens":      record.Tokens.ReasoningTokens,
+		"cached_tokens":         record.Tokens.CachedTokens,
+		"cache_read_tokens":     record.Tokens.CacheReadTokens,
+		"cache_creation_tokens": record.Tokens.CacheCreationTokens,
+		"total_tokens":          record.Tokens.TotalTokens,
+	}
+}
+
+func requestEventPerformanceResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"latency_ms": record.Performance.LatencyMS,
+		"ttft_ms":    optionalInt64Value(record.Performance.TTFTMS),
+		"tps":        optionalFloat64Value(record.Performance.TPS),
+	}
+}
+
+func requestEventBillingResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"amount":             optionalFloat64Value(record.Billing.Amount),
+		"currency":           emptyStringAsNil(record.Billing.Currency),
+		"charge_id":          emptyStringAsNil(record.Billing.ChargeID),
+		"matched_price_rule": emptyStringAsNil(record.Billing.MatchedPriceRule),
+	}
+}
+
+func requestEventRelatedResponse(record *cluster.UsageObservabilityRecord) gin.H {
+	return gin.H{
+		"usage_record_id": record.ID,
+		"request_log": gin.H{
+			"request_id":   record.RequestID,
+			"home_ip":      record.Runtime.HomeIP,
+			"available":    record.Runtime.RequestLogAvailable,
+			"download_url": requestEventRequestLogDownloadURL(record),
+		},
+	}
+}
+
+func requestEventRequestLogDownloadURL(record *cluster.UsageObservabilityRecord) any {
+	if record == nil || !record.Runtime.RequestLogAvailable || strings.TrimSpace(record.RequestID) == "" {
+		return nil
+	}
+	value := "/request-log-by-id/" + url.PathEscape(record.RequestID)
+	if homeIP := strings.TrimSpace(record.Runtime.HomeIP); homeIP != "" {
+		value += "?home_ip=" + url.QueryEscape(homeIP)
+	}
+	return value
+}
+
+func requestEventUsageIDFromParam(raw string) string {
+	value := strings.TrimSpace(raw)
+	value = strings.TrimPrefix(value, "evt_")
+	return value
+}
+
+func requestEventPayloadSummaryResponse(summary *cluster.UsageObservabilityPayloadSummary) gin.H {
+	payload := usagePayloadSummaryResponse(summary)
+	payload["body_preview"] = nil
+	return payload
+}
+
+func (h *Handler) requestEventExportRecordMap(record *cluster.UsageObservabilityRecord) map[string]any {
+	item := h.requestEventResponse(record)
+	out := flattenRequestEventExportMap(item)
+	return out
+}
+
+func flattenRequestEventExportMap(item gin.H) map[string]any {
+	out := map[string]any{}
+	for _, key := range requestEventExportCSVHeader() {
+		out[key] = requestEventFlattenedValue(item, key)
+	}
+	return out
+}
+
+func requestEventFlattenedValue(item gin.H, key string) any {
+	switch key {
+	case "home_ip", "home_port", "home_id", "cpa_node_id", "cpa_ip", "cpa_port", "cpa_label":
+		return nestedMapValue(item, "runtime", key)
+	case "credential_type", "credential_id", "auth_index", "credential_provider", "credential_label", "credential_source", "credential_api_key_preview":
+		credentialKey := strings.TrimPrefix(key, "credential_")
+		if key == "credential_type" || key == "credential_id" {
+			credentialKey = key
+		}
+		return nestedMapValue(item, "credential", credentialKey)
+	case "user_id", "username", "client_key_id", "client_key_label", "client_key_masked", "client_ip":
+		return nestedMapValue(item, "client", key)
+	case "input_tokens", "output_tokens", "reasoning_tokens", "cached_tokens", "cache_read_tokens", "cache_creation_tokens", "total_tokens":
+		return nestedMapValue(item, "tokens", key)
+	case "latency_ms", "ttft_ms", "tps":
+		return nestedMapValue(item, "performance", key)
+	case "amount", "currency", "charge_id", "matched_price_rule":
+		return nestedMapValue(item, "billing", key)
+	case "error_status_code":
+		return nestedMapValue(item, "error", "status_code")
+	case "error_upstream_status_code":
+		return nestedMapValue(item, "error", "upstream_status_code")
+	case "error_reason", "error_message", "error_body_preview":
+		return nestedMapValue(item, "error", strings.TrimPrefix(key, "error_"))
+	case "usage_record_id":
+		return nestedMapValue(item, "related", "usage_record_id")
+	case "request_log_available":
+		return nestedMapValuePath(item, "related", "request_log", "available")
+	default:
+		return item[key]
+	}
+}
+
+func nestedMapValue(item gin.H, section string, key string) any {
+	return nestedMapValuePath(item, section, key)
+}
+
+func nestedMapValuePath(item gin.H, path ...string) any {
+	var current any = item
+	for _, key := range path {
+		typed, ok := current.(gin.H)
+		if !ok {
+			if fallback, okMap := current.(map[string]any); okMap {
+				current = fallback[key]
+				continue
+			}
+			return nil
+		}
+		current = typed[key]
+	}
+	return current
+}
+
+func requestEventExportCSVHeader() []string {
+	return []string{
+		"id", "timestamp", "request_id", "upstream_request_id", "event_type", "status", "failed", "status_code", "upstream_status_code",
+		"provider", "model", "original_model", "model_alias", "endpoint", "source", "executor_type", "service_tier", "reasoning_effort",
+		"home_ip", "home_port", "home_id", "cpa_node_id", "cpa_ip", "cpa_port", "cpa_label",
+		"credential_type", "credential_id", "auth_index", "credential_provider", "credential_label", "credential_source", "credential_api_key_preview",
+		"user_id", "username", "client_key_id", "client_key_label", "client_key_masked", "client_ip",
+		"input_tokens", "output_tokens", "reasoning_tokens", "cached_tokens", "cache_read_tokens", "cache_creation_tokens", "total_tokens",
+		"latency_ms", "ttft_ms", "tps", "amount", "currency", "charge_id", "matched_price_rule",
+		"error_status_code", "error_upstream_status_code", "error_reason", "error_message", "error_body_preview",
+		"usage_record_id", "request_log_available",
+	}
+}
+
+func (h *Handler) requestEventExportCSVRow(record *cluster.UsageObservabilityRecord) []string {
+	row := h.requestEventExportRecordMap(record)
+	out := make([]string, 0, len(requestEventExportCSVHeader()))
+	for _, key := range requestEventExportCSVHeader() {
+		out = append(out, usageExportCSVValue(row[key]))
+	}
+	return out
+}
+
+func requestEventFilterOptionsResponse(options cluster.UsageObservabilityFilterOptions) gin.H {
+	statusCodes := make([]string, 0, len(options.StatusCodes))
+	for _, statusCode := range options.StatusCodes {
+		if statusCode <= 0 {
+			continue
+		}
+		statusCodes = append(statusCodes, fmt.Sprint(statusCode))
+	}
+	return gin.H{
+		"event_types":  options.EventTypes,
+		"providers":    options.Providers,
+		"models":       options.Models,
+		"home_ips":     options.HomeIPs,
+		"cpa_nodes":    options.CPANodes,
+		"status_codes": statusCodes,
+	}
+}

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -36,6 +36,20 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 			"usage_credential_health": true,
 			"usage_realtime":          true,
 			"request_log_index":       true,
+			"request_events":          true,
+			"request_event_details":   true,
+			"request_event_export":    true,
+			"request_event_filters":   true,
+			"request_events_details":  true,
+			"request_events_export":   true,
+			"request_events_filters":  true,
+			"requestEvents":           true,
+			"requestEventDetails":     true,
+			"requestEventExport":      true,
+			"requestEventFilters":     true,
+			"requestEventsDetails":    true,
+			"requestEventsExport":     true,
+			"requestEventsFilters":    true,
 			"oauth_usage":             true,
 			"logs":                    true,
 			"request_error_logs":      true,
@@ -409,6 +423,8 @@ type usageRecordHTTPQuery struct {
 	CredentialID   string
 	AuthIndex      string
 	ExecutorType   string
+	EventType      string
+	CPANode        string
 	MinLatencyMS   *int64
 	MaxLatencyMS   *int64
 	MinAmount      *float64
@@ -474,6 +490,14 @@ type usageHealthHTTPQuery struct {
 }
 
 func parseUsageRecordHTTPQuery(c *gin.Context) (usageRecordHTTPQuery, *usageHTTPError) {
+	return parseUsageRecordHTTPQueryWithPagination(c, true)
+}
+
+func parseUsageRecordHTTPQueryWithoutPagination(c *gin.Context) (usageRecordHTTPQuery, *usageHTTPError) {
+	return parseUsageRecordHTTPQueryWithPagination(c, false)
+}
+
+func parseUsageRecordHTTPQueryWithPagination(c *gin.Context, includePagination bool) (usageRecordHTTPQuery, *usageHTTPError) {
 	query := usageRecordHTTPQuery{}
 	if c == nil {
 		return query, newUsageHTTPError("invalid_request", "request is unavailable")
@@ -491,13 +515,19 @@ func parseUsageRecordHTTPQuery(c *gin.Context) (usageRecordHTTPQuery, *usageHTTP
 	query.To = to
 	query.Timezone = timezone
 
-	limit, errLimit := parseUsageLimit(c.Query("limit"), cluster.UsageObservabilityDefaultRecordLimit, cluster.UsageObservabilityMaxRecordLimit)
-	if errLimit != nil {
-		return query, errLimit
-	}
-	offset, errOffset := parseUsageOffset(c.Query("offset"))
-	if errOffset != nil {
-		return query, errOffset
+	limit := cluster.UsageObservabilityDefaultRecordLimit
+	offset := 0
+	if includePagination {
+		parsedLimit, errLimit := parseUsageLimit(c.Query("limit"), cluster.UsageObservabilityDefaultRecordLimit, cluster.UsageObservabilityMaxRecordLimit)
+		if errLimit != nil {
+			return query, errLimit
+		}
+		parsedOffset, errOffset := parseUsageOffset(c.Query("offset"))
+		if errOffset != nil {
+			return query, errOffset
+		}
+		limit = parsedLimit
+		offset = parsedOffset
 	}
 	sortValue, errSort := parseUsageSort(c.Query("sort"))
 	if errSort != nil {
@@ -557,6 +587,8 @@ func parseUsageRecordHTTPQuery(c *gin.Context) (usageRecordHTTPQuery, *usageHTTP
 	query.CredentialID = strings.TrimSpace(c.Query("credential_id"))
 	query.AuthIndex = strings.TrimSpace(c.Query("auth_index"))
 	query.ExecutorType = strings.TrimSpace(c.Query("executor_type"))
+	query.EventType = strings.TrimSpace(c.Query("event_type"))
+	query.CPANode = strings.TrimSpace(c.Query("cpa_node"))
 	query.MinLatencyMS = minLatency
 	query.MaxLatencyMS = maxLatency
 	query.MinAmount = minAmount
@@ -1041,6 +1073,8 @@ func usageObservabilityRecordQueryFromHTTP(query usageRecordHTTPQuery) cluster.U
 		CredentialID:   query.CredentialID,
 		AuthIndex:      query.AuthIndex,
 		ExecutorType:   query.ExecutorType,
+		EventType:      query.EventType,
+		CPANode:        query.CPANode,
 		MinLatencyMS:   query.MinLatencyMS,
 		MaxLatencyMS:   query.MaxLatencyMS,
 		MinAmount:      query.MinAmount,
@@ -1470,22 +1504,24 @@ func usageRecordSummaryResponse(record *cluster.UsageObservabilityRecord) gin.H 
 		}
 	}
 	return gin.H{
-		"id":                  record.ID,
-		"usage_id":            record.UsageID,
-		"timestamp":           record.Timestamp.UTC().Format(time.RFC3339Nano),
-		"request_id":          record.RequestID,
-		"upstream_request_id": emptyStringAsNil(record.UpstreamRequestID),
-		"status":              record.Status,
-		"failed":              record.Failed,
-		"status_code":         record.StatusCode,
-		"source":              emptyStringAsNil(record.Source),
-		"provider":            record.Provider,
-		"model":               record.Model,
-		"original_model":      record.OriginalModel,
-		"endpoint":            record.Endpoint,
-		"service_tier":        emptyStringAsNil(record.ServiceTier),
-		"reasoning_effort":    emptyStringAsNil(record.ReasoningEffort),
-		"executor_type":       record.ExecutorType,
+		"id":                   record.ID,
+		"usage_id":             record.UsageID,
+		"timestamp":            record.Timestamp.UTC().Format(time.RFC3339Nano),
+		"request_id":           record.RequestID,
+		"upstream_request_id":  emptyStringAsNil(record.UpstreamRequestID),
+		"event_type":           emptyStringAsNil(record.EventType),
+		"status":               record.Status,
+		"failed":               record.Failed,
+		"status_code":          record.StatusCode,
+		"upstream_status_code": optionalPositiveIntValue(record.UpstreamStatusCode),
+		"source":               emptyStringAsNil(record.Source),
+		"provider":             record.Provider,
+		"model":                record.Model,
+		"original_model":       record.OriginalModel,
+		"endpoint":             record.Endpoint,
+		"service_tier":         emptyStringAsNil(record.ServiceTier),
+		"reasoning_effort":     emptyStringAsNil(record.ReasoningEffort),
+		"executor_type":        record.ExecutorType,
 		"tokens": gin.H{
 			"input_tokens":          record.Tokens.InputTokens,
 			"output_tokens":         record.Tokens.OutputTokens,
@@ -1529,6 +1565,11 @@ func usageRecordSummaryResponse(record *cluster.UsageObservabilityRecord) gin.H 
 		},
 		"runtime": gin.H{
 			"home_ip":               record.Runtime.HomeIP,
+			"home_port":             optionalPositiveIntValue(record.Runtime.HomePort),
+			"cpa_node_id":           emptyStringAsNil(record.Runtime.CPANodeID),
+			"cpa_ip":                emptyStringAsNil(record.Runtime.CPAIP),
+			"cpa_port":              optionalPositiveIntValue(record.Runtime.CPAPort),
+			"cpa_label":             emptyStringAsNil(record.Runtime.CPALabel),
 			"request_log_available": record.Runtime.RequestLogAvailable,
 			"log_home_ip_required":  record.Runtime.LogHomeIPRequired,
 		},
@@ -1609,9 +1650,11 @@ func usageExportRecordMap(record *cluster.UsageObservabilityRecord) map[string]a
 		"timestamp":                  record.Timestamp.UTC().Format(time.RFC3339Nano),
 		"request_id":                 record.RequestID,
 		"upstream_request_id":        emptyStringAsNil(record.UpstreamRequestID),
+		"event_type":                 emptyStringAsNil(record.EventType),
 		"status":                     record.Status,
 		"failed":                     record.Failed,
 		"status_code":                record.StatusCode,
+		"upstream_status_code":       optionalPositiveIntValue(record.UpstreamStatusCode),
 		"source":                     emptyStringAsNil(record.Source),
 		"provider":                   record.Provider,
 		"model":                      record.Model,
@@ -1652,6 +1695,11 @@ func usageExportRecordMap(record *cluster.UsageObservabilityRecord) map[string]a
 		"balance_before":             optionalFloat64Value(record.Billing.BalanceBefore),
 		"balance_after":              optionalFloat64Value(record.Billing.BalanceAfter),
 		"home_ip":                    record.Runtime.HomeIP,
+		"home_port":                  optionalPositiveIntValue(record.Runtime.HomePort),
+		"cpa_node_id":                emptyStringAsNil(record.Runtime.CPANodeID),
+		"cpa_ip":                     emptyStringAsNil(record.Runtime.CPAIP),
+		"cpa_port":                   optionalPositiveIntValue(record.Runtime.CPAPort),
+		"cpa_label":                  emptyStringAsNil(record.Runtime.CPALabel),
 		"request_log_available":      record.Runtime.RequestLogAvailable,
 		"log_home_ip_required":       record.Runtime.LogHomeIPRequired,
 		"error_status_code":          errorStatusCode,
@@ -1662,13 +1710,13 @@ func usageExportRecordMap(record *cluster.UsageObservabilityRecord) map[string]a
 
 func usageExportCSVHeader() []string {
 	return []string{
-		"id", "usage_id", "timestamp", "request_id", "upstream_request_id", "status", "failed", "status_code",
+		"id", "usage_id", "timestamp", "request_id", "upstream_request_id", "event_type", "status", "failed", "status_code", "upstream_status_code",
 		"source", "provider", "model", "original_model", "endpoint", "service_tier", "reasoning_effort", "executor_type",
 		"input_tokens", "output_tokens", "reasoning_tokens", "cached_tokens", "cache_read_tokens", "cache_creation_tokens", "total_tokens",
 		"latency_ms", "ttft_ms", "tps", "api_key_id", "api_key_label", "api_key_masked", "user_id", "username", "client_ip",
 		"credential_id", "credential_type", "auth_index", "credential_provider", "credential_label", "credential_source", "credential_status", "credential_api_key_preview",
 		"charge_id", "amount", "currency", "billing_basis", "matched_price_rule", "balance_before", "balance_after",
-		"home_ip", "request_log_available", "log_home_ip_required", "error_status_code", "error_message", "error_body_preview",
+		"home_ip", "home_port", "cpa_node_id", "cpa_ip", "cpa_port", "cpa_label", "request_log_available", "log_home_ip_required", "error_status_code", "error_message", "error_body_preview",
 	}
 }
 
@@ -1707,6 +1755,13 @@ func optionalIntValue(value *int) any {
 		return nil
 	}
 	return *value
+}
+
+func optionalPositiveIntValue(value int) any {
+	if value <= 0 {
+		return nil
+	}
+	return value
 }
 
 func optionalStringValue(value *string) any {

--- a/internal/cluster/management/usage_observability_test.go
+++ b/internal/cluster/management/usage_observability_test.go
@@ -75,7 +75,7 @@ func TestGetCapabilitiesReturnsUsageObservabilityFlags(t *testing.T) {
 	if !ok {
 		t.Fatalf("capabilities = %T, want object", payload["capabilities"])
 	}
-	for _, key := range []string{"usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "request_log_index", "oauth_usage", "logs", "request_error_logs"} {
+	for _, key := range []string{"usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "request_log_index", "request_events", "request_event_details", "request_event_export", "request_event_filters", "request_events_details", "request_events_export", "request_events_filters", "requestEvents", "requestEventDetails", "requestEventExport", "requestEventFilters", "requestEventsDetails", "requestEventsExport", "requestEventsFilters", "oauth_usage", "logs", "request_error_logs"} {
 		if capabilities[key] != true {
 			t.Fatalf("capabilities[%s] = %v, want true", key, capabilities[key])
 		}
@@ -142,6 +142,195 @@ func TestListUsageRecordsReturnsJoinedItems(t *testing.T) {
 	}
 	if _, ok := payload["sortable_fields"].([]any); !ok {
 		t.Fatalf("sortable_fields = %T, want array", payload["sortable_fields"])
+	}
+}
+
+func TestListRequestEventsReturnsFrontendContract(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/request-events", handler.ListRequestEvents)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/request-events?limit=10&event_type=completion&cpa_node=cpa-a", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	if strings.Contains(resp.Body.String(), "client-key-secret") {
+		t.Fatalf("response leaked raw client key: %s", resp.Body.String())
+	}
+
+	var payload map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if payload["total"] != float64(1) || payload["sort"] != "timestamp_desc" {
+		t.Fatalf("page metadata = %#v, want one timestamp-desc event", payload)
+	}
+	items, ok := payload["items"].([]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("items = %#v, want one item", payload["items"])
+	}
+	item, ok := items[0].(map[string]any)
+	if !ok {
+		t.Fatalf("item = %T, want object", items[0])
+	}
+	if item["id"] != "evt_1" || item["event_type"] != "completion" || item["status"] != "success" || item["upstream_status_code"] != float64(201) {
+		t.Fatalf("item identity = %#v, want request event identity", item)
+	}
+	runtime, ok := item["runtime"].(map[string]any)
+	if !ok {
+		t.Fatalf("runtime = %T, want object", item["runtime"])
+	}
+	if runtime["home_ip"] != "192.0.2.10" || runtime["cpa_node_id"] != "cpa-a" || runtime["cpa_label"] != "cpa-a:8317" {
+		t.Fatalf("runtime = %#v, want Home and CPA ownership", runtime)
+	}
+	if runtime["home_port"] != float64(8327) || runtime["home_id"] != "192.0.2.10:8327" {
+		t.Fatalf("runtime Home identity = %#v, want 192.0.2.10:8327", runtime)
+	}
+	client, ok := item["client"].(map[string]any)
+	if !ok {
+		t.Fatalf("client = %T, want object", item["client"])
+	}
+	if client["client_key_masked"] != "clie...1234" {
+		t.Fatalf("client_key_masked = %v, want clie...1234", client["client_key_masked"])
+	}
+	if _, ok := item["related"].(map[string]any); !ok {
+		t.Fatalf("related = %T, want object", item["related"])
+	}
+}
+
+func TestGetRequestEventFilterOptionsReturnsDistinctOptions(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/request-events/filter-options", handler.GetRequestEventFilterOptions)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/request-events/filter-options?event_type=completion&cpa_node=cpa-a&limit=99999&offset=20", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	var payload map[string][]string
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	for key, want := range map[string]string{
+		"event_types":  "completion",
+		"providers":    "openai",
+		"models":       "gpt-4.1-mini",
+		"home_ips":     "192.0.2.10",
+		"cpa_nodes":    "cpa-a:8317",
+		"status_codes": "201",
+	} {
+		if !stringSliceContains(payload[key], want) {
+			t.Fatalf("%s = %#v, want %q", key, payload[key], want)
+		}
+	}
+}
+
+func TestGetRequestEventReturnsDetailWithRedactedLogExcerpt(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	if errMkdir := os.MkdirAll(homeLogDirectory, 0o755); errMkdir != nil {
+		t.Fatalf("MkdirAll(logs) error = %v", errMkdir)
+	}
+	logPath := filepath.Join(homeLogDirectory, "20260610010203-req-obs-1.log")
+	logBody := "request line\nAuthorization: Bearer secret-token\nresponse line\n"
+	if errWrite := os.WriteFile(logPath, []byte(logBody), 0o644); errWrite != nil {
+		t.Fatalf("WriteFile(log) error = %v", errWrite)
+	}
+	defer func() {
+		if errRemove := os.Remove(logPath); errRemove != nil && !os.IsNotExist(errRemove) {
+			t.Errorf("remove log: %v", errRemove)
+		}
+	}()
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/request-events/:id", handler.GetRequestEvent)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/request-events/evt_1?include_payload=true&include_logs=true&include_related=true", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	if strings.Contains(resp.Body.String(), "secret-token") || strings.Contains(resp.Body.String(), "client-key-secret") {
+		t.Fatalf("detail response leaked secret: %s", resp.Body.String())
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	event, ok := payload["event"].(map[string]any)
+	if !ok {
+		t.Fatalf("event = %T, want object", payload["event"])
+	}
+	if event["id"] != "evt_1" || event["request_id"] != "req-obs-1" {
+		t.Fatalf("event identity = %#v, want evt_1 req-obs-1", event)
+	}
+	payloadSummary, ok := payload["payload_summary"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload_summary = %T, want object", payload["payload_summary"])
+	}
+	if payloadSummary["body_preview"] != nil {
+		t.Fatalf("payload_summary.body_preview = %v, want nil", payloadSummary["body_preview"])
+	}
+	excerpt, ok := payload["log_excerpt"].([]any)
+	if !ok || len(excerpt) == 0 {
+		t.Fatalf("log_excerpt = %#v, want non-empty array", payload["log_excerpt"])
+	}
+}
+
+func TestExportRequestEventsReturnsJSONLWithoutRawKey(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/request-events/export", handler.ExportRequestEvents)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/request-events/export?format=jsonl&event_type=completion&cpa_node=cpa-a&limit=99999&offset=10", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	if disposition := resp.Header().Get("Content-Disposition"); !strings.Contains(disposition, `request-events.jsonl`) {
+		t.Fatalf("Content-Disposition = %q, want request-events.jsonl", disposition)
+	}
+	body := resp.Body.String()
+	if strings.Contains(body, "client-key-secret") {
+		t.Fatalf("export leaked raw client key: %s", body)
+	}
+	var row map[string]any
+	line := strings.TrimSpace(body)
+	if errDecode := json.Unmarshal([]byte(line), &row); errDecode != nil {
+		t.Fatalf("decode jsonl row: %v body=%s", errDecode, body)
+	}
+	for _, key := range []string{"id", "event_type", "home_ip", "cpa_node_id", "client_key_masked", "usage_record_id", "request_log_available"} {
+		if _, ok := row[key]; !ok {
+			t.Fatalf("export row missing %s: %#v", key, row)
+		}
+	}
+	if row["id"] != "evt_1" || row["event_type"] != "completion" || row["cpa_node_id"] != "cpa-a" {
+		t.Fatalf("export row identity = %#v, want request event fields", row)
 	}
 }
 
@@ -1005,8 +1194,8 @@ func seedUsageObservabilityManagementRecord(t *testing.T, handler *Handler) {
 	if _, errCreatePrice := handler.repo.CreateBillingModelPrice(ctx, cluster.BillingModelPriceUpdate{Provider: "openai", Model: "gpt-4.1-mini", RequestPrice: 2, Enabled: true}); errCreatePrice != nil {
 		t.Fatalf("CreateBillingModelPrice() error = %v", errCreatePrice)
 	}
-	payload := `{"timestamp":"2026-06-10T01:02:03Z","provider":"openai","model":"gpt-4.1-mini","api_key":"client-key-secret-1234","request_id":"req-obs-1","endpoint":"/v1/chat/completions","executor_type":"CodexWebsocketsExecutor","auth_index":"auth-observability","auth_type":"oauth","latency_ms":1460,"ttft_ms":333,"tokens":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}`
-	if _, errUsage := handler.repo.AppendUsage(ctx, payload, "192.0.2.10"); errUsage != nil {
+	payload := `{"timestamp":"2026-06-10T01:02:03Z","event_type":"completion","provider":"openai","model":"gpt-4.1-mini","api_key":"client-key-secret-1234","request_id":"req-obs-1","upstream_status_code":201,"client_ip":"203.0.113.8","cpa_node_id":"cpa-a","cpa_ip":"10.0.0.5","cpa_port":8317,"cpa_label":"cpa-a:8317","method":"POST","stream":true,"messages":[{"role":"user","content":"hello"}],"tools":[{"type":"function"}],"endpoint":"/v1/chat/completions","executor_type":"CodexWebsocketsExecutor","auth_index":"auth-observability","auth_type":"oauth","latency_ms":1460,"ttft_ms":333,"tokens":{"input_tokens":100,"output_tokens":50,"total_tokens":150}}`
+	if _, errUsage := handler.repo.AppendUsageWithRuntime(ctx, payload, cluster.UsageRuntimeMetadata{HomeIP: "192.0.2.10", HomePort: 8327}); errUsage != nil {
 		t.Fatalf("AppendUsage() error = %v", errUsage)
 	}
 }

--- a/internal/cluster/runtime.go
+++ b/internal/cluster/runtime.go
@@ -22,17 +22,33 @@ type RuntimeAdapter struct {
 	index     map[string]AuthIndex
 	fullCache map[string]*coreauth.Auth
 	homeIP    string
+	homePort  int
 	mu        sync.RWMutex
 }
 
 // NewRuntimeAdapter creates a new runtime adapter.
-func NewRuntimeAdapter(repo *Repository, homeIP string) *RuntimeAdapter {
+func NewRuntimeAdapter(repo *Repository, homeIP string, homePort ...int) *RuntimeAdapter {
+	port := 0
+	if len(homePort) > 0 && homePort[0] > 0 {
+		port = homePort[0]
+	}
 	return &RuntimeAdapter{
 		repo:      repo,
 		index:     make(map[string]AuthIndex),
 		fullCache: make(map[string]*coreauth.Auth),
 		homeIP:    strings.TrimSpace(homeIP),
+		homePort:  port,
 	}
+}
+
+// SetHomePort updates the advertised Home port used for future usage records.
+func (a *RuntimeAdapter) SetHomePort(port int) {
+	if a == nil || port <= 0 {
+		return
+	}
+	a.mu.Lock()
+	a.homePort = port
+	a.mu.Unlock()
 }
 
 // Enabled handles an enabled.
@@ -95,7 +111,13 @@ func (a *RuntimeAdapter) StoreUsagePayload(ctx context.Context, payload string) 
 	if !a.Enabled() {
 		return fmt.Errorf("cluster runtime adapter is disabled")
 	}
-	_, errAppend := a.repo.AppendUsage(ctx, payload, a.homeIP)
+	a.mu.RLock()
+	metadata := UsageRuntimeMetadata{
+		HomeIP:   a.homeIP,
+		HomePort: a.homePort,
+	}
+	a.mu.RUnlock()
+	_, errAppend := a.repo.AppendUsageWithRuntime(ctx, payload, metadata)
 	return errAppend
 }
 

--- a/internal/cluster/usage.go
+++ b/internal/cluster/usage.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"gorm.io/gorm"
 )
 
@@ -40,11 +42,28 @@ type UsageRecord struct {
 	AuthType            string    `gorm:"column:auth_type;index:idx_usage_auth_type_time,priority:1"`
 	APIKey              string    `gorm:"column:api_key;index:idx_usage_api_key"`
 	RequestID           string    `gorm:"column:request_id;index:idx_usage_request_id"`
-	HomeIP              string    `gorm:"column:home_ip;index:idx_usage_home_ip;index:idx_usage_home_time,priority:1"`
+	UpstreamRequestID   string    `gorm:"column:upstream_request_id;index:idx_usage_upstream_request_id"`
+	EventType           string    `gorm:"column:event_type;index:idx_usage_event_type;index:idx_usage_event_time,priority:1"`
+	UpstreamStatusCode  int       `gorm:"column:upstream_status_code;not null;default:0;index:idx_usage_upstream_status_code"`
+	HomeIP              string    `gorm:"column:home_ip;index:idx_usage_home_ip;index:idx_usage_home_time,priority:1;index:idx_usage_home_port_time,priority:1"`
+	HomePort            int       `gorm:"column:home_port;not null;default:0;index:idx_usage_home_port_time,priority:2"`
+	CPANodeID           string    `gorm:"column:cpa_node_id;index:idx_usage_cpa_node_id;index:idx_usage_cpa_node_time,priority:1"`
+	CPAIP               string    `gorm:"column:cpa_ip;index:idx_usage_cpa_ip"`
+	CPAPort             int       `gorm:"column:cpa_port;not null;default:0"`
+	CPALabel            string    `gorm:"column:cpa_label;index:idx_usage_cpa_label"`
 	TokensJSON          JSONB     `gorm:"column:tokens"`
 	FailJSON            JSONB     `gorm:"column:fail"`
 	PayloadJSON         JSONB     `gorm:"column:payload;not null"`
 	CreatedAt           time.Time `gorm:"column:created_at;not null"`
+}
+
+type UsageRuntimeMetadata struct {
+	HomeIP    string
+	HomePort  int
+	CPANodeID string
+	CPAIP     string
+	CPAPort   int
+	CPALabel  string
 }
 
 // TableName returns the database table name.
@@ -54,6 +73,11 @@ func (UsageRecord) TableName() string {
 
 // UsageRecordFromPayload derives usage record from payload.
 func UsageRecordFromPayload(payload string, homeIP string) (*UsageRecord, error) {
+	return UsageRecordFromPayloadWithRuntime(payload, UsageRuntimeMetadata{HomeIP: homeIP})
+}
+
+// UsageRecordFromPayloadWithRuntime derives usage record from payload and trusted runtime metadata.
+func UsageRecordFromPayloadWithRuntime(payload string, metadata UsageRuntimeMetadata) (*UsageRecord, error) {
 	// Validate input data before converting it into runtime state.
 	payload = strings.TrimSpace(payload)
 	if payload == "" {
@@ -62,6 +86,11 @@ func UsageRecordFromPayload(payload string, homeIP string) (*UsageRecord, error)
 	if !json.Valid([]byte(payload)) {
 		return nil, fmt.Errorf("usage payload is invalid json")
 	}
+	enrichedPayload, errEnrich := UsagePayloadWithRuntimeMetadata(payload, metadata)
+	if errEnrich != nil {
+		return nil, errEnrich
+	}
+	payload = enrichedPayload
 
 	timestampRaw := strings.TrimSpace(gjson.Get(payload, "timestamp").String())
 	if timestampRaw == "" {
@@ -98,11 +127,22 @@ func UsageRecordFromPayload(payload string, homeIP string) (*UsageRecord, error)
 		AuthType:            strings.TrimSpace(gjson.Get(payload, "auth_type").String()),
 		APIKey:              strings.TrimSpace(gjson.Get(payload, "api_key").String()),
 		RequestID:           strings.TrimSpace(gjson.Get(payload, "request_id").String()),
-		HomeIP:              strings.TrimSpace(homeIP),
+		UpstreamRequestID:   usagePayloadString(payload, "upstream_request_id", "upstream.request_id", "response.request_id", "response.id"),
+		UpstreamStatusCode:  int(usagePayloadInt(payload, "upstream_status_code", "upstream.status_code", "response.status_code")),
+		HomeIP:              usageHomeIP(payload, metadata),
+		HomePort:            int(usagePayloadInt(payload, "home_port", "home.port")),
+		CPANodeID:           usagePayloadString(payload, "cpa_node_id", "cpa.node_id", "node_id"),
+		CPAIP:               usagePayloadString(payload, "cpa_ip", "cpa.ip"),
+		CPAPort:             int(usagePayloadInt(payload, "cpa_port", "cpa.port")),
+		CPALabel:            usagePayloadString(payload, "cpa_label", "cpa.label"),
 		TokensJSON:          jsonbFromPayloadField(payload, "tokens"),
 		FailJSON:            jsonbFromPayloadField(payload, "fail"),
 		PayloadJSON:         JSONB(payload),
 		CreatedAt:           time.Now().UTC(),
+	}
+	record.EventType = usageEventTypeFromPayload(payload, record.Endpoint)
+	if strings.TrimSpace(record.CPALabel) == "" {
+		record.CPALabel = usageCPALabel(record.CPANodeID, record.CPAIP, record.CPAPort)
 	}
 	return record, nil
 }
@@ -118,7 +158,12 @@ func usageServiceTierFromPayload(payload string) string {
 
 // AppendUsage appends an usage.
 func (r *Repository) AppendUsage(ctx context.Context, payload string, homeIP string) (*UsageRecord, error) {
-	record, errRecord := UsageRecordFromPayload(payload, homeIP)
+	return r.AppendUsageWithRuntime(ctx, payload, UsageRuntimeMetadata{HomeIP: homeIP})
+}
+
+// AppendUsageWithRuntime appends usage with trusted Home/CPA runtime metadata.
+func (r *Repository) AppendUsageWithRuntime(ctx context.Context, payload string, metadata UsageRuntimeMetadata) (*UsageRecord, error) {
+	record, errRecord := UsageRecordFromPayloadWithRuntime(payload, metadata)
 	if errRecord != nil {
 		return nil, errRecord
 	}
@@ -139,6 +184,116 @@ func (r *Repository) AppendUsage(ctx context.Context, payload string, homeIP str
 		return nil, errTransaction
 	}
 	return record, nil
+}
+
+// UsagePayloadWithRuntimeMetadata fills missing runtime ownership fields without overriding reported values.
+func UsagePayloadWithRuntimeMetadata(payload string, metadata UsageRuntimeMetadata) (string, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return "", fmt.Errorf("usage payload is empty")
+	}
+	if !json.Valid([]byte(payload)) {
+		return "", fmt.Errorf("usage payload is invalid json")
+	}
+
+	out := payload
+	var errSet error
+	if metadata.HomePort > 0 && usagePayloadInt(out, "home_port", "home.port") <= 0 {
+		out, errSet = sjson.Set(out, "home_port", metadata.HomePort)
+		if errSet != nil {
+			return "", errSet
+		}
+	}
+	if value := strings.TrimSpace(metadata.CPANodeID); value != "" && usagePayloadString(out, "cpa_node_id", "cpa.node_id", "node_id") == "" {
+		out, errSet = sjson.Set(out, "cpa_node_id", value)
+		if errSet != nil {
+			return "", errSet
+		}
+	}
+	if value := strings.TrimSpace(metadata.CPAIP); value != "" && usagePayloadString(out, "cpa_ip", "cpa.ip") == "" {
+		out, errSet = sjson.Set(out, "cpa_ip", value)
+		if errSet != nil {
+			return "", errSet
+		}
+	}
+	if metadata.CPAPort > 0 && usagePayloadInt(out, "cpa_port", "cpa.port") <= 0 {
+		out, errSet = sjson.Set(out, "cpa_port", metadata.CPAPort)
+		if errSet != nil {
+			return "", errSet
+		}
+	}
+	label := strings.TrimSpace(metadata.CPALabel)
+	if label == "" {
+		label = usageRuntimeCPALabel(metadata)
+	}
+	if label != "" && usagePayloadString(out, "cpa_label", "cpa.label") == "" {
+		out, errSet = sjson.Set(out, "cpa_label", label)
+		if errSet != nil {
+			return "", errSet
+		}
+	}
+	return out, nil
+}
+
+func usageRuntimeCPALabel(metadata UsageRuntimeMetadata) string {
+	return usageCPALabel(metadata.CPANodeID, metadata.CPAIP, metadata.CPAPort)
+}
+
+func usageCPALabel(nodeID string, ip string, port int) string {
+	if nodeID := strings.TrimSpace(nodeID); nodeID != "" {
+		return nodeID
+	}
+	ip = strings.TrimSpace(ip)
+	if ip == "" {
+		return ""
+	}
+	if port > 0 {
+		return fmt.Sprintf("%s:%d", ip, port)
+	}
+	return ip
+}
+
+func usageHomeIP(payload string, metadata UsageRuntimeMetadata) string {
+	homeIP := strings.TrimSpace(metadata.HomeIP)
+	if homeIP != "" {
+		return homeIP
+	}
+	return usagePayloadString(payload, "home_ip", "home.ip")
+}
+
+func usageEventTypeFromPayload(payload string, endpoint string) string {
+	raw := usagePayloadString(payload, "event_type", "event.type", "type")
+	if normalized := normalizeUsageObservabilityEventType(raw); normalized != "" {
+		return normalized
+	}
+	return normalizeUsageObservabilityEndpointEventType(endpoint)
+}
+
+func usagePayloadString(payload string, paths ...string) string {
+	for _, path := range paths {
+		if value := strings.TrimSpace(gjson.Get(payload, path).String()); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func usagePayloadInt(payload string, paths ...string) int64 {
+	for _, path := range paths {
+		value := gjson.Get(payload, path)
+		if !value.Exists() {
+			continue
+		}
+		if value.Type == gjson.String {
+			parsed, errParse := strconv.ParseInt(strings.TrimSpace(value.String()), 10, 64)
+			if errParse == nil {
+				return parsed
+			}
+			continue
+		}
+		return value.Int()
+	}
+	return 0
 }
 
 // jsonbFromPayloadField derives jsonb from payload field.

--- a/internal/cluster/usage_observability.go
+++ b/internal/cluster/usage_observability.go
@@ -46,6 +46,8 @@ type UsageObservabilityRecordQuery struct {
 	CredentialID     string
 	AuthIndex        string
 	ExecutorType     string
+	EventType        string
+	CPANode          string
 	MinLatencyMS     *int64
 	MaxLatencyMS     *int64
 	MinAmount        *float64
@@ -61,6 +63,15 @@ type UsageObservabilityRecordQuery struct {
 type UsageObservabilityRecordListResult struct {
 	Records []UsageObservabilityRecord
 	Total   int64
+}
+
+type UsageObservabilityFilterOptions struct {
+	EventTypes  []string
+	Providers   []string
+	Models      []string
+	HomeIPs     []string
+	CPANodes    []string
+	StatusCodes []int
 }
 
 type UsageObservabilityAggregateQuery struct {
@@ -221,29 +232,31 @@ type UsageObservabilityAggregateItem struct {
 }
 
 type UsageObservabilityRecord struct {
-	ID                string
-	UsageID           uint
-	Timestamp         time.Time
-	RequestID         string
-	UpstreamRequestID string
-	Status            string
-	Failed            bool
-	StatusCode        int
-	Source            string
-	Provider          string
-	Model             string
-	OriginalModel     string
-	Endpoint          string
-	ServiceTier       string
-	ReasoningEffort   string
-	ExecutorType      string
-	Tokens            UsageObservabilityTokens
-	Performance       UsageObservabilityPerformance
-	Client            UsageObservabilityClient
-	Credential        UsageObservabilityCredential
-	Billing           UsageObservabilityBilling
-	Runtime           UsageObservabilityRuntime
-	Error             *UsageObservabilityError
+	ID                 string
+	UsageID            uint
+	Timestamp          time.Time
+	RequestID          string
+	UpstreamRequestID  string
+	EventType          string
+	Status             string
+	Failed             bool
+	StatusCode         int
+	UpstreamStatusCode int
+	Source             string
+	Provider           string
+	Model              string
+	OriginalModel      string
+	Endpoint           string
+	ServiceTier        string
+	ReasoningEffort    string
+	ExecutorType       string
+	Tokens             UsageObservabilityTokens
+	Performance        UsageObservabilityPerformance
+	Client             UsageObservabilityClient
+	Credential         UsageObservabilityCredential
+	Billing            UsageObservabilityBilling
+	Runtime            UsageObservabilityRuntime
+	Error              *UsageObservabilityError
 }
 
 type UsageObservabilityTokens struct {
@@ -295,14 +308,21 @@ type UsageObservabilityBilling struct {
 
 type UsageObservabilityRuntime struct {
 	HomeIP              string
+	HomePort            int
+	CPANodeID           string
+	CPAIP               string
+	CPAPort             int
+	CPALabel            string
 	RequestLogAvailable bool
 	LogHomeIPRequired   bool
 }
 
 type UsageObservabilityError struct {
-	StatusCode  int
-	Message     string
-	BodyPreview string
+	StatusCode         int
+	UpstreamStatusCode int
+	Reason             string
+	Message            string
+	BodyPreview        string
 }
 
 type UsageObservabilityPayloadSummary struct {
@@ -338,7 +358,15 @@ type usageObservabilityRecordRow struct {
 	AuthType             string          `gorm:"column:auth_type"`
 	RawAPIKey            string          `gorm:"column:raw_api_key"`
 	RequestID            string          `gorm:"column:request_id"`
+	UpstreamRequestID    string          `gorm:"column:upstream_request_id"`
+	EventType            string          `gorm:"column:event_type"`
+	UpstreamStatusCode   int             `gorm:"column:upstream_status_code"`
 	HomeIP               string          `gorm:"column:home_ip"`
+	HomePort             int             `gorm:"column:home_port"`
+	CPANodeID            string          `gorm:"column:cpa_node_id"`
+	CPAIP                string          `gorm:"column:cpa_ip"`
+	CPAPort              int             `gorm:"column:cpa_port"`
+	CPALabel             string          `gorm:"column:cpa_label"`
 	PayloadJSON          JSONB           `gorm:"column:payload_json"`
 	ClientAPIKeyID       *uint           `gorm:"column:client_api_key_id"`
 	ClientAPIKeyLabel    string          `gorm:"column:client_api_key_label"`
@@ -585,6 +613,35 @@ func (r *Repository) GetUsageObservabilityRecord(ctx context.Context, id string)
 	}
 	record := usageObservabilityRecordFromRow(&rows[0])
 	return &record, nil
+}
+
+func (r *Repository) UsageObservabilityFilterOptions(ctx context.Context, query UsageObservabilityRecordQuery) (UsageObservabilityFilterOptions, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return UsageObservabilityFilterOptions{}, errDB
+	}
+	ctx = contextOrBackground(ctx)
+	options := UsageObservabilityFilterOptions{}
+	var errOptions error
+	if options.EventTypes, errOptions = usageObservabilityDistinctStrings(ctx, db, query, `"usage"."event_type"`); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	if options.Providers, errOptions = usageObservabilityDistinctStrings(ctx, db, query, `"usage"."provider"`); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	if options.Models, errOptions = usageObservabilityDistinctStrings(ctx, db, query, `"usage"."model"`); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	if options.HomeIPs, errOptions = usageObservabilityDistinctStrings(ctx, db, query, `"usage"."home_ip"`); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	if options.CPANodes, errOptions = usageObservabilityDistinctStrings(ctx, db, query, `COALESCE(NULLIF("usage"."cpa_label", ''), NULLIF("usage"."cpa_node_id", ''), NULLIF("usage"."cpa_ip", ''))`); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	if options.StatusCodes, errOptions = usageObservabilityDistinctStatusCodes(ctx, db, query); errOptions != nil {
+		return UsageObservabilityFilterOptions{}, errOptions
+	}
+	return options, nil
 }
 
 func (r *Repository) GetUsageObservabilityPayloadSummary(ctx context.Context, id string) (*UsageObservabilityPayloadSummary, error) {
@@ -1815,7 +1872,15 @@ func usageObservabilityRecordSelect() string {
 		"usage"."auth_type" AS auth_type,
 		"usage"."api_key" AS raw_api_key,
 		"usage"."request_id" AS request_id,
+		"usage"."upstream_request_id" AS upstream_request_id,
+		"usage"."event_type" AS event_type,
+		"usage"."upstream_status_code" AS upstream_status_code,
 		"usage"."home_ip" AS home_ip,
+		"usage"."home_port" AS home_port,
+		"usage"."cpa_node_id" AS cpa_node_id,
+		"usage"."cpa_ip" AS cpa_ip,
+		"usage"."cpa_port" AS cpa_port,
+		"usage"."cpa_label" AS cpa_label,
 		"usage"."payload" AS payload_json,
 		"usage"."auth_index" AS usage_auth_index,
 		COALESCE("billing_charge"."api_key_id", "api_key"."id") AS client_api_key_id,
@@ -1850,6 +1915,66 @@ func usageObservabilityRecordScope(scope *gorm.DB, query UsageObservabilityRecor
 		Joins(`LEFT JOIN "auth" AS "auth_by_index" ON "auth_uuid"."uuid" IS NULL AND "auth_by_index"."deleted_at" IS NULL AND "auth_by_index"."index" = "usage"."auth_index"`).
 		Joins(`LEFT JOIN "auth" AS "auth_by_id" ON "auth_uuid"."uuid" IS NULL AND "auth_by_index"."uuid" IS NULL AND "auth_by_id"."deleted_at" IS NULL AND "auth_by_id"."id" = "usage"."auth_index"`)
 	return usageObservabilityApplyRecordFilters(scope, query)
+}
+
+func usageObservabilityDistinctStrings(ctx context.Context, db *gorm.DB, query UsageObservabilityRecordQuery, expression string) ([]string, error) {
+	type valueRow struct {
+		Value string `gorm:"column:value"`
+	}
+	var rows []valueRow
+	scope := usageObservabilityRecordScope(db.WithContext(ctx).Table("usage"), query).
+		Where(expression + ` IS NOT NULL`).
+		Where(`TRIM(` + expression + `) <> ''`).
+		Select(`DISTINCT ` + expression + ` AS value`).
+		Order("value ASC").
+		Limit(500)
+	if errFind := scope.Scan(&rows).Error; errFind != nil {
+		return nil, errFind
+	}
+	values := make([]string, 0, len(rows))
+	seen := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		value := strings.TrimSpace(row.Value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func usageObservabilityDistinctStatusCodes(ctx context.Context, db *gorm.DB, query UsageObservabilityRecordQuery) ([]int, error) {
+	type valueRow struct {
+		Value int `gorm:"column:value"`
+	}
+	expression := `CASE WHEN "usage"."failed" THEN "usage"."fail_status_code" WHEN "usage"."upstream_status_code" > 0 THEN "usage"."upstream_status_code" ELSE 200 END`
+	var rows []valueRow
+	scope := usageObservabilityRecordScope(db.WithContext(ctx).Table("usage"), query).
+		Where(expression + ` > 0`).
+		Select(`DISTINCT ` + expression + ` AS value`).
+		Order("value ASC").
+		Limit(500)
+	if errFind := scope.Scan(&rows).Error; errFind != nil {
+		return nil, errFind
+	}
+	values := make([]int, 0, len(rows))
+	seen := make(map[int]struct{}, len(rows))
+	for _, row := range rows {
+		if row.Value <= 0 {
+			continue
+		}
+		if _, exists := seen[row.Value]; exists {
+			continue
+		}
+		seen[row.Value] = struct{}{}
+		values = append(values, row.Value)
+	}
+	return values, nil
 }
 
 func usageObservabilityUsageBillingScope(scope *gorm.DB, query UsageObservabilityRecordQuery) *gorm.DB {
@@ -1909,6 +2034,11 @@ func usageObservabilityApplyRecordFilters(scope *gorm.DB, query UsageObservabili
 	if executorType := strings.TrimSpace(query.ExecutorType); executorType != "" {
 		scope = scope.Where(`"usage"."executor_type" = ?`, executorType)
 	}
+	scope = usageObservabilityEventTypeScope(scope, query.EventType)
+	if cpaNode := strings.TrimSpace(query.CPANode); cpaNode != "" {
+		matcher := "%" + strings.ToLower(cpaNode) + "%"
+		scope = scope.Where(`LOWER("usage"."cpa_node_id") LIKE ? OR LOWER("usage"."cpa_ip") LIKE ? OR LOWER("usage"."cpa_label") LIKE ? OR CAST("usage"."cpa_port" AS TEXT) LIKE ?`, matcher, matcher, matcher, "%"+cpaNode+"%")
+	}
 	if query.MinLatencyMS != nil {
 		scope = scope.Where(`"usage"."latency_ms" >= ?`, *query.MinLatencyMS)
 	}
@@ -1930,11 +2060,14 @@ func usageObservabilityApplyRecordFilters(scope *gorm.DB, query UsageObservabili
 			"usage"."model" LIKE ? OR
 			"usage"."endpoint" LIKE ? OR
 			"usage"."home_ip" LIKE ? OR
+			"usage"."cpa_node_id" LIKE ? OR
+			"usage"."cpa_ip" LIKE ? OR
+			"usage"."cpa_label" LIKE ? OR
 			"user"."username" LIKE ? OR
 			"billing_charge"."api_key_masked" LIKE ? OR
 			COALESCE("auth_uuid"."label", "auth_by_index"."label", "auth_by_id"."label") LIKE ? OR
 			"usage"."auth_index" LIKE ?)`,
-			matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher)
+			matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher, matcher)
 	}
 	if search := strings.TrimSpace(query.RequestLogSearch); search != "" {
 		matcher := "%" + search + "%"
@@ -1977,6 +2110,11 @@ func usageObservabilityApplyUsageFilters(scope *gorm.DB, query UsageObservabilit
 	}
 	if executorType := strings.TrimSpace(query.ExecutorType); executorType != "" {
 		scope = scope.Where(`"usage"."executor_type" = ?`, executorType)
+	}
+	scope = usageObservabilityEventTypeScope(scope, query.EventType)
+	if cpaNode := strings.TrimSpace(query.CPANode); cpaNode != "" {
+		matcher := "%" + strings.ToLower(cpaNode) + "%"
+		scope = scope.Where(`LOWER("usage"."cpa_node_id") LIKE ? OR LOWER("usage"."cpa_ip") LIKE ? OR LOWER("usage"."cpa_label") LIKE ? OR CAST("usage"."cpa_port" AS TEXT) LIKE ?`, matcher, matcher, matcher, "%"+cpaNode+"%")
 	}
 	if query.MinLatencyMS != nil {
 		scope = scope.Where(`"usage"."latency_ms" >= ?`, *query.MinLatencyMS)
@@ -2050,6 +2188,99 @@ func usageObservabilityStatusCodeScope(scope *gorm.DB, statusCode *int) *gorm.DB
 	return scope.Where(`"usage"."fail_status_code" = ?`, *statusCode)
 }
 
+func usageObservabilityEventTypeScope(scope *gorm.DB, eventType string) *gorm.DB {
+	value := strings.ToLower(strings.TrimSpace(eventType))
+	if value == "all" {
+		value = ""
+	}
+	if value == "" {
+		return scope
+	}
+	normalized := normalizeUsageObservabilityEventType(value)
+	if normalized == "" {
+		normalized = value
+	}
+	return scope.Where(`LOWER("usage"."event_type") = ?`, normalized)
+}
+
+func usageObservabilityEventType(row *usageObservabilityRecordRow, payload map[string]any) string {
+	if row != nil {
+		if normalized := normalizeUsageObservabilityEventType(row.EventType); normalized != "" {
+			return normalized
+		}
+	}
+	raw := firstStringFromPayload(payload, "event_type", "event.type", "type")
+	if normalized := normalizeUsageObservabilityEventType(raw); normalized != "" {
+		return normalized
+	}
+	if row != nil {
+		return normalizeUsageObservabilityEndpointEventType(row.Endpoint)
+	}
+	return "completion"
+}
+
+func firstNonZeroInt(values ...int) int {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func normalizeUsageObservabilityEventType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "-", "_")
+	normalized = strings.ReplaceAll(normalized, ".", "_")
+	switch normalized {
+	case "":
+		return ""
+	case "embedding", "embeddings":
+		return "embedding"
+	case "response", "responses":
+		return "response"
+	case "message", "messages":
+		return "message"
+	case "stream", "streaming", "delta", "chunk":
+		return "stream"
+	case "completion", "completions", "chat_completion", "chat_completions":
+		return "completion"
+	default:
+		if strings.Contains(normalized, "embedding") {
+			return "embedding"
+		}
+		if strings.Contains(normalized, "response") {
+			return "response"
+		}
+		if strings.Contains(normalized, "message") {
+			return "message"
+		}
+		if strings.Contains(normalized, "stream") || strings.Contains(normalized, "delta") || strings.Contains(normalized, "chunk") {
+			return "stream"
+		}
+		if strings.Contains(normalized, "completion") || strings.Contains(normalized, "chat") {
+			return "completion"
+		}
+		return normalized
+	}
+}
+
+func normalizeUsageObservabilityEndpointEventType(endpoint string) string {
+	normalized := strings.ToLower(strings.TrimSpace(endpoint))
+	switch {
+	case strings.Contains(normalized, "embedding"):
+		return "embedding"
+	case strings.Contains(normalized, "response"):
+		return "response"
+	case strings.Contains(normalized, "message"):
+		return "message"
+	case strings.Contains(normalized, "completion"), strings.Contains(normalized, "chat"):
+		return "completion"
+	default:
+		return "completion"
+	}
+}
+
 func usageObservabilityRecordOrder(sortValue string) string {
 	switch strings.TrimSpace(sortValue) {
 	case "timestamp_asc":
@@ -2079,22 +2310,24 @@ func usageObservabilityRecordFromRow(row *usageObservabilityRecordRow) UsageObse
 	}
 	payload := usageObservabilityPayloadMap(row.PayloadJSON)
 	record := UsageObservabilityRecord{
-		ID:                strconv.FormatUint(uint64(row.UsageID), 10),
-		UsageID:           row.UsageID,
-		Timestamp:         row.Timestamp.UTC(),
-		RequestID:         strings.TrimSpace(row.RequestID),
-		UpstreamRequestID: firstStringFromPayload(payload, "upstream_request_id", "upstream.request_id", "response.request_id", "response.id"),
-		Status:            usageObservabilityRecordStatus(row.Failed),
-		Failed:            row.Failed,
-		StatusCode:        usageObservabilityStatusCode(row.Failed, row.FailStatusCode),
-		Source:            strings.TrimSpace(row.Source),
-		Provider:          strings.TrimSpace(row.Provider),
-		Model:             strings.TrimSpace(row.Model),
-		OriginalModel:     firstNonEmptyUsageObservabilityString(row.Alias, row.Model),
-		Endpoint:          strings.TrimSpace(row.Endpoint),
-		ServiceTier:       strings.TrimSpace(row.ServiceTier),
-		ReasoningEffort:   strings.TrimSpace(row.ReasoningEffort),
-		ExecutorType:      strings.TrimSpace(row.ExecutorType),
+		ID:                 strconv.FormatUint(uint64(row.UsageID), 10),
+		UsageID:            row.UsageID,
+		Timestamp:          row.Timestamp.UTC(),
+		RequestID:          strings.TrimSpace(row.RequestID),
+		UpstreamRequestID:  firstNonEmptyUsageObservabilityString(row.UpstreamRequestID, firstStringFromPayload(payload, "upstream_request_id", "upstream.request_id", "response.request_id", "response.id")),
+		EventType:          usageObservabilityEventType(row, payload),
+		Status:             usageObservabilityRecordStatus(row.Failed),
+		Failed:             row.Failed,
+		StatusCode:         usageObservabilityStatusCode(row.Failed, row.FailStatusCode),
+		UpstreamStatusCode: firstNonZeroInt(row.UpstreamStatusCode, int(firstIntFromPayload(payload, "upstream_status_code", "upstream.status_code", "response.status_code"))),
+		Source:             strings.TrimSpace(row.Source),
+		Provider:           strings.TrimSpace(row.Provider),
+		Model:              strings.TrimSpace(row.Model),
+		OriginalModel:      firstNonEmptyUsageObservabilityString(row.Alias, row.Model),
+		Endpoint:           strings.TrimSpace(row.Endpoint),
+		ServiceTier:        strings.TrimSpace(row.ServiceTier),
+		ReasoningEffort:    strings.TrimSpace(row.ReasoningEffort),
+		ExecutorType:       strings.TrimSpace(row.ExecutorType),
 		Tokens: UsageObservabilityTokens{
 			InputTokens:         row.InputTokens,
 			OutputTokens:        row.OutputTokens,
@@ -2110,15 +2343,22 @@ func usageObservabilityRecordFromRow(row *usageObservabilityRecordRow) UsageObse
 		Billing:     usageObservabilityBilling(row),
 		Runtime: UsageObservabilityRuntime{
 			HomeIP:              strings.TrimSpace(row.HomeIP),
+			HomePort:            row.HomePort,
+			CPANodeID:           firstNonEmptyUsageObservabilityString(row.CPANodeID, firstStringFromPayload(payload, "cpa_node_id", "cpa.node_id", "node_id")),
+			CPAIP:               firstNonEmptyUsageObservabilityString(row.CPAIP, firstStringFromPayload(payload, "cpa_ip", "cpa.ip")),
+			CPAPort:             firstNonZeroInt(row.CPAPort, int(firstIntFromPayload(payload, "cpa_port", "cpa.port"))),
+			CPALabel:            firstNonEmptyUsageObservabilityString(row.CPALabel, firstStringFromPayload(payload, "cpa_label", "cpa.label")),
 			RequestLogAvailable: strings.TrimSpace(row.RequestID) != "",
 			LogHomeIPRequired:   true,
 		},
 	}
 	if row.Failed {
 		record.Error = &UsageObservabilityError{
-			StatusCode:  row.FailStatusCode,
-			Message:     usageObservabilityErrorMessage(row.FailBody),
-			BodyPreview: usageObservabilityBodyPreview(row.FailBody),
+			StatusCode:         row.FailStatusCode,
+			UpstreamStatusCode: record.UpstreamStatusCode,
+			Reason:             firstStringFromPayload(payload, "fail.reason", "error.reason", "error.type", "error.code"),
+			Message:            usageObservabilityErrorMessage(row.FailBody),
+			BodyPreview:        usageObservabilityBodyPreview(row.FailBody),
 		}
 	}
 	return record
@@ -3143,6 +3383,31 @@ func firstStringFromPayload(payload map[string]any, paths ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstIntFromPayload(payload map[string]any, paths ...string) int64 {
+	for _, path := range paths {
+		value := payloadPathValue(payload, path)
+		switch typed := value.(type) {
+		case float64:
+			return int64(typed)
+		case int64:
+			return typed
+		case int:
+			return int64(typed)
+		case json.Number:
+			parsed, errParse := typed.Int64()
+			if errParse == nil {
+				return parsed
+			}
+		case string:
+			parsed, errParse := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+			if errParse == nil {
+				return parsed
+			}
+		}
+	}
+	return 0
 }
 
 func firstBoolFromPayload(payload map[string]any, paths ...string) (bool, bool) {

--- a/internal/cluster/usage_observability_test.go
+++ b/internal/cluster/usage_observability_test.go
@@ -83,6 +83,51 @@ func TestMigrateAuthNextRetryAfterBackfillsJSON(t *testing.T) {
 	}
 }
 
+func TestMigrateUsageDerivedColumnsBackfillsStructuredMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	db, errDB := repo.database()
+	if errDB != nil {
+		t.Fatalf("database() error = %v", errDB)
+	}
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","event_type":"stream","request_id":"req-derived","upstream_request_id":"upstream-derived","upstream_status_code":202,"home_port":8328,"cpa_node_id":"node-derived","cpa_ip":"10.0.0.5","cpa_port":8317,"provider":"openai","model":"gpt-4.1-mini","endpoint":"/v1/chat/completions"}`
+	record := UsageRecord{
+		Timestamp:   time.Date(2026, time.July, 9, 1, 2, 3, 0, time.UTC),
+		RequestID:   "req-derived",
+		HomeIP:      "192.0.2.10",
+		PayloadJSON: JSONB(payload),
+		CreatedAt:   time.Now().UTC(),
+	}
+	if errCreate := db.Create(&record).Error; errCreate != nil {
+		t.Fatalf("Create(usage) error = %v", errCreate)
+	}
+
+	if errMigrate := migrateUsageDerivedColumns(db); errMigrate != nil {
+		t.Fatalf("migrateUsageDerivedColumns() error = %v", errMigrate)
+	}
+
+	var updated UsageRecord
+	if errFirst := db.First(&updated, "id = ?", record.ID).Error; errFirst != nil {
+		t.Fatalf("First(usage) error = %v", errFirst)
+	}
+	if updated.EventType != "stream" {
+		t.Fatalf("event_type = %q, want stream", updated.EventType)
+	}
+	if updated.UpstreamRequestID != "upstream-derived" || updated.UpstreamStatusCode != 202 {
+		t.Fatalf("upstream = %q/%d, want upstream-derived/202", updated.UpstreamRequestID, updated.UpstreamStatusCode)
+	}
+	if updated.HomePort != 8328 {
+		t.Fatalf("home_port = %d, want 8328", updated.HomePort)
+	}
+	if updated.CPANodeID != "node-derived" || updated.CPAIP != "10.0.0.5" || updated.CPAPort != 8317 || updated.CPALabel != "node-derived" {
+		t.Fatalf("CPA ownership = node:%q ip:%q port:%d label:%q, want node-derived 10.0.0.5 8317 node-derived", updated.CPANodeID, updated.CPAIP, updated.CPAPort, updated.CPALabel)
+	}
+}
+
 func TestUsageObservabilityOverviewTopCredentialUsesModelStateNextRetry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cluster/usage_test.go
+++ b/internal/cluster/usage_test.go
@@ -23,3 +23,57 @@ func TestUsageRecordFromPayloadStoresRequestIDAndHomeIP(t *testing.T) {
 		t.Fatalf("total tokens = %d, want 15", record.TotalTokens)
 	}
 }
+
+func TestUsageRecordFromPayloadWithRuntimeStoresOwnershipColumns(t *testing.T) {
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","request_id":"req-runtime-1","endpoint":"/v1/responses","upstream_status_code":"202","tokens":{"total_tokens":3}}`
+
+	record, errRecord := UsageRecordFromPayloadWithRuntime(payload, UsageRuntimeMetadata{
+		HomeIP:    "192.0.2.10",
+		HomePort:  8327,
+		CPANodeID: "node-1",
+		CPAIP:     "10.0.0.5",
+		CPAPort:   8317,
+	})
+	if errRecord != nil {
+		t.Fatalf("UsageRecordFromPayloadWithRuntime: %v", errRecord)
+	}
+
+	if record.HomeIP != "192.0.2.10" || record.HomePort != 8327 {
+		t.Fatalf("home ownership = %s:%d, want 192.0.2.10:8327", record.HomeIP, record.HomePort)
+	}
+	if record.CPANodeID != "node-1" || record.CPAIP != "10.0.0.5" || record.CPAPort != 8317 || record.CPALabel != "node-1" {
+		t.Fatalf("CPA ownership = node=%q ip=%q port=%d label=%q, want node-1 10.0.0.5 8317 node-1", record.CPANodeID, record.CPAIP, record.CPAPort, record.CPALabel)
+	}
+	if record.EventType != "response" {
+		t.Fatalf("event type = %q, want response", record.EventType)
+	}
+	if record.UpstreamStatusCode != 202 {
+		t.Fatalf("upstream status code = %d, want 202", record.UpstreamStatusCode)
+	}
+}
+
+func TestUsageRecordFromPayloadDoesNotTreatClientIPAsCPAIP(t *testing.T) {
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","request_id":"req-client-ip","client_ip":"203.0.113.8","endpoint":"/v1/chat/completions"}`
+
+	record, errRecord := UsageRecordFromPayloadWithRuntime(payload, UsageRuntimeMetadata{HomeIP: "192.0.2.10"})
+	if errRecord != nil {
+		t.Fatalf("UsageRecordFromPayloadWithRuntime: %v", errRecord)
+	}
+
+	if record.CPAIP != "" {
+		t.Fatalf("CPA IP = %q, want empty when only client_ip exists", record.CPAIP)
+	}
+}
+
+func TestUsageRecordFromPayloadDerivesCPALabelFromPayloadOwnership(t *testing.T) {
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","request_id":"req-cpa-label","cpa_node_id":"node-from-payload","cpa_ip":"10.0.0.5","cpa_port":8317}`
+
+	record, errRecord := UsageRecordFromPayloadWithRuntime(payload, UsageRuntimeMetadata{HomeIP: "192.0.2.10"})
+	if errRecord != nil {
+		t.Fatalf("UsageRecordFromPayloadWithRuntime: %v", errRecord)
+	}
+
+	if record.CPALabel != "node-from-payload" {
+		t.Fatalf("CPA label = %q, want node-from-payload", record.CPALabel)
+	}
+}

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -73,6 +73,11 @@ func (r *RouteRegistry) Register(group *gin.RouterGroup) {
 		keys = append(keys, k)
 	}
 	sort.Slice(keys, func(i, j int) bool {
+		iWildcard := routePathHasWildcard(keys[i].Path)
+		jWildcard := routePathHasWildcard(keys[j].Path)
+		if iWildcard != jWildcard {
+			return !iWildcard
+		}
 		if keys[i].Path == keys[j].Path {
 			return keys[i].Method < keys[j].Method
 		}
@@ -85,6 +90,15 @@ func (r *RouteRegistry) Register(group *gin.RouterGroup) {
 		}
 		group.Handle(k.Method, k.Path, h)
 	}
+}
+
+func routePathHasWildcard(path string) bool {
+	for _, segment := range strings.Split(path, "/") {
+		if strings.HasPrefix(segment, ":") || strings.HasPrefix(segment, "*") {
+			return true
+		}
+	}
+	return false
 }
 
 type RouteOption func(*RouteRegistry)
@@ -190,6 +204,10 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodGet, "/usage/realtime", handler.GetUsageRealtime)
 	r.Set(http.MethodGet, "/usage/health/providers", handler.GetUsageProviderHealth)
 	r.Set(http.MethodGet, "/usage/health/credentials", handler.GetUsageCredentialHealth)
+	r.Set(http.MethodGet, "/request-events", handler.ListRequestEvents)
+	r.Set(http.MethodGet, "/request-events/export", handler.ExportRequestEvents)
+	r.Set(http.MethodGet, "/request-events/filter-options", handler.GetRequestEventFilterOptions)
+	r.Set(http.MethodGet, "/request-events/:id", handler.GetRequestEvent)
 	r.Set(http.MethodGet, "/request-logs", handler.ListRequestLogs)
 	r.Set(http.MethodGet, "/billing/overview", handler.GetBillingOverview)
 	r.Set(http.MethodGet, "/billing/charges", handler.ListBillingCharges)

--- a/internal/managementhttp/server_test.go
+++ b/internal/managementhttp/server_test.go
@@ -128,10 +128,56 @@ func TestClusterManagementUsageObservabilityRoutesRegistered(t *testing.T) {
 		{Method: http.MethodGet, Path: "/usage/realtime"},
 		{Method: http.MethodGet, Path: "/usage/health/providers"},
 		{Method: http.MethodGet, Path: "/usage/health/credentials"},
+		{Method: http.MethodGet, Path: "/request-events"},
+		{Method: http.MethodGet, Path: "/request-events/export"},
+		{Method: http.MethodGet, Path: "/request-events/filter-options"},
+		{Method: http.MethodGet, Path: "/request-events/:id"},
 		{Method: http.MethodGet, Path: "/request-logs"},
 	} {
 		if reg.routes[route] == nil {
 			t.Fatalf("route %s %s was not registered", route.Method, route.Path)
+		}
+	}
+}
+
+func TestRouteRegistryRegistersStaticRoutesBeforeWildcards(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	group := engine.Group("")
+	reg := newRouteRegistry()
+	reg.Set(http.MethodGet, "/request-events/:id", func(c *gin.Context) {
+		c.String(http.StatusOK, "id:"+c.Param("id"))
+	})
+	reg.Set(http.MethodGet, "/request-events/export", func(c *gin.Context) {
+		c.String(http.StatusOK, "export")
+	})
+	reg.Set(http.MethodGet, "/request-events/filter-options", func(c *gin.Context) {
+		c.String(http.StatusOK, "filter-options")
+	})
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("Register() panic = %v", recovered)
+		}
+	}()
+	reg.Register(group)
+
+	for _, tc := range []struct {
+		path string
+		want string
+	}{
+		{path: "/request-events/export", want: "export"},
+		{path: "/request-events/filter-options", want: "filter-options"},
+		{path: "/request-events/evt_1", want: "id:evt_1"},
+	} {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+		engine.ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d", tc.path, resp.Code, http.StatusOK)
+		}
+		if got := resp.Body.String(); got != tc.want {
+			t.Fatalf("%s body = %q, want %q", tc.path, got, tc.want)
 		}
 	}
 }

--- a/internal/respserver/push/usage.go
+++ b/internal/respserver/push/usage.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/respserver/dispatch"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -29,6 +30,11 @@ func handleUsage(ctx context.Context, env dispatch.Env, args []string) dispatch.
 	if payload == "" || !gjson.Valid(payload) {
 		return dispatch.Err("invalid usage json")
 	}
+	enrichedPayload, errEnrich := usagePayloadWithCPAIdentity(payload, env)
+	if errEnrich != nil {
+		return dispatch.Err("invalid usage json")
+	}
+	payload = enrichedPayload
 
 	// Always update scheduler state before queuing persistence so cooldowns are applied even if log persistence fails.
 	if env.Runtime != nil {
@@ -52,6 +58,13 @@ func handleUsage(ctx context.Context, env dispatch.Env, args []string) dispatch.
 	// This server doesn't maintain a real list, so always return 1 as a stable
 	// integer reply and avoid client retries.
 	return dispatch.Integer(1)
+}
+
+func usagePayloadWithCPAIdentity(payload string, env dispatch.Env) (string, error) {
+	return cluster.UsagePayloadWithRuntimeMetadata(payload, cluster.UsageRuntimeMetadata{
+		CPANodeID: strings.TrimSpace(env.NodeID),
+		CPAIP:     strings.TrimSpace(env.ClientIP),
+	})
 }
 
 // appendUsageLog appends an usage log.

--- a/internal/respserver/push/usage_test.go
+++ b/internal/respserver/push/usage_test.go
@@ -1,0 +1,42 @@
+package push
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/respserver/dispatch"
+	"github.com/tidwall/gjson"
+)
+
+func TestUsagePayloadWithCPAIdentityFillsMissingRuntimeFields(t *testing.T) {
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","provider":"openai","model":"gpt-4.1-mini","request_id":"req-1"}`
+	enriched, errEnrich := usagePayloadWithCPAIdentity(payload, dispatch.Env{NodeID: "node-1", ClientIP: "10.0.0.5"})
+	if errEnrich != nil {
+		t.Fatalf("usagePayloadWithCPAIdentity() error = %v", errEnrich)
+	}
+	if got := gjson.Get(enriched, "cpa_node_id").String(); got != "node-1" {
+		t.Fatalf("cpa_node_id = %q, want node-1", got)
+	}
+	if got := gjson.Get(enriched, "cpa_ip").String(); got != "10.0.0.5" {
+		t.Fatalf("cpa_ip = %q, want 10.0.0.5", got)
+	}
+	if got := gjson.Get(enriched, "cpa_label").String(); got != "node-1" {
+		t.Fatalf("cpa_label = %q, want node-1", got)
+	}
+}
+
+func TestUsagePayloadWithCPAIdentityPreservesReportedRuntimeFields(t *testing.T) {
+	payload := `{"timestamp":"2026-07-09T01:02:03Z","provider":"openai","model":"gpt-4.1-mini","request_id":"req-1","cpa_node_id":"reported-node","cpa_ip":"192.0.2.10","cpa_label":"reported-label"}`
+	enriched, errEnrich := usagePayloadWithCPAIdentity(payload, dispatch.Env{NodeID: "node-1", ClientIP: "10.0.0.5"})
+	if errEnrich != nil {
+		t.Fatalf("usagePayloadWithCPAIdentity() error = %v", errEnrich)
+	}
+	if got := gjson.Get(enriched, "cpa_node_id").String(); got != "reported-node" {
+		t.Fatalf("cpa_node_id = %q, want reported-node", got)
+	}
+	if got := gjson.Get(enriched, "cpa_ip").String(); got != "192.0.2.10" {
+		t.Fatalf("cpa_ip = %q, want 192.0.2.10", got)
+	}
+	if got := gjson.Get(enriched, "cpa_label").String(); got != "reported-label" {
+		t.Fatalf("cpa_label = %q, want reported-label", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add DB-backed request event Management API endpoints:
  - `GET /request-events`
  - `GET /request-events/:id`
  - `GET /request-events/export`
  - `GET /request-events/filter-options`
- Persist structured usage metadata for request events, including event type, upstream request/status, Home port, and CPA node ownership.
- Enrich RESP usage payloads with trusted CPA identity from the Home runtime so the UI can show which CPA handled each request.
- Add structured filtering for `event_type` and `cpa_node` without relying on payload text matching.
- Update Management API docs in English and Chinese.

## Details

- Adds request event list/detail/export responses for frontend observability views.
- Adds filter options for event type, provider, model, Home IP, CPA node, and status code.
- Adds usage derived columns and migration/backfill logic.
- Preserves the security boundary by keeping request payload body preview as `null`.
- Fixes route registration ordering so static routes like `/request-events/export` are not shadowed by `/:id`.

## Verification

- `go test ./internal/cluster ./internal/cluster/management ./internal/managementhttp ./internal/respserver/push`
- `go build -o test-output ./cmd/home`
- `git diff --check`
- `go test ./...`