### PR TITLE
fix(billing): finalize cache token pricing semantics

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1539,7 +1539,6 @@ Model price fields:
 | `output_price_per_million` | number | Output-token price. |
 | `cache_read_price_per_million` | number | Cache-read token price. |
 | `cache_write_price_per_million` | number | Cache-write token price. |
-| `cache_write_price_configured` | boolean | Whether cache-write pricing is explicitly configured, including an explicit zero. |
 | `request_price` | number | Per-request price. |
 | `source` | string | Price source. |
 | `enabled` | boolean | Whether the rule is active. |
@@ -1564,7 +1563,6 @@ Request body fields:
 | `output_price_per_million` | number | no | Non-negative output-token price. |
 | `cache_read_price_per_million` | number | no | Non-negative cache-read token price. |
 | `cache_write_price_per_million` | number | no | Non-negative cache-write token price. |
-| `cache_write_price_configured` | boolean | no | Whether cache-write pricing is explicitly configured, including an explicit zero. Set this with `cache_write_price_per_million: 0` to distinguish a free cache-write bucket from an omitted price. |
 | `request_price` | number | no | Non-negative per-request price. |
 | `source` | string | no | Price source such as `manual`. |
 | `enabled` | boolean | no | Whether the rule is active. Defaults to `true`. |
@@ -1614,13 +1612,13 @@ Partially updates billing settings. In `response` mode, a missing response tier 
 { "service_tier_source": "response" }
 ```
 
-Charge `price_snapshot` audit data includes `requested_service_tier`, optional `response_service_tier`, `service_tier_source`, `effective_service_tier`, `response_tier_fallback`, `matched_service_tier`, and `min_input_tokens`. Context-band selection uses the original total input count. Separately priced OpenAI cached reads and explicitly configured cache writes are removed from ordinary input; an omitted cache-write price remains ordinary input, while an explicitly configured zero-price bucket remains auditable. Claude-style separate cache buckets retain their existing behavior.
+Charge `price_snapshot` audit data includes `requested_service_tier`, optional `response_service_tier`, `service_tier_source`, `effective_service_tier`, `response_tier_fallback`, `matched_service_tier`, and `min_input_tokens`. Context-band selection uses the original total input count. In the OpenAI Responses protocol, `input_tokens` includes both cache-read and cache-write tokens. Home removes cache-read tokens from ordinary input before applying the cache-read price. When `cache_write_price_per_million` is positive, Home also removes cache-write tokens from ordinary input before applying that separate price; when the price is zero or omitted, those cache-write tokens remain billed as ordinary input. In the Anthropic Messages protocol, `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` are independent buckets, so Home prices them independently without subtracting either cache bucket from input.
 
 ### POST `/billing/model-prices/import/preview`
 
-Creates a server-side, immutable `models.dev` import preview. The server fetches and pins the source snapshot; clients provide targets, matching policy, aliases, row multipliers, and optional source-match overrides. The response contains `preview_id`, `preview_revision`, source provenance, `generated_at`, `expires_at`, explicit `atomic: true`, rows, and an exact summary.
+Creates a server-side, immutable `models.dev` import preview. The server fetches and pins the source snapshot; clients provide targets, matching policy, aliases, row multipliers, and optional source-match overrides. Invalid request-controlled input returns `422 invalid_import_preview`, a catalog fetch failure returns `502 models_dev_fetch_failed`, and an internal preview persistence failure returns `500 billing_import_preview_failed`. A successful response contains `preview_id`, `preview_revision`, source provenance, `generated_at`, `expires_at`, explicit `atomic: true`, rows, and an exact summary.
 
-Preview targets currently describe only the wildcard base rule (`service_tier: "*"`, `min_input_tokens: 0`); other target scopes are rejected rather than silently rewritten. A matched row includes official prices, final multiplied prices, `cache_write_price_configured`, the exact `write_rule`, optional complete `existing_rule` snapshot with `revision`, and a machine-readable reason. Models.dev context bands create distinct wildcard rows at their inclusive lower bounds. `row_multipliers` apply to the exact returned row key, including a context-band key. When cache prices are excluded, updates preserve the existing cache prices instead of clearing them. Unsupported dimensions, malformed or invalid prices/bands, duplicate bands, or a tier that omits a price dimension configured by its base rule make the whole target non-applicable; the server never imports a potentially undercharged subset.
+Preview targets currently describe only the wildcard base rule (`service_tier: "*"`, `min_input_tokens: 0`); other target scopes are rejected rather than silently rewritten. A matched row includes official prices, final multiplied prices, the exact `write_rule`, optional complete `existing_rule` snapshot with `revision`, and a machine-readable reason. Models.dev context bands create distinct wildcard rows at their inclusive lower bounds. `row_multipliers` apply to the exact returned row key, including a context-band key. When cache prices are excluded, updates preserve the existing cache prices instead of clearing them. Unsupported dimensions, malformed or invalid prices/bands, duplicate bands, or a tier that omits a price dimension configured by its base rule make the whole target non-applicable; the server never imports a potentially undercharged subset.
 
 `policy.overwrite_mode` is `missing`, `sync`, or `all`. `missing` creates only absent rules, `sync` may update prior `source=sync` rules, and `all` may overwrite manual/default rules. Preview rows requiring an overwrite use action `overwrite` and require confirmation on apply.
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1539,7 +1539,6 @@ Query 参数：
 | `output_price_per_million` | number | Output-token 价格。 |
 | `cache_read_price_per_million` | number | Cache-read token 价格。 |
 | `cache_write_price_per_million` | number | Cache-write token 价格。 |
-| `cache_write_price_configured` | boolean | 是否显式配置了 cache-write 价格；显式的零价格也为 `true`。 |
 | `request_price` | number | 每请求价格。 |
 | `source` | string | 价格来源。 |
 | `enabled` | boolean | 规则是否启用。 |
@@ -1564,7 +1563,6 @@ Query 参数：
 | `output_price_per_million` | number | 否 | 非负 output-token 价格。 |
 | `cache_read_price_per_million` | number | 否 | 非负 cache-read token 价格。 |
 | `cache_write_price_per_million` | number | 否 | 非负 cache-write token 价格。 |
-| `cache_write_price_configured` | boolean | 否 | 是否显式配置 cache-write 价格，显式零价也包括在内。与 `cache_write_price_per_million: 0` 一起设置，可区分免费 cache-write bucket 与未配置价格。 |
 | `request_price` | number | 否 | 非负每请求价格。 |
 | `source` | string | 否 | 价格来源，例如 `manual`。 |
 | `enabled` | boolean | 否 | 规则是否启用；默认 `true`。 |
@@ -1614,13 +1612,13 @@ Query 参数：
 { "service_tier_source": "response" }
 ```
 
