### PR TITLE
feat(user-billing): support precise time ranges

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1348,7 +1348,7 @@ Example response:
 
 All paths in this section are relative to the Management API base URL, for example `/v0/management/billing/overview` or `/v0/management/proxy/proxy-pools`. They are not `/user` routes and require the management key.
 
-Only `/billing/overview`, `/billing/charges`, and `/billing/balance-records` parse `from` and `to` as `YYYY-MM-DD`, RFC3339, or Unix seconds. A date-only `to` value includes the whole ending UTC day. Pagination with `limit` and `offset` applies only to `/billing/charges` and `/billing/balance-records`; those routes use `limit` default `50`, max `200`, and normalize negative `offset` values to `0`. `/billing/model-prices` supports only `provider`, `model`, and `enabled` query parameters. `/proxy/proxy-pools` currently does not parse query parameters.
+Only `/billing/overview`, `/billing/charges`, and `/billing/balance-records` parse `from` and `to` as `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values use UTC calendar dates, and a date-only `to` includes the whole ending UTC day. Explicit timestamp `to` values are inclusive exact instants and are not expanded. Clients that need a full natural day outside UTC should send RFC3339 boundaries with the intended timezone offset through the final nanosecond. Pagination with `limit` and `offset` applies only to `/billing/charges` and `/billing/balance-records`; those routes use `limit` default `50`, max `200`, and normalize negative `offset` values to `0`. `/billing/model-prices` supports only `provider`, `model`, and `enabled` query parameters. `/proxy/proxy-pools` currently does not parse query parameters.
 
 ### GET `/billing/overview`
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1348,7 +1348,7 @@ Query 参数：
 
 本节所有路径都相对于 Management API 基础 URL，例如 `/v0/management/billing/overview` 或 `/v0/management/proxy/proxy-pools`。这些不是 `/user` 路由，调用时需要管理密钥。
 
-只有 `/billing/overview`、`/billing/charges` 和 `/billing/balance-records` 会将 `from` 和 `to` 解析为 `YYYY-MM-DD`、RFC3339 或 Unix 秒。只有日期的 `to` 会包含结束 UTC 日期的完整一天。分页参数 `limit` 和 `offset` 仅适用于 `/billing/charges` 和 `/billing/balance-records`；这些路由的 `limit` 默认值为 `50`，最大值为 `200`，负数 `offset` 会规范化为 `0`。`/billing/model-prices` 仅支持 `provider`、`model` 和 `enabled` 查询参数。`/proxy/proxy-pools` 当前不解析查询参数。
+只有 `/billing/overview`、`/billing/charges` 和 `/billing/balance-records` 会将 `from` 和 `to` 解析为 `YYYY-MM-DD`、RFC3339 或 Unix 秒。纯日期值使用 UTC 日历日期，只有日期的 `to` 会包含结束 UTC 日期的完整一天。显式时间戳形式的 `to` 是包含在结果内的精确时刻，不会自动扩展。需要查询完整非 UTC 自然日的客户端应发送带目标时区偏移且覆盖到最后一纳秒的 RFC3339 边界。分页参数 `limit` 和 `offset` 仅适用于 `/billing/charges` 和 `/billing/balance-records`；这些路由的 `limit` 默认值为 `50`，最大值为 `200`，负数 `offset` 会规范化为 `0`。`/billing/model-prices` 仅支持 `provider`、`model` 和 `enabled` 查询参数。`/proxy/proxy-pools` 当前不解析查询参数。
 
 ### GET `/billing/overview`
 

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -457,7 +457,7 @@ User billing routes are under the `/user` base path, so the full paths are `/use
 
 User billing responses do not include admin notes, global totals, model price management data, proxy-pool data, raw API keys, masked API keys, price snapshots, matched price rules, endpoint, `balance_before`, or other users' data.
 
-User billing `from` and `to` query parameters only accept `YYYY-MM-DD`. A date-only `to` includes the whole ending UTC day.
+User billing `from` and `to` query parameters accept `YYYY-MM-DD`, RFC3339, or Unix seconds. Unix-second values must be between `2000-01-01T00:00:00Z` and `9999-12-31T23:59:59Z`; millisecond timestamps are rejected. A date-only `to` includes the whole ending UTC day. Explicit timestamp `to` values are inclusive exact instants and are not expanded. Clients that need a full natural day outside UTC should send RFC3339 boundaries with the intended timezone offset through the final nanosecond, for example `23:59:59.999999999+08:00`.
 
 ### GET `/billing/overview`
 
