### PR TITLE
fix(usage): return contiguous activity buckets

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -2604,12 +2604,12 @@ Invalid filters, sorts, or pagination return `400`; missing credentials return `
 
 These endpoints read persisted `usage`, `billing_charge`, `api_key`, `user`, and `auth` data. Responses never return raw client access keys, provider API keys, OAuth tokens, cookies, authorization headers, complete payloads, or complete failure bodies. They may return `api_key_masked`, redacted `body_preview`, and payload summaries.
 
-The aggregate range parameters apply to `/usage/overview`, `/usage/aggregates`, `/usage/realtime`, `/usage/health/providers`, and `/usage/health/credentials`, and they also act as the base range for `/usage/records` and `/usage/export`. `/usage/overview` and `/usage/aggregates` automatically fill a recent 24-hour window when `from` or `to` is missing; `/usage/records` and `/usage/export` do not fill a time range automatically.
+The aggregate range parameters apply to `/usage/overview`, `/usage/aggregates`, `/usage/realtime`, `/usage/health/providers`, and `/usage/health/credentials`, and they also act as the base range for `/usage/records` and `/usage/export`. All usage ranges use the half-open interval `[from,to)`: `from` is included and `to` is excluded. A date-only `to` value is normalized to the next local midnight, so the selected calendar day remains fully included across DST transitions. `/usage/overview` and `/usage/aggregates` automatically fill a recent 24-hour window when `from` or `to` is missing; `/usage/records` and `/usage/export` do not fill a time range automatically.
 
 | Query | Type | Default | Description |
 | --- | --- | --- | --- |
 | `from` | string | `to - 24h` for `/usage/overview` and `/usage/aggregates`; none for other endpoints | Start time. Supports `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values are interpreted as 00:00:00 in `timezone`. |
-| `to` | string | current time for `/usage/overview` and `/usage/aggregates`; none for other endpoints | End time. Supports `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values include the full day in `timezone`. |
+| `to` | string | current time for `/usage/overview` and `/usage/aggregates`; none for other endpoints | Exclusive end time. Supports `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values include the full day in `timezone` by using the next local midnight as the exclusive boundary. |
 | `timezone` | string | `UTC` | Statistics timezone for date-only `from`/`to` and `day`/`week` trend buckets. |
 | `provider` | string | none | Exact provider filter. |
 | `model` | string | none | Fuzzy model filter. |
@@ -2645,7 +2645,7 @@ Query parameters in addition to aggregate range parameters:
 
 | Query | Type | Default | Description |
 | --- | --- | --- | --- |
-| `interval` | string | `auto` | `minute`, `hour`, `day`, `week`, or `auto`. `day` and `week` buckets use `timezone`; response timestamps remain UTC RFC3339. |
+| `interval` | string | `auto` | `minute`, `hour`, `day`, `week`, or `auto`. `day` and `week` buckets use `timezone`; response timestamps remain UTC RFC3339. A response is limited to 10,000 trend buckets. `auto` promotes to a coarser interval when needed; an explicit interval that exceeds the limit returns `400 invalid_interval_range`. |
 
 Top-level response fields:
 
@@ -2654,11 +2654,11 @@ Top-level response fields:
 | `range` | object | Applied time range, timezone, and interval. |
 | `live` | object | Recent short-window RPM, TPM, error rate, and latency. |
 | `totals` | object | Request counts, success/failure counts, tokens, amount, latency, and active subject counts. |
-| `trend` | array | Trend buckets aggregated by `interval`. |
+| `trend` | array | Contiguous trend buckets intersecting the applied half-open range at `interval`, including zero-request buckets. The first and last buckets may be partial. |
 | `cost_breakdown` | array | Empty when reliable cost splitting is unavailable; the API does not fabricate indivisible cost details. |
 | `model_efficiency` | array | Model efficiency list sorted by total tokens. |
 | `top` | object | `users`, `client_keys`, `credentials`, `providers`, `models`, `endpoints`, and `errors`. |
-| `activity` | array | Health activity series aligned with the trend buckets. |
+| `activity` | array | Health activity series aligned one-for-one with the contiguous trend buckets. `status` is `empty` for zero requests, `healthy` below 5% errors, `degraded` from 5% to below 50% errors, and `unavailable` from 50% errors. |
 
 ### GET `/usage/records`
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -2574,12 +2574,12 @@ collector 直接读取 DB 凭证，不接受 HMC 提交 URL。探测前会重新
 
 这些接口读取持久化 `usage`、`billing_charge`、`api_key`、`user` 和 `auth` 数据。响应不会返回 raw client access key、provider API key、OAuth token、cookie、authorization header、完整 payload 或完整失败 body。允许返回 `api_key_masked`、脱敏 `body_preview` 和 payload summary。
 