-扣费 `price_snapshot` 审计数据包含 `requested_service_tier`、可选的 `response_service_tier`、`service_tier_source`、`effective_service_tier`、`response_tier_fallback`、`matched_service_tier` 和 `min_input_tokens`。上下文分段使用原始 input-token 总数。OpenAI 风格的独立 cache-read 与显式配置的 cache-write 会从普通 input 中扣除；未配置的 cache-write 仍按普通 input 计费，而显式配置为零的 bucket 仍可审计。Claude 风格的独立缓存桶保持现有行为。
+扣费 `price_snapshot` 审计数据包含 `requested_service_tier`、可选的 `response_service_tier`、`service_tier_source`、`effective_service_tier`、`response_tier_fallback`、`matched_service_tier` 和 `min_input_tokens`。上下文分段使用原始 input-token 总数。在 OpenAI Responses 协议中，`input_tokens` 已包含 cache-read 和 cache-write token。Home 会先从普通 input 中扣除 cache-read token，再应用 cache-read 价格；当 `cache_write_price_per_million` 大于零时，也会先从普通 input 中扣除 cache-write token，再应用独立的 cache-write 价格；价格为零或未提供时，这些 cache-write token 仍按普通 input 计费。在 Anthropic Messages 协议中，`input_tokens`、`cache_read_input_tokens` 和 `cache_creation_input_tokens` 是相互独立的 bucket，因此 Home 会分别计费，不会从 input 中扣除任何 cache bucket。
 
 ### POST `/billing/model-prices/import/preview`
 
-创建服务端的不可变 `models.dev` 导入预览。服务端拉取并固定来源快照；客户端提供目标、匹配策略、别名、行倍率和可选的来源匹配覆盖。响应包含 `preview_id`、`preview_revision`、来源信息、`generated_at`、`expires_at`、明确的 `atomic: true`、行和精确汇总。
+创建服务端的不可变 `models.dev` 导入预览。服务端拉取并固定来源快照；客户端提供目标、匹配策略、别名、行倍率和可选的来源匹配覆盖。客户端可控的输入无效时返回 `422 invalid_import_preview`，目录拉取失败时返回 `502 models_dev_fetch_failed`，内部 preview 持久化失败时返回 `500 billing_import_preview_failed`。成功响应包含 `preview_id`、`preview_revision`、来源信息、`generated_at`、`expires_at`、明确的 `atomic: true`、行和精确汇总。
 
-当前 preview target 只描述通配符 base 规则（`service_tier: "*"`、`min_input_tokens: 0`）；其他 target scope 会被拒绝，不会被静默改写。已匹配行会包含官方价格、倍率后的最终价格、`cache_write_price_configured`、精确的 `write_rule`、带 `revision` 的完整可选 `existing_rule` 快照，以及机器可读的原因。models.dev 上下文分段会生成不同包含式下界的通配符行；`row_multipliers` 按返回的精确 row key 生效，包含 context-band 行。排除 cache 价格时，更新会保留已有 cache 价格，不会将其清空。出现不支持的价格维度、格式错误或无效的价格/分段、重复分段，或 tier 缺少 base 已配置价格维度时，整个 target 都不可应用，服务端不会导入可能低估计费的子集。
+当前 preview target 只描述通配符 base 规则（`service_tier: "*"`、`min_input_tokens: 0`）；其他 target scope 会被拒绝，不会被静默改写。已匹配行会包含官方价格、倍率后的最终价格、精确的 `write_rule`、带 `revision` 的完整可选 `existing_rule` 快照，以及机器可读的原因。models.dev 上下文分段会生成不同包含式下界的通配符行；`row_multipliers` 按返回的精确 row key 生效，包含 context-band 行。排除 cache 价格时，更新会保留已有 cache 价格，不会将其清空。出现不支持的价格维度、格式错误或无效的价格/分段、重复分段，或 tier 缺少 base 已配置价格维度时，整个 target 都不可应用；服务端不会导入可能低估计费的子集。
 
 `policy.overwrite_mode` 可为 `missing`、`sync` 或 `all`。`missing` 只创建缺失规则，`sync` 可更新已有 `source=sync` 规则，`all` 还可覆盖 manual/default 规则。`overwrite` 行在 apply 时必须确认。
 

--- a/internal/cluster/billing.go
+++ b/internal/cluster/billing.go
@@ -1190,11 +1190,16 @@ func billingChargeAmount(usage *UsageRecord, snapshot BillingPriceSnapshot) floa
 	if cacheReadTokens == 0 && usage.CachedTokens > 0 {
 		cacheReadTokens = usage.CachedTokens
 	}
-	// OpenAI-style cached_tokens are included in input_tokens. Claude reports
-	// cache_read_tokens/cache_creation_tokens as separate billing buckets.
+	// OpenAI/Codex style: cache_read/cache_write live under input_tokens details and
+	// are subsets of input_tokens. Claude/Anthropic report mutually exclusive buckets.
 	cacheWriteTokens := usage.CacheCreationTokens