@@ -473,8 +473,8 @@ Query parameters:
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `from` | string | Optional start date in `YYYY-MM-DD` format. |
-| `to` | string | Optional end date in `YYYY-MM-DD` format. Includes the full UTC day. |
+| `from` | string | Optional start time: `YYYY-MM-DD`, RFC3339, or Unix seconds. |
+| `to` | string | Optional inclusive end time. Date-only values include the full UTC day; explicit timestamps are preserved exactly. |
 
 Example response:
 
@@ -519,8 +519,8 @@ Query parameters:
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `from` | string | Optional start date in `YYYY-MM-DD` format. |
-| `to` | string | Optional end date in `YYYY-MM-DD` format. Includes the full UTC day. |
+| `from` | string | Optional start time: `YYYY-MM-DD`, RFC3339, or Unix seconds. |
+| `to` | string | Optional inclusive end time. Date-only values include the full UTC day; explicit timestamps are preserved exactly. |
 | `limit` | integer | Optional page size. Default `50`, max `200`. Invalid non-positive or non-integer values return `400`. |
 | `offset` | integer | Optional page offset. Default `0`. Negative or non-integer values return `400`. |
 
@@ -566,8 +566,9 @@ Common errors:
 ```json
 { "error": "bearer_token_required", "message": "bearer token is required" }
 { "error": "invalid_token", "message": "invalid token" }
-{ "error": "invalid_from", "message": "from must be YYYY-MM-DD" }
-{ "error": "invalid_to", "message": "to must be YYYY-MM-DD" }
+{ "error": "invalid_from", "message": "from must be YYYY-MM-DD, RFC3339, or unix seconds" }
+{ "error": "invalid_to", "message": "to must be YYYY-MM-DD, RFC3339, or unix seconds" }
+{ "error": "invalid_time_range", "message": "from must not be after to" }
 { "error": "invalid_limit", "message": "limit must be a positive integer" }
 { "error": "invalid_offset", "message": "offset must be a non-negative integer" }
 ```

--- a/docs/user/api_CN.md
+++ b/docs/user/api_CN.md
@@ -457,7 +457,7 @@ Authorization: Bearer user.jwt.token
 
 用户计费响应不包含管理员备注、全局汇总、模型价格管理数据、代理池数据、原始 API keys、脱敏 API keys、价格快照、匹配的价格规则、endpoint、`balance_before` 或其他用户的数据。
 
-用户计费的 `from` 和 `to` 查询参数只接受 `YYYY-MM-DD`。只有日期的 `to` 会包含结束 UTC 日期的完整一天。
+用户计费的 `from` 和 `to` 查询参数接受 `YYYY-MM-DD`、RFC3339 或 Unix 秒。Unix 秒值必须位于 `2000-01-01T00:00:00Z` 到 `9999-12-31T23:59:59Z` 之间；毫秒时间戳会被拒绝。只有日期的 `to` 会包含结束 UTC 日期的完整一天。显式时间戳形式的 `to` 是包含在结果内的精确时刻，不会自动扩展。需要查询完整非 UTC 自然日的客户端应发送带目标时区偏移且覆盖到最后一纳秒的 RFC3339 边界，例如 `23:59:59.999999999+08:00`。
 
 ### GET `/billing/overview`
 
@@ -473,8 +473,8 @@ Authorization: Bearer user.jwt.token
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
-| `from` | string | 可选开始日期，格式为 `YYYY-MM-DD`。 |
-| `to` | string | 可选结束日期，格式为 `YYYY-MM-DD`；包含完整 UTC 当天。 |
+| `from` | string | 可选开始时间：`YYYY-MM-DD`、RFC3339 或 Unix 秒。 |
+| `to` | string | 可选结束时间，包含该时刻；纯日期包含完整 UTC 当天，显式时间戳精确保留。 |
 
 响应示例：
 
@@ -519,8 +519,8 @@ Authorization: Bearer user.jwt.token
 
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
-| `from` | string | 可选开始日期，格式为 `YYYY-MM-DD`。 |
-| `to` | string | 可选结束日期，格式为 `YYYY-MM-DD`；包含完整 UTC 当天。 |
+| `from` | string | 可选开始时间：`YYYY-MM-DD`、RFC3339 或 Unix 秒。 |
+| `to` | string | 可选结束时间，包含该时刻；纯日期包含完整 UTC 当天，显式时间戳精确保留。 |
 | `limit` | integer | 可选分页大小；默认 `50`，最大 `200`。非法的非正数或非整数会返回 `400`。 |
 | `offset` | integer | 可选分页偏移；默认 `0`。负数或非整数会返回 `400`。 |
 