-汇总范围参数适用于 `/usage/overview`、`/usage/aggregates`、`/usage/realtime`、`/usage/health/providers`、`/usage/health/credentials`，也作为 `/usage/records` 和 `/usage/export` 的基础范围。`/usage/overview` 和 `/usage/aggregates` 在缺少 `from` 或 `to` 时会自动补齐最近 24 小时窗口；`/usage/records` 和 `/usage/export` 不自动补齐时间范围。
+汇总范围参数适用于 `/usage/overview`、`/usage/aggregates`、`/usage/realtime`、`/usage/health/providers`、`/usage/health/credentials`，也作为 `/usage/records` 和 `/usage/export` 的基础范围。所有 usage 范围统一采用半开区间 `[from,to)`：包含 `from`，不包含 `to`。仅日期形式的 `to` 会归一化为下一个本地午夜，因此即使跨越 DST，也会完整包含所选日历日。`/usage/overview` 和 `/usage/aggregates` 在缺少 `from` 或 `to` 时会自动补齐最近 24 小时窗口；`/usage/records` 和 `/usage/export` 不自动补齐时间范围。
 
 | Query | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | `from` | string | `/usage/overview` 和 `/usage/aggregates` 默认为 `to - 24h`；其他接口无 | 起始时间，支持 `YYYY-MM-DD`、RFC3339 或 Unix 秒；只有日期时按 `timezone` 解释为当天 00:00:00。 |
-| `to` | string | `/usage/overview` 和 `/usage/aggregates` 默认为当前时间；其他接口无 | 结束时间，支持 `YYYY-MM-DD`、RFC3339 或 Unix 秒；只有日期时按 `timezone` 解释并包含当天完整一天。 |
+| `to` | string | `/usage/overview` 和 `/usage/aggregates` 默认为当前时间；其他接口无 | 不包含的结束时间，支持 `YYYY-MM-DD`、RFC3339 或 Unix 秒；只有日期时使用下一个本地午夜作为排他边界，从而按 `timezone` 完整包含当天。 |
 | `timezone` | string | `UTC` | 用于日期型 `from`/`to` 和 `day`/`week` 趋势桶的统计时区。 |
 | `provider` | string | 无 | Provider 精确筛选。 |
 | `model` | string | 无 | 模型模糊筛选。 |
@@ -2615,7 +2615,7 @@ Query 参数除汇总范围参数外还支持：
 
 | Query | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| `interval` | string | `auto` | `minute`、`hour`、`day`、`week` 或 `auto`。`day` 和 `week` 会按 `timezone` 切桶，响应时间仍为 UTC RFC3339。 |
+| `interval` | string | `auto` | `minute`、`hour`、`day`、`week` 或 `auto`。`day` 和 `week` 会按 `timezone` 切桶，响应时间仍为 UTC RFC3339。响应最多包含 10,000 个趋势桶；`auto` 会在需要时自动提升粒度，显式 interval 超出限制时返回 `400 invalid_interval_range`。 |
 
 输出顶层字段：
 
@@ -2624,11 +2624,11 @@ Query 参数除汇总范围参数外还支持：
 | `range` | object | 应用后的时间范围、timezone 和 interval。 |
 | `live` | object | 最近短窗口 RPM、TPM、错误率和延迟。 |
 | `totals` | object | 请求数、成功/失败数、token、金额、延迟和活跃主体数量。 |
-| `trend` | array | 按 `interval` 聚合的趋势桶。 |
+| `trend` | array | 与已应用半开区间相交的连续 `interval` 趋势桶，包含请求数为零的时间桶；首尾桶可能是不完整桶。 |
 | `cost_breakdown` | array | 当前不伪造不可拆分的费用明细，无法可靠拆分时为空数组。 |
 | `model_efficiency` | array | 按总 token 排序的模型效率列表。 |
 | `top` | object | `users`、`client_keys`、`credentials`、`providers`、`models`、`endpoints` 和 `errors`。 |