-	if billingCacheReadIncludedInInput(usage) {
+	// Only peel write out of input when a positive separate write rate is used.
+	// Configured write=0 means "no write premium" while tokens still bill as input.
+	if billingCacheTokensIncludedInInput(usage) {
 		inputTokens -= cacheReadTokens
+		if snapshot.CacheWritePricePerMillion > 0 {
+			inputTokens -= cacheWriteTokens
+		}
 		if inputTokens < 0 {
 			inputTokens = 0
 		}
@@ -1209,8 +1214,10 @@ func billingChargeAmount(usage *UsageRecord, snapshot BillingPriceSnapshot) floa
 		float64(cacheWriteTokens)*snapshot.CacheWritePricePerMillion/1000000
 }
 
-func billingCacheReadIncludedInInput(usage *UsageRecord) bool {
-	if usage == nil || (usage.CacheReadTokens <= 0 && usage.CachedTokens <= 0) {
+// billingCacheTokensIncludedInInput reports whether cache read/write counts are
+// already included inside usage.InputTokens (OpenAI/Codex/OpenAI-compatible).
+func billingCacheTokensIncludedInInput(usage *UsageRecord) bool {
+	if usage == nil {
 		return false
 	}
 	provider := strings.ToLower(strings.TrimSpace(usage.Provider))

--- a/internal/cluster/billing.go
+++ b/internal/cluster/billing.go
@@ -49,7 +49,6 @@ type BillingModelPriceRecord struct {
 	OutputPricePerMillion     float64        `gorm:"column:output_price_per_million;not null;default:0"`
 	CacheReadPricePerMillion  float64        `gorm:"column:cache_read_price_per_million;not null;default:0"`
 	CacheWritePricePerMillion float64        `gorm:"column:cache_write_price_per_million;not null;default:0"`
-	CacheWritePriceConfigured bool           `gorm:"column:cache_write_price_configured;not null;default:false"`
 	RequestPrice              float64        `gorm:"column:request_price;not null;default:0"`
 	Source                    string         `gorm:"column:source;not null;default:manual"`
 	Enabled                   bool           `gorm:"column:enabled;not null;index:idx_billing_model_price_enabled"`
@@ -113,7 +112,6 @@ type BillingModelPriceUpdate struct {
 	OutputPricePerMillion     float64
 	CacheReadPricePerMillion  float64
 	CacheWritePricePerMillion float64
-	CacheWritePriceConfigured bool
 	RequestPrice              float64
 	Source                    string
 	Enabled                   bool
@@ -129,7 +127,6 @@ type BillingModelPricePatch struct {
 	OutputPricePerMillion     *float64
 	CacheReadPricePerMillion  *float64
 	CacheWritePricePerMillion *float64
-	CacheWritePriceConfigured *bool
 	RequestPrice              *float64
 	Source                    *string
 	Enabled                   *bool
@@ -231,7 +228,6 @@ type BillingPriceSnapshot struct {
 	OutputPricePerMillion     float64 `json:"output_price_per_million"`
 	CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million"`
 	CacheWritePricePerMillion float64 `json:"cache_write_price_per_million"`
-	CacheWritePriceConfigured bool    `json:"cache_write_price_configured"`
 	RequestPrice              float64 `json:"request_price"`
 	MatchedServiceTier        string  `json:"matched_service_tier"`
 	MinInputTokens            int64   `json:"min_input_tokens"`
@@ -298,7 +294,6 @@ func (r *Repository) CreateBillingModelPrice(ctx context.Context, update Billing
 		OutputPricePerMillion:     update.OutputPricePerMillion,
 		CacheReadPricePerMillion:  update.CacheReadPricePerMillion,
 		CacheWritePricePerMillion: update.CacheWritePricePerMillion,
-		CacheWritePriceConfigured: update.CacheWritePriceConfigured || update.CacheWritePricePerMillion > 0,
 		RequestPrice:              update.RequestPrice,
 		Source:                    billingPriceSource(update.Source),
 		Enabled:                   update.Enabled,
@@ -754,11 +749,6 @@ func billingModelPricePatchUpdates(patch BillingModelPricePatch) map[string]any 
 	if patch.CacheWritePricePerMillion != nil {
 		updates["cache_write_price_per_million"] = *patch.CacheWritePricePerMillion
 	}
-	if patch.CacheWritePriceConfigured != nil {
-		updates["cache_write_price_configured"] = *patch.CacheWritePriceConfigured
-	} else if patch.CacheWritePricePerMillion != nil && *patch.CacheWritePricePerMillion > 0 {
-		updates["cache_write_price_configured"] = true
-	}
 	if patch.RequestPrice != nil {
 		updates["request_price"] = *patch.RequestPrice
 	}
@@ -1168,7 +1158,6 @@ func billingPriceSnapshotForUsage(ctx context.Context, tx *gorm.DB, usage *Usage
 		OutputPricePerMillion:     price.OutputPricePerMillion,
 		CacheReadPricePerMillion:  price.CacheReadPricePerMillion,
 		CacheWritePricePerMillion: price.CacheWritePricePerMillion,
-		CacheWritePriceConfigured: price.CacheWritePriceConfigured,
 		RequestPrice:              price.RequestPrice,
 		MatchedServiceTier:        price.ServiceTier,
 		MinInputTokens:            price.MinInputTokens,
@@ -1186,7 +1175,6 @@ func billingChargeAmount(usage *UsageRecord, snapshot BillingPriceSnapshot) floa
 	}
 	inputTokens := usage.InputTokens
 	cacheReadTokens := usage.CacheReadTokens
-	cacheWritePriceConfigured := snapshot.CacheWritePriceConfigured || snapshot.CacheWritePricePerMillion > 0
 	if cacheReadTokens == 0 && usage.CachedTokens > 0 {
 		cacheReadTokens = usage.CachedTokens
 	}
@@ -1204,7 +1192,7 @@ func billingChargeAmount(usage *UsageRecord, snapshot BillingPriceSnapshot) floa
 			inputTokens = 0
 		}
 	}
-	if !cacheWritePriceConfigured {
+	if snapshot.CacheWritePricePerMillion <= 0 {
 		cacheWriteTokens = 0
 	}
 	return snapshot.RequestPrice +
@@ -1430,9 +1418,6 @@ func migrateBillingIndexes(db *gorm.DB) error {
 		return errDefaults
 	}
 	if errDefaults := db.Model(&BillingModelPriceRecord{}).Where("revision IS NULL OR revision < ?", 1).Update("revision", 1).Error; errDefaults != nil {
-		return errDefaults
-	}
-	if errDefaults := db.Model(&BillingModelPriceRecord{}).Where("cache_write_price_per_million > ?", 0).Update("cache_write_price_configured", true).Error; errDefaults != nil {
 		return errDefaults
 	}
 	return db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_billing_model_price_active_unique ON billing_model_price (provider, model, service_tier, min_input_tokens) WHERE deleted_at IS NULL AND enabled = TRUE`).Error

--- a/internal/cluster/billing_import.go
+++ b/internal/cluster/billing_import.go
@@ -125,12 +125,11 @@ type BillingModelPriceImportPreviewInput struct {
 }
 
 type BillingModelPriceImportCost struct {
-	Input                float64 `json:"input"`
-	Output               float64 `json:"output"`
-	CacheRead            float64 `json:"cache_read"`
-	CacheWrite           float64 `json:"cache_write"`
-	CacheWriteConfigured bool    `json:"cache_write_configured"`
-	Request              float64 `json:"request"`
+	Input      float64 `json:"input"`
+	Output     float64 `json:"output"`
+	CacheRead  float64 `json:"cache_read"`
+	CacheWrite float64 `json:"cache_write"`
+	Request    float64 `json:"request"`
 }
 
 type BillingModelPriceImportContextBand struct {
@@ -169,7 +168,6 @@ type BillingModelPriceImportRuleSnapshot struct {
 	OutputPricePerMillion     float64 `json:"output_price_per_million"`
 	CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million"`
 	CacheWritePricePerMillion float64 `json:"cache_write_price_per_million"`
-	CacheWritePriceConfigured bool    `json:"cache_write_price_configured"`
 	RequestPrice              float64 `json:"request_price"`
 	Source                    string  `json:"source"`
 	Enabled                   bool    `json:"enabled"`
@@ -178,12 +176,11 @@ type BillingModelPriceImportRuleSnapshot struct {
 }
 
 type BillingModelPriceImportWriteRule struct {
-	Source                    string `json:"source"`
-	Enabled                   bool   `json:"enabled"`
-	Note                      string `json:"note"`
-	ServiceTier               string `json:"service_tier"`
-	MinInputTokens            int64  `json:"min_input_tokens"`
-	CacheWritePriceConfigured bool   `json:"cache_write_price_configured"`
+	Source         string `json:"source"`
+	Enabled        bool   `json:"enabled"`
+	Note           string `json:"note"`
+	ServiceTier    string `json:"service_tier"`
+	MinInputTokens int64  `json:"min_input_tokens"`
 }
 
 type BillingModelPriceImportReason struct {
@@ -641,7 +638,6 @@ func billingImportMatchedRow(rowKey string, target BillingModelPriceImportTarget
 	if !policy.IncludeCachePrices && existing != nil {
 		final.CacheRead = existing.CacheReadPricePerMillion
 		final.CacheWrite = existing.CacheWritePricePerMillion
-		final.CacheWriteConfigured = existing.CacheWritePriceConfigured
 	}
 	row := BillingModelPriceImportPreviewRow{RowKey: rowKey, Provider: strings.ToLower(strings.TrimSpace(target.Provider)), Model: strings.TrimSpace(target.Model), ServiceTier: BillingServiceTierWildcard, MinInputTokens: band.MinInputTokens, Label: strings.TrimSpace(target.Label), Status: status, MatchedProvider: match.Provider, MatchedModel: match.Model, MatchedName: match.Name, Official: &band.Cost, Multiplier: multiplier, Reasons: []BillingModelPriceImportReason{{Code: "matched", Message: "Exact models.dev match."}}}
 	if row.Label == "" {
@@ -676,7 +672,7 @@ func billingImportMatchedRow(rowKey string, target BillingModelPriceImportTarget
 	if existing != nil {
 		enabled = existing.Enabled
 	}
-	row.WriteRule = &BillingModelPriceImportWriteRule{Source: BillingPriceSourceSync, Enabled: enabled, Note: fmt.Sprintf("synced from models.dev (%s/%s) x%g @ %s", match.Provider, match.Model, multiplier, fetchedAt.UTC().Format("2006-01-02")), ServiceTier: row.ServiceTier, MinInputTokens: row.MinInputTokens, CacheWritePriceConfigured: final.CacheWriteConfigured}
+	row.WriteRule = &BillingModelPriceImportWriteRule{Source: BillingPriceSourceSync, Enabled: enabled, Note: fmt.Sprintf("synced from models.dev (%s/%s) x%g @ %s", match.Provider, match.Model, multiplier, fetchedAt.UTC().Format("2006-01-02")), ServiceTier: row.ServiceTier, MinInputTokens: row.MinInputTokens}
 	return row
 }
 
@@ -856,7 +852,7 @@ func applyBillingModelPriceImportRow(ctx context.Context, tx *gorm.DB, row Billi
 		return "", ErrBillingImportInvalidSelection
 	}
 	if row.ExistingRule == nil {
-		record := BillingModelPriceRecord{ID: billingID("price"), Provider: strings.ToLower(strings.TrimSpace(row.Provider)), Model: strings.TrimSpace(row.Model), ServiceTier: row.ServiceTier, MinInputTokens: row.MinInputTokens, InputPricePerMillion: row.Final.Input, OutputPricePerMillion: row.Final.Output, CacheReadPricePerMillion: row.Final.CacheRead, CacheWritePricePerMillion: row.Final.CacheWrite, CacheWritePriceConfigured: row.Final.CacheWriteConfigured, RequestPrice: row.Final.Request, Source: BillingPriceSourceSync, Enabled: row.WriteRule.Enabled, Note: row.WriteRule.Note, Revision: 1}
+		record := BillingModelPriceRecord{ID: billingID("price"), Provider: strings.ToLower(strings.TrimSpace(row.Provider)), Model: strings.TrimSpace(row.Model), ServiceTier: row.ServiceTier, MinInputTokens: row.MinInputTokens, InputPricePerMillion: row.Final.Input, OutputPricePerMillion: row.Final.Output, CacheReadPricePerMillion: row.Final.CacheRead, CacheWritePricePerMillion: row.Final.CacheWrite, RequestPrice: row.Final.Request, Source: BillingPriceSourceSync, Enabled: row.WriteRule.Enabled, Note: row.WriteRule.Note, Revision: 1}
 		if errCreate := tx.WithContext(ctx).Create(&record).Error; errCreate != nil {
 			return "", errCreate
 		}
@@ -866,7 +862,7 @@ func applyBillingModelPriceImportRow(ctx context.Context, tx *gorm.DB, row Billi
 	if errRevision != nil {
 		return "", ErrBillingImportRuleConflict
 	}
-	updates := map[string]any{"input_price_per_million": row.Final.Input, "output_price_per_million": row.Final.Output, "cache_read_price_per_million": row.Final.CacheRead, "cache_write_price_per_million": row.Final.CacheWrite, "cache_write_price_configured": row.Final.CacheWriteConfigured, "request_price": row.Final.Request, "source": BillingPriceSourceSync, "enabled": row.WriteRule.Enabled, "note": row.WriteRule.Note, "revision": gorm.Expr("revision + ?", 1)}
+	updates := map[string]any{"input_price_per_million": row.Final.Input, "output_price_per_million": row.Final.Output, "cache_read_price_per_million": row.Final.CacheRead, "cache_write_price_per_million": row.Final.CacheWrite, "request_price": row.Final.Request, "source": BillingPriceSourceSync, "enabled": row.WriteRule.Enabled, "note": row.WriteRule.Note, "revision": gorm.Expr("revision + ?", 1)}
 	result := tx.WithContext(ctx).Model(&BillingModelPriceRecord{}).Where("id = ? AND revision = ?", row.ExistingRule.ID, expectedRevision).Updates(updates)
 	if result.Error != nil {
 		return "", result.Error
@@ -1000,7 +996,6 @@ func billingImportMultiplyCost(cost BillingModelPriceImportCost, multiplier floa
 	if includeCache {
 		result.CacheRead = cost.CacheRead * multiplier
 		result.CacheWrite = cost.CacheWrite * multiplier
-		result.CacheWriteConfigured = cost.CacheWriteConfigured
 	}
 	return result
 }
@@ -1022,7 +1017,7 @@ func billingImportBareModel(model string) string {
 	return trimmed
 }
 func billingImportRuleSnapshot(rule BillingModelPriceRecord) BillingModelPriceImportRuleSnapshot {
-	return BillingModelPriceImportRuleSnapshot{ID: rule.ID, Provider: rule.Provider, Model: rule.Model, ServiceTier: rule.ServiceTier, MinInputTokens: rule.MinInputTokens, InputPricePerMillion: rule.InputPricePerMillion, OutputPricePerMillion: rule.OutputPricePerMillion, CacheReadPricePerMillion: rule.CacheReadPricePerMillion, CacheWritePricePerMillion: rule.CacheWritePricePerMillion, CacheWritePriceConfigured: rule.CacheWritePriceConfigured, RequestPrice: rule.RequestPrice, Source: rule.Source, Enabled: rule.Enabled, Note: rule.Note, Revision: strconv.FormatInt(rule.Revision, 10)}
+	return BillingModelPriceImportRuleSnapshot{ID: rule.ID, Provider: rule.Provider, Model: rule.Model, ServiceTier: rule.ServiceTier, MinInputTokens: rule.MinInputTokens, InputPricePerMillion: rule.InputPricePerMillion, OutputPricePerMillion: rule.OutputPricePerMillion, CacheReadPricePerMillion: rule.CacheReadPricePerMillion, CacheWritePricePerMillion: rule.CacheWritePricePerMillion, RequestPrice: rule.RequestPrice, Source: rule.Source, Enabled: rule.Enabled, Note: rule.Note, Revision: strconv.FormatInt(rule.Revision, 10)}
 }
 func billingImportPreviewSummary(rows []BillingModelPriceImportPreviewRow) BillingModelPriceImportSummary {
 	var summary BillingModelPriceImportSummary

--- a/internal/cluster/billing_import_test.go
+++ b/internal/cluster/billing_import_test.go
@@ -20,8 +20,8 @@ func TestBillingModelPriceImportAppliesAtomicallyAndReplaysIdempotently(t *testi
 	if len(preview.Rows) != 1 || preview.Rows[0].Action != "create" || !preview.Rows[0].Applicable {
 		t.Fatalf("preview rows = %#v", preview.Rows)
 	}
-	if preview.Rows[0].Final == nil || !preview.Rows[0].Final.CacheWriteConfigured {
-		t.Fatalf("preview did not preserve configured zero cache write: %#v", preview.Rows[0])
+	if preview.Rows[0].Final == nil || preview.Rows[0].Final.CacheWrite != 0 {
+		t.Fatalf("preview cache-write price = %#v, want zero", preview.Rows[0].Final)
 	}
 	input := BillingModelPriceImportApplyInput{PreviewID: preview.PreviewID, PreviewRevision: preview.PreviewRevision, SelectedKeys: []string{preview.Rows[0].RowKey}, IdempotencyKey: "replay-key"}
 	first, errApply := repo.ApplyBillingModelPriceImport(ctx, input)
@@ -39,7 +39,7 @@ func TestBillingModelPriceImportAppliesAtomicallyAndReplaysIdempotently(t *testi
 	if errRules != nil {
 		t.Fatalf("ListBillingModelPrices() error = %v", errRules)
 	}
-	if len(rules) != 1 || !rules[0].CacheWritePriceConfigured || rules[0].Revision != 1 || first.Rows[0].ResourceID != rules[0].ID {
+	if len(rules) != 1 || rules[0].Revision != 1 || first.Rows[0].ResourceID != rules[0].ID {
 		t.Fatalf("stored rules = %#v", rules)
 	}
 	operation, errOperation := repo.GetBillingModelPriceImportOperation(ctx, first.OperationID)
@@ -57,7 +57,7 @@ func TestBillingModelPriceImportUsesContextBandRowMultiplier(t *testing.T) {
 	catalog := billingImportTestCatalog()
 	catalog.Models[0].ContextBands = []BillingModelPriceImportContextBand{{
 		MinInputTokens: 272001,
-		Cost:           BillingModelPriceImportCost{Input: 4, Output: 16, CacheWriteConfigured: true},
+		Cost:           BillingModelPriceImportCost{Input: 4, Output: 16},
 	}}
 	input := billingImportTestInput("missing")
 	input.Policy.RowMultipliers = map[string]float64{
@@ -89,7 +89,6 @@ func TestBillingModelPriceImportPreservesExistingCachePricesWhenExcluded(t *test
 		OutputPricePerMillion:     2,
 		CacheReadPricePerMillion:  7,
 		CacheWritePricePerMillion: 9,
-		CacheWritePriceConfigured: true,
 		Source:                    BillingPriceSourceSync,
 		Enabled:                   true,
 	})
@@ -102,7 +101,7 @@ func TestBillingModelPriceImportPreservesExistingCachePricesWhenExcluded(t *test
 	if errPreview != nil {
 		t.Fatalf("CreateBillingModelPriceImportPreview() error = %v", errPreview)
 	}
-	if len(preview.Rows) != 1 || preview.Rows[0].Final == nil || preview.Rows[0].Final.CacheRead != 7 || preview.Rows[0].Final.CacheWrite != 9 || !preview.Rows[0].Final.CacheWriteConfigured {
+	if len(preview.Rows) != 1 || preview.Rows[0].Final == nil || preview.Rows[0].Final.CacheRead != 7 || preview.Rows[0].Final.CacheWrite != 9 {
 		t.Fatalf("preview row = %#v, want existing cache prices preserved", preview.Rows)
 	}
 	_, errApply := repo.ApplyBillingModelPriceImport(ctx, BillingModelPriceImportApplyInput{
@@ -118,7 +117,7 @@ func TestBillingModelPriceImportPreservesExistingCachePricesWhenExcluded(t *test
 	if errStored != nil {
 		t.Fatalf("GetBillingModelPrice() error = %v", errStored)
 	}
-	if stored.InputPricePerMillion != 2 || stored.OutputPricePerMillion != 8 || stored.CacheReadPricePerMillion != 7 || stored.CacheWritePricePerMillion != 9 || !stored.CacheWritePriceConfigured {
+	if stored.InputPricePerMillion != 2 || stored.OutputPricePerMillion != 8 || stored.CacheReadPricePerMillion != 7 || stored.CacheWritePricePerMillion != 9 {
 		t.Fatalf("stored rule = %#v, want imported token prices and preserved cache prices", stored)
 	}
 }
@@ -179,7 +178,7 @@ func TestBillingModelPriceImportPreservesContextBandScopeForReviewRows(t *testin
 	catalog := billingImportTestCatalog()
 	catalog.Models[0].ContextBands = []BillingModelPriceImportContextBand{{
 		MinInputTokens: 272001,
-		Cost:           BillingModelPriceImportCost{Input: 4, Output: 16, CacheWriteConfigured: true},
+		Cost:           BillingModelPriceImportCost{Input: 4, Output: 16},
 	}}
 
 	preview, errPreview := repo.CreateBillingModelPriceImportPreview(ctx, billingImportTestInput("missing"), catalog)
@@ -387,8 +386,8 @@ func TestBillingModelPriceImportRejectsNonBaseTargetAndUnsafeContextBand(t *test
 	}
 	duplicateCatalog := billingImportTestCatalog()
 	duplicateCatalog.Models[0].ContextBands = []BillingModelPriceImportContextBand{
-		{MinInputTokens: 272001, Cost: BillingModelPriceImportCost{Input: 4, Output: 16, CacheWriteConfigured: true}},
-		{MinInputTokens: 272001, Cost: BillingModelPriceImportCost{Input: 5, Output: 20, CacheWriteConfigured: true}},
+		{MinInputTokens: 272001, Cost: BillingModelPriceImportCost{Input: 4, Output: 16}},
+		{MinInputTokens: 272001, Cost: BillingModelPriceImportCost{Input: 5, Output: 20}},
 	}
 	duplicatePreview, errDuplicatePreview := repo.CreateBillingModelPriceImportPreview(ctx, billingImportTestInput("missing"), duplicateCatalog)
 	if errDuplicatePreview != nil {
@@ -423,14 +422,12 @@ func TestBillingModelPriceImportRejectsChangedRuleRevision(t *testing.T) {
 	}
 }
 
-func TestBillingChargeAmountKeepsConfiguredZeroCacheWritePriceFree(t *testing.T) {
+func TestBillingChargeAmountKeepsZeroPricedOpenAICacheWritesInInput(t *testing.T) {
 	t.Parallel()
 
 	usage := &UsageRecord{Provider: "openai", ExecutorType: "OpenAICompatExecutor", InputTokens: 1000, CacheCreationTokens: 100}
-	configured := billingChargeAmount(usage, BillingPriceSnapshot{InputPricePerMillion: 1000, CacheWritePricePerMillion: 0, CacheWritePriceConfigured: true})
-	omitted := billingChargeAmount(usage, BillingPriceSnapshot{InputPricePerMillion: 1000, CacheWritePricePerMillion: 0})
-	if configured != 1 || omitted != 1 {
-		t.Fatalf("configured/omitted cache-write charge = %g/%g, want 1/1", configured, omitted)
+	if amount := billingChargeAmount(usage, BillingPriceSnapshot{InputPricePerMillion: 1000}); amount != 1 {
+		t.Fatalf("zero-price cache-write charge = %g, want 1", amount)
 	}
 }
 
@@ -519,5 +516,5 @@ func billingImportTestInput(overwriteMode string) BillingModelPriceImportPreview
 }
 
 func billingImportTestCatalog() BillingModelPriceImportCatalog {
-	return BillingModelPriceImportCatalog{SourceURL: "https://models.dev/api.json", Version: "fixture-v1", FetchedAt: time.Date(2026, time.July, 11, 0, 0, 0, 0, time.UTC), Models: []BillingModelPriceImportCatalogModel{{Provider: "openai", Model: "gpt-import", Name: "GPT Import", Cost: &BillingModelPriceImportCost{Input: 2, Output: 8, CacheWrite: 0, CacheWriteConfigured: true}}}}
+	return BillingModelPriceImportCatalog{SourceURL: "https://models.dev/api.json", Version: "fixture-v1", FetchedAt: time.Date(2026, time.July, 11, 0, 0, 0, 0, time.UTC), Models: []BillingModelPriceImportCatalogModel{{Provider: "openai", Model: "gpt-import", Name: "GPT Import", Cost: &BillingModelPriceImportCost{Input: 2, Output: 8, CacheWrite: 0}}}}
 }

--- a/internal/cluster/billing_test.go
+++ b/internal/cluster/billing_test.go
@@ -451,13 +451,13 @@ func TestBillingChargeAmountNormalizesOpenAICacheBuckets(t *testing.T) {
 		CacheReadPricePerMillion:  0.5,
 		CacheWritePricePerMillion: 3,
 	}
-	if amount := billingChargeAmount(usage, snapshot); amount != 1.925 {
-		t.Fatalf("billingChargeAmount() = %v, want 1.925", amount)
+	if amount := billingChargeAmount(usage, snapshot); amount != 1.725 {
+		t.Fatalf("billingChargeAmount() = %v, want 1.725", amount)
 	}
 
 	usage.CachedTokens = 0
-	if amount := billingChargeAmount(usage, snapshot); amount != 1.925 {
-		t.Fatalf("billingChargeAmount() with explicit cache read = %v, want 1.925", amount)
+	if amount := billingChargeAmount(usage, snapshot); amount != 1.725 {
+		t.Fatalf("billingChargeAmount() with explicit cache read = %v, want 1.725", amount)
 	}
 }
 

--- a/internal/cluster/billing_tiered_test.go
+++ b/internal/cluster/billing_tiered_test.go
@@ -37,7 +37,7 @@ func TestBillingMigrationPreservesLegacyPriceAsWildcardBaseBand(t *testing.T) {
 	if errFirst := db.First(&record, "id = ?", "legacy").Error; errFirst != nil {
 		t.Fatalf("load migrated row: %v", errFirst)
 	}
-	if record.ServiceTier != BillingServiceTierWildcard || record.MinInputTokens != 0 || record.InputPricePerMillion != 2 || record.Revision != 1 || record.CacheWritePriceConfigured {
+	if record.ServiceTier != BillingServiceTierWildcard || record.MinInputTokens != 0 || record.InputPricePerMillion != 2 || record.Revision != 1 {
 		t.Fatalf("migrated record = %+v", record)
 	}
 }

--- a/internal/cluster/billing_tiered_test.go
+++ b/internal/cluster/billing_tiered_test.go
@@ -154,7 +154,7 @@ func TestBillingChargeAmountSeparatesOpenAICacheReadAndWrite(t *testing.T) {
 
 	snapshot := BillingPriceSnapshot{InputPricePerMillion: 10, CacheReadPricePerMillion: 2, CacheWritePricePerMillion: 12.5}
 	usage := &UsageRecord{InputTokens: 100, CachedTokens: 30, CacheCreationTokens: 20}
-	if got, want := billingChargeAmount(usage, snapshot), 0.00101; math.Abs(got-want) > 1e-12 {
+	if got, want := billingChargeAmount(usage, snapshot), 0.00081; math.Abs(got-want) > 1e-12 {
 		t.Fatalf("billingChargeAmount() = %.9f, want %.9f", got, want)
 	}
 
@@ -169,7 +169,7 @@ func TestBillingChargeAmountSeparatesOpenAICacheWriteWithoutCacheRead(t *testing
 
 	usage := &UsageRecord{Provider: "openai", InputTokens: 100, CacheCreationTokens: 20}
 	snapshot := BillingPriceSnapshot{InputPricePerMillion: 10, CacheWritePricePerMillion: 12.5}
-	if got, want := billingChargeAmount(usage, snapshot), 0.00125; math.Abs(got-want) > 1e-12 {
+	if got, want := billingChargeAmount(usage, snapshot), 0.00105; math.Abs(got-want) > 1e-12 {
 		t.Fatalf("billingChargeAmount() = %.9f, want %.9f", got, want)
 	}
 }
@@ -204,7 +204,7 @@ func TestBillingOpenAICompatibleProviderNameDoesNotSelectClaudeBuckets(t *testin
 		CacheCreationTokens: 20,
 	}
 	snapshot := BillingPriceSnapshot{InputPricePerMillion: 10, CacheReadPricePerMillion: 2, CacheWritePricePerMillion: 12.5}
-	if got, want := billingChargeAmount(usage, snapshot), 0.00101; math.Abs(got-want) > 1e-12 {
+	if got, want := billingChargeAmount(usage, snapshot), 0.00081; math.Abs(got-want) > 1e-12 {
 		t.Fatalf("billingChargeAmount() = %.9f, want %.9f", got, want)
 	}
 	if got, want := billingCacheTokens(usage), int64(50); got != want {

--- a/internal/cluster/management/billing.go
+++ b/internal/cluster/management/billing.go
@@ -22,7 +22,6 @@ type billingModelPriceRequest struct {
 	OutputPricePerMillion     *float64 `json:"output_price_per_million"`
 	CacheReadPricePerMillion  *float64 `json:"cache_read_price_per_million"`
 	CacheWritePricePerMillion *float64 `json:"cache_write_price_per_million"`
-	CacheWritePriceConfigured *bool    `json:"cache_write_price_configured"`
 	RequestPrice              *float64 `json:"request_price"`
 	Source                    *string  `json:"source"`
 	Enabled                   *bool    `json:"enabled"`
@@ -307,7 +306,6 @@ func billingModelPriceUpdateFromRequest(c *gin.Context, body billingModelPriceRe
 		OutputPricePerMillion:     floatValue(body.OutputPricePerMillion),
 		CacheReadPricePerMillion:  floatValue(body.CacheReadPricePerMillion),
 		CacheWritePricePerMillion: floatValue(body.CacheWritePricePerMillion),
-		CacheWritePriceConfigured: boolValue(body.CacheWritePriceConfigured),
 		RequestPrice:              floatValue(body.RequestPrice),
 		Source:                    strings.TrimSpace(billingStringValue(body.Source)),
 		Enabled:                   true,
@@ -386,7 +384,6 @@ func billingModelPricePatchFromRequest(c *gin.Context, body billingModelPriceReq
 	patch.OutputPricePerMillion = body.OutputPricePerMillion
 	patch.CacheReadPricePerMillion = body.CacheReadPricePerMillion
 	patch.CacheWritePricePerMillion = body.CacheWritePricePerMillion
-	patch.CacheWritePriceConfigured = body.CacheWritePriceConfigured
 	patch.RequestPrice = body.RequestPrice
 	if body.Source != nil {
 		source := strings.TrimSpace(*body.Source)
@@ -414,13 +411,6 @@ func floatValue(value *float64) float64 {
 	return *value
 }
 
-func boolValue(value *bool) bool {
-	if value == nil {
-		return false
-	}
-	return *value
-}
-
 func int64Value(value *int64) int64 {
 	if value == nil {
 		return 0
@@ -442,7 +432,6 @@ func billingModelPriceResponse(record *cluster.BillingModelPriceRecord) gin.H {
 		"output_price_per_million":      record.OutputPricePerMillion,
 		"cache_read_price_per_million":  record.CacheReadPricePerMillion,
 		"cache_write_price_per_million": record.CacheWritePricePerMillion,
-		"cache_write_price_configured":  record.CacheWritePriceConfigured,
 		"request_price":                 record.RequestPrice,
 		"source":                        record.Source,
 		"enabled":                       record.Enabled,

--- a/internal/cluster/management/billing_import.go
+++ b/internal/cluster/management/billing_import.go
@@ -44,7 +44,7 @@ func (h *Handler) PreviewBillingModelPriceImport(c *gin.Context) {
 	}
 	preview, errPreview := h.repo.CreateBillingModelPriceImportPreview(ctx, body, catalog)
 	if errPreview != nil {
-		respondError(c, http.StatusUnprocessableEntity, "invalid_import_preview", errPreview)
+		respondError(c, http.StatusInternalServerError, "billing_import_preview_failed", errPreview)
 		return
 	}
 	c.JSON(http.StatusOK, preview)
@@ -214,7 +214,7 @@ func parseBillingModelPriceImportCost(value any) (*cluster.BillingModelPriceImpo
 	if !hasInput && !hasOutput && !hasCacheRead && !hasCacheWrite && !hasRequest {
 		return nil, billingModelPriceImportCostPresence{}, false
 	}
-	return &cluster.BillingModelPriceImportCost{Input: input, Output: output, CacheRead: cacheRead, CacheWrite: cacheWrite, CacheWriteConfigured: hasCacheWrite, Request: request}, billingModelPriceImportCostPresence{Input: hasInput, Output: hasOutput, CacheRead: hasCacheRead, CacheWrite: hasCacheWrite, Request: hasRequest}, true
+	return &cluster.BillingModelPriceImportCost{Input: input, Output: output, CacheRead: cacheRead, CacheWrite: cacheWrite, Request: request}, billingModelPriceImportCostPresence{Input: hasInput, Output: hasOutput, CacheRead: hasCacheRead, CacheWrite: hasCacheWrite, Request: hasRequest}, true
 }
 
 func parseBillingModelPriceImportContextBands(value any, base billingModelPriceImportCostPresence) ([]cluster.BillingModelPriceImportContextBand, []string) {

--- a/internal/cluster/management/billing_test.go
+++ b/internal/cluster/management/billing_test.go
@@ -141,7 +141,7 @@ func TestBillingSettingsGetAndPatch(t *testing.T) {
 	}
 }
 
-func TestParseBillingModelPriceImportCatalogPreservesContextBandAndConfiguredZero(t *testing.T) {
+func TestParseBillingModelPriceImportCatalogPreservesZeroPricedContextBand(t *testing.T) {
 	t.Parallel()
 
 	catalog, errCatalog := parseBillingModelPriceImportCatalog([]byte(`{
@@ -154,10 +154,10 @@ func TestParseBillingModelPriceImportCatalogPreservesContextBandAndConfiguredZer
 	if errCatalog != nil {
 		t.Fatalf("parseBillingModelPriceImportCatalog() error = %v", errCatalog)
 	}
-	if len(catalog.Models) != 1 || catalog.Models[0].Cost == nil || !catalog.Models[0].Cost.CacheWriteConfigured {
+	if len(catalog.Models) != 1 || catalog.Models[0].Cost == nil || catalog.Models[0].Cost.CacheWrite != 0 {
 		t.Fatalf("catalog models = %#v", catalog.Models)
 	}
-	if len(catalog.Models[0].ContextBands) != 1 || catalog.Models[0].ContextBands[0].MinInputTokens != 272001 || !catalog.Models[0].ContextBands[0].Cost.CacheWriteConfigured {
+	if len(catalog.Models[0].ContextBands) != 1 || catalog.Models[0].ContextBands[0].MinInputTokens != 272001 || catalog.Models[0].ContextBands[0].Cost.CacheWrite != 0 || len(catalog.Models[0].ContextBands[0].MissingPriceFields) != 0 {
 		t.Fatalf("context bands = %#v", catalog.Models[0].ContextBands)
 	}
 }
@@ -310,6 +310,26 @@ func TestPreviewBillingModelPriceImportValidatesBeforeFetchingCatalog(t *testing
 	}
 	if fetched {
 		t.Fatal("invalid preview fetched the models.dev catalog")
+	}
+}
+
+func TestPreviewBillingModelPriceImportReturnsInternalErrorForDatabaseFailure(t *testing.T) {
+	t.Parallel()
+
+	handler, closeRepo := newBillingManagementTestHandler(t)
+	closeRepo()
+	handler.SetModelsDevHTTPClient(&http.Client{Transport: billingImportRoundTripper(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"openai":{"models":{"gpt-import":{"cost":{"input":2,"output":8}}}}}`))}, nil
+	})})
+	response := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(response)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/billing/model-prices/import/preview", strings.NewReader(`{"source":"models.dev","targets":[{"provider":"openai","model":"gpt-import"}],"policy":{"overwrite_mode":"missing","default_multiplier":1}}`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	handler.PreviewBillingModelPriceImport(ctx)
+
+	if response.Code != http.StatusInternalServerError || !strings.Contains(response.Body.String(), "billing_import_preview_failed") {
+		t.Fatalf("status = %d body=%s, want 500 billing_import_preview_failed", response.Code, response.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Normalize cache-read and cache-write billing according to the upstream protocol token-bucket semantics.
- Prevent OpenAI Responses and Codex cache-write tokens from being charged once as ordinary input and again at the separate cache-write rate.
- Remove the redundant `cache_write_price_configured` field from billing persistence, Management API payloads, charge snapshots, and model-price import data.
- Return server-side preview persistence failures as `500 billing_import_preview_failed` instead of classifying them as invalid client input.
- Document the final behavior in both English and Chinese and extend regression coverage.

## Problem

OpenAI Responses reports cache details as subsets of `input_tokens`:

```text
input_tokens
├── cache-read tokens
└── cache-write tokens
```

Home already removed cache-read tokens before applying the separate cache-read price. Cache-write tokens were still left inside ordinary input while also being charged at a positive cache-write rate, which caused double billing.

Anthropic Messages has a different contract: `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` are independent buckets. Those buckets must remain independently priced and must not be normalized like OpenAI Responses.

## Billing behavior

| Protocol / executor | Upstream token buckets | Home billing behavior |
| --- | --- | --- |
| OpenAI Responses / Codex / OpenAI-compatible | Cache read and cache write are included in `input_tokens` | Remove cache reads from ordinary input. When the cache-write price is positive, also remove cache writes before applying the separate write price. |
| OpenAI Responses with zero or omitted cache-write price | Cache writes remain part of `input_tokens` | Keep cache-write tokens billed as ordinary input; do not add a separate cache-write charge. |
| Anthropic Messages / Claude | Input, cache read, and cache creation are independent | Price every bucket independently without subtracting cache buckets from input. |

OpenAI-compatible executors retain OpenAI semantics even when a provider name contains `anthropic`.

## API and persistence changes

The redundant `cache_write_price_configured` field has been removed from:

- `BillingModelPriceRecord`
- model-price create and patch inputs
- model-price Management API responses
- charge `price_snapshot`
- models.dev preview costs, existing-rule snapshots, and write rules
- import apply persistence updates
- Management API documentation

A positive `cache_write_price_per_million` is sufficient to select separate cache-write pricing. A zero or omitted value has the same billing meaning, so a second configuration flag is unnecessary.

The models.dev parser still tracks whether source price dimensions are present through parser-local metadata. This preserves fail-closed validation for incomplete context tiers without exposing another public configuration field.

Existing databases may retain the old column because GORM AutoMigrate is intentionally non-destructive, but Home no longer reads or writes it. New schemas do not create it.

## Import preview error handling

`POST /billing/model-prices/import/preview` now distinguishes client, upstream, and server failures:

| Failure | Status | Error code |
| --- | --- | --- |
| Invalid request-controlled preview input | `422` | `invalid_import_preview` |
| models.dev fetch or catalog failure | `502` | `models_dev_fetch_failed` |
| Database cleanup, query, insert, or preview persistence failure | `500` | `billing_import_preview_failed` |

Apply error semantics remain unchanged.

## Compatibility

- No CPA-to-Home usage payload shape changes are required.
- Existing canonical `input_tokens`, `cached_tokens`, `cache_read_tokens`, and `cache_creation_tokens` fields continue to be consumed.
- Anthropic Messages billing behavior is unchanged.
- Historical billing charge records are not recalculated.
- Clients should use `cache_write_price_per_million` directly; the removed boolean is no longer returned.

## Regression coverage

Tests cover:

- OpenAI cache read and cache write together
- OpenAI cache write without cache read
- zero cache-write price remaining in ordinary OpenAI input
- OpenAI-compatible providers whose names contain `anthropic`
- Anthropic / Claude independent cache buckets
- models.dev zero-priced cache-write context tiers
- incomplete context-tier price detection
- model-price import persistence and idempotent replay
- preview database failures returning `500 billing_import_preview_failed`

## Validation

- `go test -count=1 ./internal/cluster ./internal/cluster/management`
- `go build -o test-output ./cmd/home && rm test-output`
- `git diff --check`
- GitHub Actions `build`: passed
- GitHub Actions `agents-md-guard`: passed