@@ -566,8 +566,9 @@ Authorization: Bearer user.jwt.token
 ```json
 { "error": "bearer_token_required", "message": "bearer token is required" }
 { "error": "invalid_token", "message": "invalid token" }
-{ "error": "invalid_from", "message": "from must be YYYY-MM-DD" }
-{ "error": "invalid_to", "message": "to must be YYYY-MM-DD" }
+{ "error": "invalid_from", "message": "from must be YYYY-MM-DD, RFC3339, or unix seconds" }
+{ "error": "invalid_to", "message": "to must be YYYY-MM-DD, RFC3339, or unix seconds" }
+{ "error": "invalid_time_range", "message": "from must not be after to" }
 { "error": "invalid_limit", "message": "limit must be a positive integer" }
 { "error": "invalid_offset", "message": "offset must be a non-negative integer" }
 ```

--- a/internal/userapi/billing.go
+++ b/internal/userapi/billing.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	userBillingDefaultLimit = 50
-	userBillingMaxLimit     = 200
+	userBillingDefaultLimit         = 50
+	userBillingMaxLimit             = 200
+	userBillingMinUnixSeconds int64 = 946684800    // 2000-01-01T00:00:00Z
+	userBillingMaxUnixSeconds int64 = 253402300799 // 9999-12-31T23:59:59Z
 )
 
 // CurrentUserBillingOverview returns the billing overview for the authenticated user.
@@ -138,6 +140,10 @@ func userBillingDateRangeFromRequest(c *gin.Context) (*time.Time, *time.Time, bo
 	if !ok {
 		return nil, nil, false
 	}
+	if from != nil && to != nil && from.After(*to) {
+		respondError(c, http.StatusBadRequest, "invalid_time_range", fmt.Errorf("from must not be after to"))
+		return nil, nil, false
+	}
 	return from, to, true
 }
 