-| `activity` | array | 与趋势桶一致的健康活动序列。 |
+| `activity` | array | 与连续趋势桶一一对齐的健康活动序列。请求数为零时 `status` 为 `empty`；错误率低于 5% 为 `healthy`；5%（含）至 50%（不含）为 `degraded`；达到 50% 为 `unavailable`。 |
 
 ### GET `/usage/records`
 

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -75,6 +75,10 @@ func (h *Handler) GetUsageOverview(c *gin.Context) {
 	defer cancel()
 	overview, errOverview := h.repo.UsageObservabilityOverview(ctx, usageObservabilityOverviewQueryFromHTTP(query))
 	if errOverview != nil {
+		if errors.Is(errOverview, cluster.ErrUsageObservabilityTooManyTrendBuckets) {
+			respondUsageHTTPError(c, newUsageHTTPError("invalid_interval_range", "%v", errOverview))
+			return
+		}
 		respondError(c, http.StatusInternalServerError, "usage_overview_load_failed", errOverview)
 		return
 	}
@@ -966,7 +970,7 @@ func parseUsageTimeRange(rawFrom string, rawTo string, location *time.Location) 
 	return from, to, nil
 }
 
-func optionalUsageTime(raw string, endOfDay bool, location *time.Location) (*time.Time, *usageHTTPError) {
+func optionalUsageTime(raw string, exclusiveDayEnd bool, location *time.Location) (*time.Time, *usageHTTPError) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
 		return nil, nil
@@ -983,8 +987,8 @@ func optionalUsageTime(raw string, endOfDay bool, location *time.Location) (*tim
 	}
 	if parsedDay, errDay := time.ParseInLocation("2006-01-02", value, location); errDay == nil {
 		parsed := parsedDay
-		if endOfDay {
-			parsed = parsed.Add(24*time.Hour - time.Nanosecond)
+		if exclusiveDayEnd {
+			parsed = parsed.AddDate(0, 0, 1)
 		}
 		parsed = parsed.UTC()
 		return &parsed, nil

--- a/internal/cluster/management/usage_observability_test.go
+++ b/internal/cluster/management/usage_observability_test.go
@@ -36,6 +36,48 @@ func TestUsageRecordsRejectsInvalidRange(t *testing.T) {
 	}
 }
 
+func TestParseUsageDateOnlyRangeUsesDSTSafeExclusiveEnd(t *testing.T) {
+	t.Parallel()
+
+	location, errLocation := time.LoadLocation("America/New_York")
+	if errLocation != nil {
+		t.Fatalf("LoadLocation() error = %v", errLocation)
+	}
+	tests := []struct {
+		name     string
+		date     string
+		wantFrom time.Time
+		wantTo   time.Time
+	}{
+		{
+			name:     "spring forward",
+			date:     "2026-03-08",
+			wantFrom: time.Date(2026, time.March, 8, 5, 0, 0, 0, time.UTC),
+			wantTo:   time.Date(2026, time.March, 9, 4, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "fall back",
+			date:     "2026-11-01",
+			wantFrom: time.Date(2026, time.November, 1, 4, 0, 0, 0, time.UTC),
+			wantTo:   time.Date(2026, time.November, 2, 5, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			from, to, errRange := parseUsageTimeRange(test.date, test.date, location)
+			if errRange != nil {
+				t.Fatalf("parseUsageTimeRange() error = %v", errRange)
+			}
+			if from == nil || !from.Equal(test.wantFrom) {
+				t.Fatalf("from = %v, want %v", from, test.wantFrom)
+			}
+			if to == nil || !to.Equal(test.wantTo) {
+				t.Fatalf("to = %v, want %v", to, test.wantTo)
+			}
+		})
+	}
+}
+
 func TestUsageAggregatesRejectsInvalidGroupBy(t *testing.T) {
 	handler, closeRepo := newUsageObservabilityTestHandler(t)
 	defer closeRepo()
@@ -143,6 +185,31 @@ func TestListUsageRecordsReturnsJoinedItems(t *testing.T) {
 	}
 	if _, ok := payload["sortable_fields"].([]any); !ok {
 		t.Fatalf("sortable_fields = %T, want array", payload["sortable_fields"])
+	}
+}
+
+func TestListUsageRecordsTreatsToAsExclusive(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/usage/records", handler.ListUsageRecords)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/usage/records?from=2026-06-10T01:00:00Z&to=2026-06-10T01:02:03Z", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if payload["total"] != float64(0) {
+		t.Fatalf("total = %v, want 0 for record exactly at exclusive to", payload["total"])
 	}
 }
 
@@ -719,8 +786,8 @@ func TestGetUsageOverviewUsesRequestedIntervalAndTimezone(t *testing.T) {
 		t.Fatalf("range.interval = %v, want day", rangeValue["interval"])
 	}
 	trend, ok := payload["trend"].([]any)
-	if !ok || len(trend) != 1 {
-		t.Fatalf("trend = %#v, want one point", payload["trend"])
+	if !ok || len(trend) != 2 {
+		t.Fatalf("trend = %#v, want two contiguous points", payload["trend"])
 	}
 	point, ok := trend[0].(map[string]any)
 	if !ok {
@@ -728,6 +795,67 @@ func TestGetUsageOverviewUsesRequestedIntervalAndTimezone(t *testing.T) {
 	}
 	if point["bucket_start"] != "2026-06-09T16:00:00Z" {
 		t.Fatalf("bucket_start = %v, want 2026-06-09T16:00:00Z", point["bucket_start"])
+	}
+	activity, ok := payload["activity"].([]any)
+	if !ok || len(activity) != 2 {
+		t.Fatalf("activity = %#v, want two contiguous points", payload["activity"])
+	}
+	emptyPoint, ok := activity[1].(map[string]any)
+	if !ok {
+		t.Fatalf("activity[1] = %T, want object", activity[1])
+	}
+	if emptyPoint["request_count"] != float64(0) || emptyPoint["status"] != "empty" {
+		t.Fatalf("activity[1] = %#v, want empty zero-request bucket", emptyPoint)
+	}
+}
+
+func TestGetUsageOverviewTreatsToAsExclusiveBucketBoundary(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecord(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/usage/overview", handler.GetUsageOverview)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/usage/overview?from=2026-06-09T16:00:00Z&to=2026-06-10T16:00:00Z&timezone=Asia/Shanghai&interval=day", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	trend, ok := payload["trend"].([]any)
+	if !ok || len(trend) != 1 {
+		t.Fatalf("trend = %#v, want one day bucket", payload["trend"])
+	}
+	activity, ok := payload["activity"].([]any)
+	if !ok || len(activity) != 1 {
+		t.Fatalf("activity = %#v, want one day bucket", payload["activity"])
+	}
+}
+
+func TestGetUsageOverviewRejectsExcessiveExplicitBucketCount(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/usage/overview", handler.GetUsageOverview)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/usage/overview?from=2026-06-01T00:00:00Z&to=2026-06-09T00:00:00Z&interval=minute", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusBadRequest)
+	}
+	if !strings.Contains(resp.Body.String(), "invalid_interval_range") {
+		t.Fatalf("body = %s, want invalid_interval_range", resp.Body.String())
 	}
 }
 

--- a/internal/cluster/usage_observability.go
+++ b/internal/cluster/usage_observability.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -20,11 +21,16 @@ const (
 	UsageObservabilityMaxRecordLimit     = 200
 	UsageObservabilityDefaultGroupLimit  = 20
 	UsageObservabilityMaxGroupLimit      = 100
+	// UsageObservabilityMaxTrendBuckets bounds each overview trend and its aligned activity series.
+	UsageObservabilityMaxTrendBuckets = 10000
 
 	UsageObservabilityCurrencyCredits     = "credits"
 	UsageObservabilityBillingBasisCharge  = "billing_charge"
 	UsageObservabilityBillingBasisUnknown = "unknown"
 )
+
+// ErrUsageObservabilityTooManyTrendBuckets indicates that the applied range and interval exceed the response limit.
+var ErrUsageObservabilityTooManyTrendBuckets = errors.New("usage overview trend bucket limit exceeded")
 
 var usageObservabilitySecretPattern = regexp.MustCompile(`(?i)(authorization|access_token|refresh_token|api_key|client_secret|cookie|set-cookie|bearer|secret)(["']?\s*[:=]\s*["']?|\s+)[^"'\s,;\]}]+`)
 
@@ -746,8 +752,11 @@ func (r *Repository) UsageObservabilityOverview(ctx context.Context, query Usage
 		return UsageObservabilityOverview{}, errTotals
 	}
 
-	interval := usageObservabilityOverviewIntervalFromBounds(query.Interval, query.From, query.To, bounds)
 	location := usageObservabilityLocation(query.Timezone)
+	interval, errInterval := usageObservabilityOverviewIntervalForBounds(query.Interval, location, query.From, query.To, bounds)
+	if errInterval != nil {
+		return UsageObservabilityOverview{}, errInterval
+	}
 	overview := UsageObservabilityOverview{
 		Range: UsageObservabilityOverviewRange{
 			From:     usageObservabilityRangeTimeFromBounds(query.From, bounds, true),
@@ -768,7 +777,10 @@ func (r *Repository) UsageObservabilityOverview(ctx context.Context, query Usage
 	if errTrend != nil {
 		return UsageObservabilityOverview{}, errTrend
 	}
-	overview.Trend = trend
+	overview.Trend, errTrend = usageObservabilityFillTrend(trend, interval, location, query.From, query.To, bounds)
+	if errTrend != nil {
+		return UsageObservabilityOverview{}, errTrend
+	}
 	overview.Activity = usageObservabilityActivity(overview.Trend)
 	modelEfficiency, errModelEfficiency := usageObservabilityAggregateItemsSQL(db, recordQuery, "model", "total_tokens", "desc", 10)
 	if errModelEfficiency != nil {
@@ -1109,6 +1121,44 @@ func usageObservabilityTrendFromBucketRows(rows []usageObservabilityTrendBucketR
 	return points
 }
 
+func usageObservabilityFillTrend(points []UsageObservabilityTrendPoint, interval string, location *time.Location, from *time.Time, to *time.Time, bounds usageObservabilityOverviewBounds) ([]UsageObservabilityTrendPoint, error) {
+	rangeStart, rangeEnd, endExclusive := usageObservabilityTrendRange(from, to, bounds)
+	lastIncluded, ok := usageObservabilityLastIncludedTime(rangeStart, rangeEnd, endExclusive)
+	if !ok {
+		return []UsageObservabilityTrendPoint{}, nil
+	}
+
+	firstBucketStart, _ := usageObservabilityBucketRange(rangeStart, interval, location)
+	lastBucketStart, _ := usageObservabilityBucketRange(lastIncluded, interval, location)
+	pointsByStart := make(map[int64]UsageObservabilityTrendPoint, len(points))
+	for _, point := range points {
+		pointsByStart[point.BucketStart.UnixNano()] = point
+	}
+
+	filled := make([]UsageObservabilityTrendPoint, 0, len(points))
+	for cursor := firstBucketStart; !cursor.After(lastBucketStart); {
+		if len(filled) >= UsageObservabilityMaxTrendBuckets {
+			return nil, fmt.Errorf("%w: maximum is %d", ErrUsageObservabilityTooManyTrendBuckets, UsageObservabilityMaxTrendBuckets)
+		}
+		bucketStart, bucketEnd := usageObservabilityBucketRange(cursor, interval, location)
+		if point, ok := pointsByStart[bucketStart.UnixNano()]; ok {
+			filled = append(filled, point)
+		} else {
+			filled = append(filled, UsageObservabilityTrendPoint{
+				BucketStart: bucketStart,
+				BucketEnd:   bucketEnd,
+			})
+		}
+
+		next := bucketEnd.Add(time.Nanosecond)
+		if !next.After(cursor) {
+			break
+		}
+		cursor = next
+	}
+	return filled, nil
+}
+
 func usageObservabilityTrendBucketUnixSQL(db *gorm.DB, interval string, location *time.Location, query UsageObservabilityRecordQuery, bounds usageObservabilityOverviewBounds) (string, []any) {
 	bucketSeconds := int64(86400)
 	subtractSeconds := int64(0)
@@ -1187,14 +1237,12 @@ type usageObservabilityTrendBucketCaseSegment struct {
 }
 
 func usageObservabilityTrendCaseRange(query UsageObservabilityRecordQuery, bounds usageObservabilityOverviewBounds) (time.Time, time.Time) {
-	start, end := usageObservabilityBoundsTimes(bounds)
-	if query.From != nil {
-		start = query.From.UTC()
+	start, end, endExclusive := usageObservabilityTrendRange(query.From, query.To, bounds)
+	lastIncluded, ok := usageObservabilityLastIncludedTime(start, end, endExclusive)
+	if !ok {
+		return time.Time{}, time.Time{}
 	}
-	if query.To != nil {
-		end = query.To.UTC()
-	}
-	return start.UTC(), end.UTC()
+	return start.UTC(), lastIncluded.UTC()
 }
 
 func usageObservabilityTimezoneOffsetChanges(location *time.Location, start time.Time, end time.Time) bool {
@@ -2005,7 +2053,7 @@ func usageObservabilityApplyRecordFilters(scope *gorm.DB, query UsageObservabili
 		scope = scope.Where(`"usage"."timestamp" >= ?`, query.From.UTC())
 	}
 	if query.To != nil {
-		scope = scope.Where(`"usage"."timestamp" <= ?`, query.To.UTC())
+		scope = scope.Where(`"usage"."timestamp" < ?`, query.To.UTC())
 	}
 	if provider := strings.ToLower(strings.TrimSpace(query.Provider)); provider != "" {
 		scope = scope.Where(`LOWER("usage"."provider") = ?`, provider)
@@ -2102,7 +2150,7 @@ func usageObservabilityApplyUsageFilters(scope *gorm.DB, query UsageObservabilit
 		scope = scope.Where(`"usage"."timestamp" >= ?`, query.From.UTC())
 	}
 	if query.To != nil {
-		scope = scope.Where(`"usage"."timestamp" <= ?`, query.To.UTC())
+		scope = scope.Where(`"usage"."timestamp" < ?`, query.To.UTC())
 	}
 	if provider := strings.ToLower(strings.TrimSpace(query.Provider)); provider != "" {
 		scope = scope.Where(`LOWER("usage"."provider") = ?`, provider)
@@ -2968,6 +3016,24 @@ func usageObservabilityOverviewIntervalFromBounds(requested string, from *time.T
 	return usageObservabilityOverviewIntervalFromTimes(requested, start, end)
 }
 
+func usageObservabilityOverviewIntervalForBounds(requested string, location *time.Location, from *time.Time, to *time.Time, bounds usageObservabilityOverviewBounds) (string, error) {
+	interval := usageObservabilityOverviewIntervalFromBounds(requested, from, to, bounds)
+	auto := strings.EqualFold(strings.TrimSpace(requested), "auto") || strings.TrimSpace(requested) == ""
+	for {
+		count := usageObservabilityTrendBucketCount(interval, location, from, to, bounds, UsageObservabilityMaxTrendBuckets)
+		if count <= UsageObservabilityMaxTrendBuckets {
+			return interval, nil
+		}
+		if auto {
+			if next := usageObservabilityCoarserInterval(interval); next != interval {
+				interval = next
+				continue
+			}
+		}
+		return "", fmt.Errorf("%w: interval %q produces more than %d buckets", ErrUsageObservabilityTooManyTrendBuckets, interval, UsageObservabilityMaxTrendBuckets)
+	}
+}
+
 func usageObservabilityOverviewIntervalFromTimes(requested string, start time.Time, end time.Time) string {
 	switch strings.ToLower(strings.TrimSpace(requested)) {
 	case "minute", "hour", "day", "week":
@@ -2980,6 +3046,73 @@ func usageObservabilityOverviewIntervalFromTimes(requested string, start time.Ti
 		return "hour"
 	}
 	return "day"
+}
+
+func usageObservabilityCoarserInterval(interval string) string {
+	switch interval {
+	case "minute":
+		return "hour"
+	case "hour":
+		return "day"
+	case "day":
+		return "week"
+	default:
+		return interval
+	}
+}
+
+func usageObservabilityTrendBucketCount(interval string, location *time.Location, from *time.Time, to *time.Time, bounds usageObservabilityOverviewBounds, limit int) int {
+	rangeStart, rangeEnd, endExclusive := usageObservabilityTrendRange(from, to, bounds)
+	lastIncluded, ok := usageObservabilityLastIncludedTime(rangeStart, rangeEnd, endExclusive)
+	if !ok {
+		return 0
+	}
+	firstBucketStart, _ := usageObservabilityBucketRange(rangeStart, interval, location)
+	lastBucketStart, _ := usageObservabilityBucketRange(lastIncluded, interval, location)
+	count := 0
+	for cursor := firstBucketStart; !cursor.After(lastBucketStart); {
+		count++
+		if limit > 0 && count > limit {
+			return count
+		}
+		_, bucketEnd := usageObservabilityBucketRange(cursor, interval, location)
+		next := bucketEnd.Add(time.Nanosecond)
+		if !next.After(cursor) {
+			break
+		}
+		cursor = next
+	}
+	return count
+}
+
+func usageObservabilityTrendRange(from *time.Time, to *time.Time, bounds usageObservabilityOverviewBounds) (time.Time, time.Time, bool) {
+	start, end := usageObservabilityBoundsTimes(bounds)
+	if from != nil {
+		start = from.UTC()
+	}
+	endExclusive := false
+	if to != nil {
+		end = to.UTC()
+		// Explicit usage query ranges are half-open: [from,to).
+		endExclusive = true
+	}
+	return start, end, endExclusive
+}
+
+func usageObservabilityLastIncludedTime(start time.Time, end time.Time, endExclusive bool) (time.Time, bool) {
+	if start.IsZero() || end.IsZero() {
+		return time.Time{}, false
+	}
+	if endExclusive {
+		if !end.After(start) {
+			return time.Time{}, false
+		}
+		return end.Add(-time.Nanosecond), true
+	}
+	if end.Before(start) {
+		return time.Time{}, false
+	}
+	return end, true
 }
 
 func usageObservabilityRangeTime(value *time.Time, rows []usageObservabilityRecordRow, first bool) string {
@@ -3100,7 +3233,7 @@ func usageObservabilityBucketRange(timestamp time.Time, interval string, locatio
 
 func usageObservabilityHealthStatus(errorRate float64, requestCount int64) string {
 	if requestCount == 0 {
-		return "unknown"
+		return "empty"
 	}
 	if errorRate >= 0.50 {
 		return "unavailable"

--- a/internal/cluster/usage_observability_test.go
+++ b/internal/cluster/usage_observability_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -726,6 +727,164 @@ func TestUsageObservabilityOverviewBuildsTrendWithSQLBuckets(t *testing.T) {
 	second := overview.Trend[1]
 	if second.RequestCount != 1 || second.SuccessCount != 0 || second.FailedCount != 1 {
 		t.Fatalf("second counts = requests:%d success:%d failed:%d, want 1/0/1", second.RequestCount, second.SuccessCount, second.FailedCount)
+	}
+}
+
+func TestUsageObservabilityOverviewFillsEmptyTrendBuckets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	seedUsageObservabilityRecord(t, ctx, repo)
+	from := time.Date(2026, time.June, 10, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.June, 12, 23, 59, 59, 0, time.UTC)
+	overview, errOverview := repo.UsageObservabilityOverview(ctx, UsageObservabilityOverviewQuery{
+		From:     &from,
+		To:       &to,
+		Interval: "day",
+		Timezone: "UTC",
+	})
+	if errOverview != nil {
+		t.Fatalf("UsageObservabilityOverview() error = %v", errOverview)
+	}
+	if len(overview.Trend) != 3 {
+		t.Fatalf("trend point count = %d, want 3", len(overview.Trend))
+	}
+	if overview.Trend[0].RequestCount != 1 {
+		t.Fatalf("first request count = %d, want 1", overview.Trend[0].RequestCount)
+	}
+	for index := 1; index < len(overview.Trend); index++ {
+		if overview.Trend[index].RequestCount != 0 {
+			t.Fatalf("trend[%d] request count = %d, want 0", index, overview.Trend[index].RequestCount)
+		}
+		if overview.Activity[index].Status != "empty" {
+			t.Fatalf("activity[%d] status = %q, want empty", index, overview.Activity[index].Status)
+		}
+	}
+}
+
+func TestUsageObservabilityOverviewUsesHalfOpenEndBoundary(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	seedUsageObservabilityRecord(t, ctx, repo)
+	from := time.Date(2026, time.June, 10, 1, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.June, 10, 1, 2, 3, 0, time.UTC)
+	overview, errOverview := repo.UsageObservabilityOverview(ctx, UsageObservabilityOverviewQuery{
+		From:     &from,
+		To:       &to,
+		Interval: "hour",
+		Timezone: "UTC",
+	})
+	if errOverview != nil {
+		t.Fatalf("UsageObservabilityOverview() error = %v", errOverview)
+	}
+	if overview.Totals.RequestCount != 0 {
+		t.Fatalf("request count = %d, want 0 for record exactly at exclusive to", overview.Totals.RequestCount)
+	}
+	if len(overview.Trend) != 1 || overview.Trend[0].RequestCount != 0 {
+		t.Fatalf("trend = %+v, want one empty partial bucket", overview.Trend)
+	}
+	if len(overview.Activity) != 1 || overview.Activity[0].Status != "empty" {
+		t.Fatalf("activity = %+v, want one empty bucket", overview.Activity)
+	}
+}
+
+func TestUsageObservabilityOverviewRejectsTooManyExplicitTrendBuckets(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	from := time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC)
+	to := from.Add(8 * 24 * time.Hour)
+	_, errOverview := repo.UsageObservabilityOverview(ctx, UsageObservabilityOverviewQuery{
+		From:     &from,
+		To:       &to,
+		Interval: "minute",
+		Timezone: "UTC",
+	})
+	if !errors.Is(errOverview, ErrUsageObservabilityTooManyTrendBuckets) {
+		t.Fatalf("UsageObservabilityOverview() error = %v, want bucket limit error", errOverview)
+	}
+}
+
+func TestUsageObservabilityOverviewAutoPromotesIntervalForBucketLimit(t *testing.T) {
+	t.Parallel()
+
+	from := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2040, time.January, 1, 0, 0, 0, 0, time.UTC)
+	interval, errInterval := usageObservabilityOverviewIntervalForBounds("auto", time.UTC, &from, &to, usageObservabilityOverviewBounds{})
+	if errInterval != nil {
+		t.Fatalf("usageObservabilityOverviewIntervalForBounds() error = %v", errInterval)
+	}
+	if interval != "week" {
+		t.Fatalf("interval = %q, want week", interval)
+	}
+}
+
+func TestUsageObservabilityOverviewFillsEmptyRangeAcrossDST(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	from := time.Date(2026, time.March, 7, 12, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.March, 9, 12, 0, 0, 0, time.UTC)
+	overview, errOverview := repo.UsageObservabilityOverview(ctx, UsageObservabilityOverviewQuery{
+		From:     &from,
+		To:       &to,
+		Interval: "day",
+		Timezone: "America/New_York",
+	})
+	if errOverview != nil {
+		t.Fatalf("UsageObservabilityOverview() error = %v", errOverview)
+	}
+	wantStarts := []time.Time{
+		time.Date(2026, time.March, 7, 5, 0, 0, 0, time.UTC),
+		time.Date(2026, time.March, 8, 5, 0, 0, 0, time.UTC),
+		time.Date(2026, time.March, 9, 4, 0, 0, 0, time.UTC),
+	}
+	if len(overview.Trend) != len(wantStarts) {
+		t.Fatalf("trend point count = %d, want %d", len(overview.Trend), len(wantStarts))
+	}
+	for index, wantStart := range wantStarts {
+		if !overview.Trend[index].BucketStart.Equal(wantStart) {
+			t.Fatalf("trend[%d] bucket start = %v, want %v", index, overview.Trend[index].BucketStart, wantStart)
+		}
+		if overview.Activity[index].RequestCount != 0 || overview.Activity[index].Status != "empty" {
+			t.Fatalf("activity[%d] = %+v, want empty zero-request bucket", index, overview.Activity[index])
+		}
+	}
+}
+
+func TestUsageObservabilityHealthStatusContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		errorRate    float64
+		requestCount int64
+		want         string
+	}{
+		{name: "empty", errorRate: 0, requestCount: 0, want: "empty"},
+		{name: "healthy", errorRate: 0.049, requestCount: 10, want: "healthy"},
+		{name: "degraded", errorRate: 0.05, requestCount: 10, want: "degraded"},
+		{name: "unavailable", errorRate: 0.50, requestCount: 10, want: "unavailable"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := usageObservabilityHealthStatus(test.errorRate, test.requestCount); got != test.want {
+				t.Fatalf("usageObservabilityHealthStatus() = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Make `GET /usage/overview` return contiguous `trend` and `activity` series across the applied time range, including zero-request buckets.

This allows clients to correctly represent cases such as “2 active periods out of 7” without reimplementing timezone, DST, and bucket-boundary logic.

## Changes

- Fill missing `trend` buckets with zero-valued points.
- Keep `activity` aligned one-to-one with `trend`.
- Return `status: empty` for zero-request activity buckets.
- Standardize usage ranges as half-open intervals: `[from,to)`.
- Normalize date-only `to` values to the next local midnight using DST-safe calendar arithmetic.
- Limit overview responses to 10,000 trend buckets.
- Automatically promote `interval=auto` to a coarser interval when necessary.
- Return `400 invalid_interval_range` when an explicit interval exceeds the bucket limit.
- Document partial first/last buckets and the updated range contract.
- Update both English and Chinese Management API documentation.

## Compatibility

This changes `/usage/overview` from sparse to contiguous time-series output, so consumers may receive additional zero-request buckets.

The `to` boundary is now consistently exclusive across usage overview, records, aggregates, realtime, health, and export filtering.

## Validation

- `go test -count=1 ./internal/cluster ./internal/cluster/management`
- `go build -o test-output ./cmd/home && rm test-output`
- `git diff --check`

Tests cover:

- missing-bucket generation;
- exact exclusive `to` boundaries;
- date-only ranges across 23-hour and 25-hour DST days;
- explicit bucket-limit rejection;
- automatic interval promotion;
- aligned `trend` and `activity` output.