@@ -146,16 +152,31 @@ func userBillingDateQuery(c *gin.Context, key string, endOfDay bool) (*time.Time
 	if raw == "" {
 		return nil, true
 	}
-	parsed, errParse := time.ParseInLocation("2006-01-02", raw, time.UTC)
+	parsed, dateOnly, errParse := parseUserBillingTime(raw)
 	if errParse != nil {
-		respondError(c, http.StatusBadRequest, "invalid_"+key, fmt.Errorf("%s must be YYYY-MM-DD", key))
+		respondError(c, http.StatusBadRequest, "invalid_"+key, fmt.Errorf("%s must be YYYY-MM-DD, RFC3339, or unix seconds", key))
 		return nil, false
 	}
 	parsed = parsed.UTC()
-	if endOfDay {
+	if endOfDay && dateOnly {
 		parsed = time.Date(parsed.Year(), parsed.Month(), parsed.Day(), 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
 	}
 	return &parsed, true
+}
+
+func parseUserBillingTime(raw string) (time.Time, bool, error) {
+	if parsed, errDate := time.ParseInLocation(time.DateOnly, raw, time.UTC); errDate == nil {
+		return parsed, true, nil
+	}
+	if parsed, errRFC3339 := time.Parse(time.RFC3339Nano, raw); errRFC3339 == nil {
+		return parsed, false, nil
+	}
+	if unixSeconds, errUnix := strconv.ParseInt(raw, 10, 64); errUnix == nil {
+		if unixSeconds >= userBillingMinUnixSeconds && unixSeconds <= userBillingMaxUnixSeconds {
+			return time.Unix(unixSeconds, 0).UTC(), false, nil
+		}
+	}
+	return time.Time{}, false, fmt.Errorf("time must be YYYY-MM-DD, RFC3339, or unix seconds")
 }
 
 func userBillingPaginationFromRequest(c *gin.Context) (int, int, bool) {

--- a/internal/userapi/billing_test.go
+++ b/internal/userapi/billing_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"testing"
 	"time"
@@ -46,6 +47,53 @@ func TestUserBillingChargesUseAuthenticatedUserOnly(t *testing.T) {
 	}
 	secondPayload := decodeUserBillingChargeList(t, secondResp)
 	assertUserBillingChargeRequests(t, secondPayload.Items, []string{"req-second"}, []string{"req-first"})
+}
+
+func TestUserBillingChargesAcceptRFC3339TimezoneRange(t *testing.T) {
+	t.Parallel()
+
+	handler, closeRepo := newUserBillingTestHandler(t)
+	defer closeRepo()
+
+	firstUser, _ := seedUserBillingCharges(t, handler)
+	token := createUserBillingBearerToken(t, handler, firstUser.ID)
+
+	tests := []struct {
+		name        string
+		from        string
+		to          string
+		wantRequest []string
+	}{
+		{
+			name:        "Shanghai June 10 includes the charge",
+			from:        "2026-06-10T00:00:00+08:00",
+			to:          "2026-06-10T23:59:59.999999999+08:00",
+			wantRequest: []string{"req-first"},
+		},
+		{
+			name: "Shanghai June 9 excludes the charge",
+			from: "2026-06-09T00:00:00+08:00",
+			to:   "2026-06-09T23:59:59.999999999+08:00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := url.Values{"from": {tt.from}, "to": {tt.to}}
+			resp := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(resp)
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/billing/charges?"+query.Encode(), nil)
+			ctx.Request.Header.Set("Authorization", "Bearer "+token)
+
+			handler.ListCurrentUserBillingCharges(ctx)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+			}
+			payload := decodeUserBillingChargeList(t, resp)
+			assertUserBillingChargeRequests(t, payload.Items, tt.wantRequest, nil)
+		})
+	}
 }
 
 func TestUserBillingOverviewUsesAuthenticatedUserOnly(t *testing.T) {
@@ -118,15 +166,77 @@ func TestUserBillingChargesValidateQuery(t *testing.T) {
 	token := createUserBillingBearerToken(t, handler, user.ID)
 
 	tests := []struct {
-		name string
-		path string
+		name        string
+		path        string
+		wantError   string
+		wantMessage string
 	}{
-		{name: "invalid limit", path: "/billing/charges?limit=0"},
-		{name: "non integer limit", path: "/billing/charges?limit=abc"},
-		{name: "invalid offset", path: "/billing/charges?offset=-1"},
-		{name: "non integer offset", path: "/billing/charges?offset=abc"},
-		{name: "invalid from", path: "/billing/charges?from=2026-06-10T00:00:00Z"},
-		{name: "invalid to", path: "/billing/charges?to=2026-06-10T00:00:00Z"},
+		{
+			name:        "invalid limit",
+			path:        "/billing/charges?limit=0",
+			wantError:   "invalid_limit",
+			wantMessage: "limit must be a positive integer",
+		},
+		{
+			name:        "non integer limit",
+			path:        "/billing/charges?limit=abc",
+			wantError:   "invalid_limit",
+			wantMessage: "limit must be a positive integer",
+		},
+		{
+			name:        "invalid offset",
+			path:        "/billing/charges?offset=-1",
+			wantError:   "invalid_offset",
+			wantMessage: "offset must be a non-negative integer",
+		},
+		{
+			name:        "non integer offset",
+			path:        "/billing/charges?offset=abc",
+			wantError:   "invalid_offset",
+			wantMessage: "offset must be a non-negative integer",
+		},
+		{
+			name:        "invalid from",
+			path:        "/billing/charges?from=not-a-time",
+			wantError:   "invalid_from",
+			wantMessage: "from must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "invalid to",
+			path:        "/billing/charges?to=not-a-time",
+			wantError:   "invalid_to",
+			wantMessage: "to must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "unix milliseconds",
+			path:        "/billing/charges?from=1783612800000",
+			wantError:   "invalid_from",
+			wantMessage: "from must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "date missing separators",
+			path:        "/billing/charges?from=20260710",
+			wantError:   "invalid_from",
+			wantMessage: "from must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "unix seconds below supported range",
+			path:        "/billing/charges?from=946684799",
+			wantError:   "invalid_from",
+			wantMessage: "from must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "unix seconds above supported range",
+			path:        "/billing/charges?to=253402300800",
+			wantError:   "invalid_to",
+			wantMessage: "to must be YYYY-MM-DD, RFC3339, or unix seconds",
+		},
+		{
+			name:        "from after to",
+			path:        "/billing/charges?from=2026-07-11T00:00:00Z&to=2026-07-10T23:59:59Z",
+			wantError:   "invalid_time_range",
+			wantMessage: "from must not be after to",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -139,6 +249,112 @@ func TestUserBillingChargesValidateQuery(t *testing.T) {
 
 			if resp.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+			}
+			var payload struct {
+				Error   string `json:"error"`
+				Message string `json:"message"`
+			}
+			if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+				t.Fatalf("decode error response: %v", errDecode)
+			}
+			if payload.Error != tt.wantError || payload.Message != tt.wantMessage {
+				t.Fatalf("error response = %#v, want error=%q message=%q", payload, tt.wantError, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestUserBillingDateQuerySupportsExplicitTimeRanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		endOfDay bool
+		want     time.Time
+	}{
+		{
+			name:     "date-only end includes UTC day",
+			value:    "2026-07-10",
+			endOfDay: true,
+			want:     time.Date(2026, time.July, 10, 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC),
+		},
+		{
+			name:     "RFC3339 end preserves exact nanosecond boundary",
+			value:    "2026-07-10T23:59:59.999999999+08:00",
+			endOfDay: true,
+			want:     time.Date(2026, time.July, 10, 15, 59, 59, int(time.Second-time.Nanosecond), time.UTC),
+		},
+		{
+			name:     "unix seconds",
+			value:    "1783612800",
+			endOfDay: true,
+			want:     time.Unix(1783612800, 0).UTC(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+			ctx.Request = httptest.NewRequest(http.MethodGet, "/billing/charges", nil)
+			query := ctx.Request.URL.Query()
+			query.Set("to", tt.value)
+			ctx.Request.URL.RawQuery = query.Encode()
+
+			got, ok := userBillingDateQuery(ctx, "to", tt.endOfDay)
+			if !ok || got == nil {
+				t.Fatalf("userBillingDateQuery() = %v, %v; want a parsed time", got, ok)
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("userBillingDateQuery() = %s, want %s", got.Format(time.RFC3339Nano), tt.want.Format(time.RFC3339Nano))
+			}
+		})
+	}
+}
+
+func TestParseUserBillingTimeValidatesUnixSecondsRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "minimum supported unix second",
+			raw:  "946684800",
+			want: time.Unix(userBillingMinUnixSeconds, 0).UTC(),
+		},
+		{
+			name: "maximum supported unix second",
+			raw:  "253402300799",
+			want: time.Unix(userBillingMaxUnixSeconds, 0).UTC(),
+		},
+		{name: "before supported range", raw: "946684799", wantErr: true},
+		{name: "after supported range", raw: "253402300800", wantErr: true},
+		{name: "unix milliseconds", raw: "1783612800000", wantErr: true},
+		{name: "date missing separators", raw: "20260710", wantErr: true},
+		{name: "maximum int64", raw: "9223372036854775807", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, dateOnly, errParse := parseUserBillingTime(tt.raw)
+			if tt.wantErr {
+				if errParse == nil {
+					t.Fatalf("parseUserBillingTime(%q) error = nil, want an error", tt.raw)
+				}
+				return
+			}
+			if errParse != nil {
+				t.Fatalf("parseUserBillingTime(%q) error = %v", tt.raw, errParse)
+			}
+			if dateOnly {
+				t.Fatalf("parseUserBillingTime(%q) dateOnly = true, want false", tt.raw)
+			}
+			if !got.Equal(tt.want) {
+				t.Fatalf("parseUserBillingTime(%q) = %s, want %s", tt.raw, got.Format(time.RFC3339Nano), tt.want.Format(time.RFC3339Nano))
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Allow User Billing `from` and `to` query parameters to use `YYYY-MM-DD`, RFC3339, or Unix seconds.
- Preserve explicit RFC3339 and Unix-second boundaries exactly.
- Keep date-only `to` behavior backward compatible by expanding it to the end of the UTC day.
- Add coverage for timezone-offset RFC3339 ranges, Unix timestamps, date-only boundaries, and invalid query values.
- Update English and Chinese User/Management API documentation.

## Related Issues

- Fixes router-for-me/Home-Management-Center#39

## Validation

```bash
go test -count=1 ./internal/userapi
go build -o test-output ./cmd/home && rm -f test-output
git diff --check

## Compatibility

Existing clients that send date-only YYYY-MM-DD parameters retain the same UTC date-range behavior.
```