### PR TITLE
feat(management): add stable API key mutations

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -110,6 +110,7 @@ The table below is extracted from the final Home route registry built by `intern
 | `DELETE` | `/api-keys` |
 | `GET` | `/api-keys` |
 | `PATCH` | `/api-keys` |
+| `POST` | `/api-keys` |
 | `PUT` | `/api-keys` |
 | `GET` | `/billing/overview` |
 | `GET` | `/billing/charges` |
@@ -1182,6 +1183,8 @@ Example response:
   "api-keys": ["client-key-1"],
   "items": [
     {
+      "id": 1,
+      "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
       "user-id": 1,
@@ -1192,6 +1195,8 @@ Example response:
   ],
   "api_key_entries": [
     {
+      "id": 1,
+      "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
       "user-id": 1,
@@ -1210,12 +1215,48 @@ Fields:
 | `api-keys` | array of string | Compatibility list of raw client keys. |
 | `items` | array of `APIKeyEntry` | Structured API key records. |
 | `api_key_entries` | array of `APIKeyEntry` | Alias of `items`. |
+| `APIKeyEntry.id` | integer | Stable database primary key of the API key. |
+| `APIKeyEntry.api_key_id` | integer | Alias of `id`. |
 | `APIKeyEntry.api-key` | string | Client API key. |
 | `APIKeyEntry.api_key` | string | Alias of `api-key`. |
 | `APIKeyEntry.user-id` | integer or null | Bound `user.id`; `null` means unbound. |
 | `APIKeyEntry.user_id` | integer or null | Alias of `user-id`. |
 | `APIKeyEntry.channels` | array of integer | Bound channel group IDs. An empty array is non-restrictive. |
 | `APIKeyEntry.model_groups` | array of integer | Bound model group IDs. An empty array is non-restrictive. |
+
+### POST `/api-keys`
+
+Atomically creates one client API key without replacing the existing list.
+
+```json
+{
+  "api_key": "client-key-1",
+  "user_id": 1,
+  "channels": [1],
+  "model_groups": [2]
+}
+```
+
+The request also accepts `api-key`, `key`, or `value` as the key field. `user-id` and `model-groups` are accepted as aliases.
+
+A new key value receives a new stable identifier. Re-adding an identical soft-deleted key restores the previous record and reuses its identifier. Creating an active duplicate returns `409 api_key_exists`.
+
+Successful response:
+
+```json
+{
+  "api_key": {
+    "id": 1,
+    "api_key_id": 1,
+    "api-key": "client-key-1",
+    "api_key": "client-key-1",
+    "user-id": 1,
+    "user_id": 1,
+    "channels": [1],
+    "model_groups": [2]
+  }
+}
+```
 
 ### PUT `/api-keys`
 
@@ -1259,6 +1300,8 @@ Entry fields:
 
 If `user_id` references a missing user, the API returns `404 user_not_found`.
 
+`PUT` is an explicit complete-list replacement operation with last-write-wins semantics. `id` and `api_key_id` are response-only for this operation and are ignored in structured input. Unchanged key values preserve their identifiers, removed values are soft-deleted, and new values receive new identifiers unless they restore an identical soft-deleted value.
+
 Successful response:
 
 ```json
@@ -1267,7 +1310,27 @@ Successful response:
 
 ### PATCH `/api-keys`
 
-Updates one client API key by index or by old value. When `old/new` is used and the old value does not exist, `new` is appended. This route can also update `user_id`, `channels`, and `model_groups` for an existing API key.
+Updates one client API key. Stable `id` / `api_key_id` selection is preferred. Legacy `index`, `old/new`, and raw-key selectors remain available for compatibility and are resolved to one database record before the update is applied. When `old/new` is used and the old value does not exist, `new` is created atomically. This route can also update `user_id`, `channels`, and `model_groups` for an existing API key.
+
+ID update:
+
+```json
+{
+  "id": 1,
+  "value": {
+    "api_key": "new-key",
+    "user_id": 1,
+    "channels": [1],
+    "model_groups": [2]
+  }
+}
+```
+
+Binding-only updates can select the record by ID without resending the key value:
+
+```json
+{ "api_key_id": 1, "channels": [1] }
+```
 
 Index update:
 
@@ -1302,26 +1365,23 @@ Fields:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
+| `id` | integer | conditionally | Preferred stable API key identifier. Alias: `api_key_id`, `api-key-id`. |
 | `index` | integer | conditionally | Zero-based index. |
-| `value` | string or `APIKeyEntry` | conditionally | New value paired with `index`. Structured entries are accepted. |
+| `value` | string or `APIKeyEntry` | conditionally | New value paired with `id` or `index`. Structured entries are accepted. |
 | `old` | string | conditionally | Old key to find. |
 | `new` | string | conditionally | New key; appended when `old` is not found. |
-| `api_key` | string | conditionally | Direct-binding target. Aliases: `api-key`, `key`. |
+| `api_key` | string | conditionally | Legacy raw-key target. When supplied with `id`, it must match the selected record. Aliases: `api-key`, `key`. |
 | `user_id` | integer | no | Bound `user.id`. Alias: `user-id`; `0` clears the binding. |
 | `channels` | array of integer | no | Channel group IDs. |
 | `model_groups` | array of integer | no | Model group IDs. Alias: `model-groups`. |
 
-Normal response:
-
-```json
-{ "status": "ok" }
-```
-
-Direct binding update response:
+Successful response:
 
 ```json
 {
   "api_key": {
+    "id": 1,
+    "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
     "user-id": 1,
@@ -1334,12 +1394,13 @@ Direct binding update response:
 
 ### DELETE `/api-keys`
 
-Deletes a client API key by index or value.
+Deletes one client API key. Stable ID selection is preferred; index and value selectors remain available for compatibility.
 
 Query parameters:
 
 | Query | Type | Description |
 | --- | --- | --- |
+| `id` | integer | Preferred stable API key identifier. Aliases: `api_key_id`, `api-key-id`. |
 | `index` | integer | Delete the key at this zero-based index. |
 | `value` | string | Delete the key whose trimmed value matches. |
 | `api_key` | string | Alias of `value`. |
@@ -1351,6 +1412,8 @@ Example response:
 ```json
 { "status": "ok" }
 ```
+
+Unknown IDs return `404 api_key_not_found`. If an ID and key selector are both supplied but identify different records, the API returns `400 invalid_api_key_selector`.
 
 ## Billing
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -110,6 +110,7 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `DELETE` | `/api-keys` |
 | `GET` | `/api-keys` |
 | `PATCH` | `/api-keys` |
+| `POST` | `/api-keys` |
 | `PUT` | `/api-keys` |
 | `GET` | `/billing/overview` |
 | `GET` | `/billing/charges` |
@@ -1182,6 +1183,8 @@ Path 参数：
   "api-keys": ["client-key-1"],
   "items": [
     {
+      "id": 1,
+      "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
       "user-id": 1,
@@ -1192,6 +1195,8 @@ Path 参数：
   ],
   "api_key_entries": [
     {
+      "id": 1,
+      "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
       "user-id": 1,
@@ -1210,12 +1215,48 @@ Path 参数：
 | `api-keys` | array of string | 兼容旧客户端的原始 key 列表。 |
 | `items` | array of `APIKeyEntry` | 结构化 API key records。 |
 | `api_key_entries` | array of `APIKeyEntry` | `items` 的 alias。 |
+| `APIKeyEntry.id` | integer | API key 的稳定数据库主键。 |
+| `APIKeyEntry.api_key_id` | integer | `id` 的 alias。 |
 | `APIKeyEntry.api-key` | string | 客户端 API key。 |
 | `APIKeyEntry.api_key` | string | `api-key` 的 alias。 |
 | `APIKeyEntry.user-id` | integer or null | 绑定的 `user.id`；`null` 表示未绑定。 |
 | `APIKeyEntry.user_id` | integer or null | `user-id` 的 alias。 |
 | `APIKeyEntry.channels` | array of integer | 绑定的 channel group IDs；空数组表示不限制。 |
 | `APIKeyEntry.model_groups` | array of integer | 绑定的 model group IDs；空数组表示不限制。 |
+
+### POST `/api-keys`
+
+原子创建一个客户端 API key，不替换现有列表。
+
+```json
+{
+  "api_key": "client-key-1",
+  "user_id": 1,
+  "channels": [1],
+  "model_groups": [2]
+}
+```
+
+密钥字段也接受 `api-key`、`key` 或 `value`；`user-id` 和 `model-groups` 作为别名。
+
+新的密钥值会获得新的稳定标识。如果重新添加与历史软删除记录完全相同的密钥值，则恢复原记录并复用原标识。创建已存在的活跃密钥会返回 `409 api_key_exists`。
+
+成功输出：
+
+```json
+{
+  "api_key": {
+    "id": 1,
+    "api_key_id": 1,
+    "api-key": "client-key-1",
+    "api_key": "client-key-1",
+    "user-id": 1,
+    "user_id": 1,
+    "channels": [1],
+    "model_groups": [2]
+  }
+}
+```
 
 ### PUT `/api-keys`
 
@@ -1259,6 +1300,8 @@ Entry 字段：
 
 如果 `user_id` 引用不存在的用户，接口返回 `404 user_not_found`。
 
+`PUT` 是显式的完整列表替换操作，采用 last-write-wins 语义。对于此操作，`id` 和 `api_key_id` 仅用于响应，在结构化输入中会被忽略。未改变的密钥值保留原标识，被移除的值会软删除，新值会获得新标识；如果新值恢复了完全相同的软删除记录，则复用原标识。
+
 成功输出：
 
 ```json
@@ -1267,7 +1310,27 @@ Entry 字段：
 
 ### PATCH `/api-keys`
 
-按下标或旧值更新客户端 API key。使用 `old/new` 时，如果旧值不存在，会追加 `new`。此接口还可以更新已有 API key 的 `user_id`、`channels` 和 `model_groups`。
+更新一个客户端 API key。优先使用稳定的 `id` / `api_key_id` 定位。旧的 `index`、`old/new` 和原始 key selector 继续作为兼容方式，后端会先将其解析到一条数据库记录，再执行定向更新。使用 `old/new` 时，如果旧值不存在，会原子创建 `new`。此接口还可以更新已有 API key 的 `user_id`、`channels` 和 `model_groups`。
+
+按 ID 更新：
+
+```json
+{
+  "id": 1,
+  "value": {
+    "api_key": "new-key",
+    "user_id": 1,
+    "channels": [1],
+    "model_groups": [2]
+  }
+}
+```
+
+仅更新绑定时，可以按 ID 定位而不重复发送密钥值：
+
+```json
+{ "api_key_id": 1, "channels": [1] }
+```
 
 按下标更新：
 
@@ -1302,26 +1365,23 @@ Entry 字段：
 
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
+| `id` | integer | 条件必填 | 推荐使用的稳定 API key 标识；别名：`api_key_id`、`api-key-id`。 |
 | `index` | integer | 条件必填 | 从 0 开始的下标。 |
-| `value` | string or `APIKeyEntry` | 条件必填 | 和 `index` 配套的新值；支持结构化 entry。 |
+| `value` | string or `APIKeyEntry` | 条件必填 | 和 `id` 或 `index` 配套的新值；支持结构化 entry。 |
 | `old` | string | 条件必填 | 要查找的旧 key。 |
 | `new` | string | 条件必填 | 新 key；旧值不存在时追加。 |
-| `api_key` | string | 条件必填 | 直接修改绑定时的目标 key；也接受 `api-key`、`key`。 |
+| `api_key` | string | 条件必填 | 旧版原始 key selector；和 `id` 同时提交时必须匹配该记录；也接受 `api-key`、`key`。 |
 | `user_id` | integer | 否 | 绑定的 `user.id`；也接受 `user-id`；传 `0` 清空绑定。 |
 | `channels` | array of integer | 否 | Channel group IDs。 |
 | `model_groups` | array of integer | 否 | Model group IDs；也接受 `model-groups`。 |
 
-常规输出：
-
-```json
-{ "status": "ok" }
-```
-
-直接修改绑定时输出：
+成功输出：
 
 ```json
 {
   "api_key": {
+    "id": 1,
+    "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
     "user-id": 1,
@@ -1334,12 +1394,13 @@ Entry 字段：
 
 ### DELETE `/api-keys`
 
-按下标或值删除客户端 API key。
+删除一个客户端 API key。优先使用稳定 ID；下标和值 selector 继续作为兼容方式。
 
 Query 参数：
 
 | Query | 类型 | 说明 |
 | --- | --- | --- |
+| `id` | integer | 推荐使用的稳定 API key 标识；别名：`api_key_id`、`api-key-id`。 |
 | `index` | integer | 删除指定从 0 开始下标的 key。 |
 | `value` | string | 删除 trim 后匹配的 key。 |
 | `api_key` | string | `value` 的 alias。 |
@@ -1351,6 +1412,8 @@ Query 参数：
 ```json
 { "status": "ok" }
 ```
+
+未知 ID 返回 `404 api_key_not_found`。如果同时提交的 ID 和 key selector 指向不同记录，接口返回 `400 invalid_api_key_selector`。
 
 ## Billing
 

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -16,7 +16,11 @@ import (
 // ErrAPIKeyExists indicates that an API key value is already owned by another record.
 var ErrAPIKeyExists = errors.New("api key already exists")
 
+// ErrAPIKeySelectorMismatch indicates that multiple selectors do not identify the same API key.
+var ErrAPIKeySelectorMismatch = errors.New("api key selector mismatch")
+
 type APIKeyEntry struct {
+	ID          uint
 	APIKey      string
 	UserID      *uint
 	Channels    []uint
@@ -24,6 +28,7 @@ type APIKeyEntry struct {
 }
 
 type APIKeyEntryUpdate struct {
+	ID          uint
 	APIKey      string
 	UserID      *uint
 	Channels    *[]uint
@@ -34,6 +39,32 @@ type APIKeyUserUpdate struct {
 	APIKey      *string
 	Channels    *[]uint
 	ModelGroups *[]uint
+}
+
+type APIKeySelector struct {
+	ID     uint
+	APIKey string
+	Index  *int
+}
+
+type APIKeyAdminUpdate struct {
+	APIKey      *string
+	UserID      *uint
+	Channels    *[]uint
+	ModelGroups *[]uint
+}
+
+// IsAPIKeyConflictError reports whether an error is an API key uniqueness conflict.
+func IsAPIKeyConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAPIKeyExists) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unique constraint") ||
+		strings.Contains(message, "duplicate key")
 }
 
 // ListAPIKeyEntries returns API key rows with group bindings.
@@ -84,6 +115,214 @@ func (r *Repository) ReplaceAPIKeyEntries(ctx context.Context, entries []APIKeyE
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
 	return stats, errTransaction
+}
+
+// CreateAPIKey creates or restores one API key without replacing the full key list.
+func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate) (*APIKeyRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	key := strings.TrimSpace(update.APIKey)
+	if key == "" {
+		return nil, fmt.Errorf("api key is required")
+	}
+
+	userID := normalizeOptionalUserID(update.UserID)
+	channelsJSON := emptyAPIKeyChannelsJSON()
+	if update.Channels != nil {
+		var errChannels error
+		channelsJSON, errChannels = apiKeyChannelsJSON(*update.Channels)
+		if errChannels != nil {
+			return nil, errChannels
+		}
+	}
+	modelGroupsJSON := emptyAPIKeyModelGroupsJSON()
+	if update.ModelGroups != nil {
+		var errModelGroups error
+		modelGroupsJSON, errModelGroups = apiKeyModelGroupsJSON(*update.ModelGroups)
+		if errModelGroups != nil {
+			return nil, errModelGroups
+		}
+	}
+
+	record := &APIKeyRecord{}
+	ctx = contextOrBackground(ctx)
+	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if userID != nil {
+			if errUser := ensureUserExists(ctx, tx, *userID); errUser != nil {
+				return errUser
+			}
+		}
+
+		existing := &APIKeyRecord{}
+		errFirst := tx.WithContext(ctx).Unscoped().Where("api_key = ?", key).First(existing).Error
+		switch {
+		case errors.Is(errFirst, gorm.ErrRecordNotFound):
+			record.APIKey = key
+			record.UserID = userID
+			record.Channels = channelsJSON
+			record.ModelGroups = modelGroupsJSON
+			if errCreate := tx.WithContext(ctx).Create(record).Error; errCreate != nil {
+				if IsAPIKeyConflictError(errCreate) {
+					return ErrAPIKeyExists
+				}
+				return errCreate
+			}
+		case errFirst != nil:
+			return errFirst
+		case existing.DeletedAt.Valid:
+			if errRestore := tx.WithContext(ctx).Unscoped().
+				Model(&APIKeyRecord{}).
+				Where("id = ?", existing.ID).
+				Updates(map[string]any{
+					"user_id":      userID,
+					"channels":     channelsJSON,
+					"model_groups": modelGroupsJSON,
+					"deleted_at":   nil,
+				}).Error; errRestore != nil {
+				return errRestore
+			}
+			if errReload := tx.WithContext(ctx).Where("id = ?", existing.ID).First(record).Error; errReload != nil {
+				return errReload
+			}
+		default:
+			return ErrAPIKeyExists
+		}
+
+		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
+	})
+	if errTransaction != nil {
+		return nil, errTransaction
+	}
+	return record, nil
+}
+
+// UpdateAPIKey updates one API key selected by stable ID or a legacy selector.
+func (r *Repository) UpdateAPIKey(ctx context.Context, selector APIKeySelector, update APIKeyAdminUpdate) (*APIKeyRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	if errSelector := validateAPIKeySelector(selector); errSelector != nil {
+		return nil, errSelector
+	}
+
+	record := &APIKeyRecord{}
+	ctx = contextOrBackground(ctx)
+	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errFind := findAPIKeyRecord(ctx, tx, selector, record); errFind != nil {
+			return errFind
+		}
+		if update.APIKey != nil {
+			nextKey := strings.TrimSpace(*update.APIKey)
+			if nextKey == "" {
+				return fmt.Errorf("api key is required")
+			}
+			if nextKey != strings.TrimSpace(record.APIKey) {
+				if errAvailable := ensureAPIKeyValueAvailable(ctx, tx, nextKey, record.ID); errAvailable != nil {
+					return errAvailable
+				}
+			}
+			record.APIKey = nextKey
+		}
+		if update.UserID != nil {
+			nextUserID := normalizeOptionalUserID(update.UserID)
+			if nextUserID != nil {
+				if errUser := ensureUserExists(ctx, tx, *nextUserID); errUser != nil {
+					return errUser
+				}
+			}
+			record.UserID = nextUserID
+		}
+		if update.Channels != nil {
+			channelsJSON, errChannels := apiKeyChannelsJSON(*update.Channels)
+			if errChannels != nil {
+				return errChannels
+			}
+			record.Channels = channelsJSON
+		}
+		if update.ModelGroups != nil {
+			modelGroupsJSON, errModelGroups := apiKeyModelGroupsJSON(*update.ModelGroups)
+			if errModelGroups != nil {
+				return errModelGroups
+			}
+			record.ModelGroups = modelGroupsJSON
+		}
+		if errSave := tx.WithContext(ctx).Save(record).Error; errSave != nil {
+			if IsAPIKeyConflictError(errSave) {
+				return ErrAPIKeyExists
+			}
+			return errSave
+		}
+		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
+	})
+	if errTransaction != nil {
+		return nil, errTransaction
+	}
+	return record, nil
+}
+
+// DeleteAPIKey deletes one API key selected by stable ID or a legacy selector.
+func (r *Repository) DeleteAPIKey(ctx context.Context, selector APIKeySelector) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	if errSelector := validateAPIKeySelector(selector); errSelector != nil {
+		return errSelector
+	}
+
+	ctx = contextOrBackground(ctx)
+	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		record := &APIKeyRecord{}
+		if errFind := findAPIKeyRecord(ctx, tx, selector, record); errFind != nil {
+			return errFind
+		}
+		if errDelete := tx.WithContext(ctx).Delete(record).Error; errDelete != nil {
+			return errDelete
+		}
+		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
+	})
+}
+
+func validateAPIKeySelector(selector APIKeySelector) error {
+	if selector.ID > 0 && selector.Index != nil {
+		return ErrAPIKeySelectorMismatch
+	}
+	if selector.Index != nil && *selector.Index < 0 {
+		return fmt.Errorf("invalid api key index")
+	}
+	if selector.ID == 0 && selector.Index == nil && strings.TrimSpace(selector.APIKey) == "" {
+		return fmt.Errorf("api key selector is required")
+	}
+	return nil
+}
+
+func findAPIKeyRecord(ctx context.Context, tx *gorm.DB, selector APIKeySelector, record *APIKeyRecord) error {
+	if tx == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	if record == nil {
+		return fmt.Errorf("api key record is nil")
+	}
+
+	query := tx.WithContext(contextOrBackground(ctx))
+	switch {
+	case selector.ID > 0:
+		query = query.Where("id = ?", selector.ID)
+	case selector.Index != nil:
+		query = query.Order("id").Offset(*selector.Index)
+	default:
+		query = query.Where("api_key = ?", strings.TrimSpace(selector.APIKey))
+	}
+	if errFirst := query.First(record).Error; errFirst != nil {
+		return errFirst
+	}
+	if selector.ID > 0 && strings.TrimSpace(selector.APIKey) != "" && strings.TrimSpace(record.APIKey) != strings.TrimSpace(selector.APIKey) {
+		return ErrAPIKeySelectorMismatch
+	}
+	return nil
 }
 
 // UpdateAPIKeyBindings updates user and group bindings for one API key.
@@ -565,9 +804,11 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 	}
 
 	stats := APIKeyUpsertStats{}
+	existingByID := make(map[uint]*APIKeyRecord, len(existing))
 	existingByKey := make(map[string]*APIKeyRecord, len(existing))
 	for i := range existing {
 		record := &existing[i]
+		existingByID[record.ID] = record
 		key := strings.TrimSpace(record.APIKey)
 		if key == "" {
 			continue
@@ -575,13 +816,12 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 		existingByKey[key] = record
 	}
 
-	keep := make(map[string]struct{}, len(entries))
+	keepIDs := make(map[uint]struct{}, len(entries))
 	for _, entry := range entries {
 		key := strings.TrimSpace(entry.APIKey)
 		if key == "" {
 			continue
 		}
-		keep[key] = struct{}{}
 		userID := normalizeOptionalUserID(entry.UserID)
 		if userID != nil {
 			if errUser := ensureUserExists(ctx, tx, *userID); errUser != nil {
@@ -605,18 +845,30 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 			}
 		}
 
-		if record := existingByKey[key]; record != nil {
+		record := existingByID[entry.ID]
+		if record == nil {
+			record = existingByKey[key]
+		}
+		if record != nil {
+			if duplicate := existingByKey[key]; duplicate != nil && duplicate.ID != record.ID {
+				return APIKeyUpsertStats{}, ErrAPIKeyExists
+			}
+			keepIDs[record.ID] = struct{}{}
 			updates := make(map[string]any)
-			updatedBindings := false
+			updatedEntry := false
 			if record.DeletedAt.Valid {
 				updates["deleted_at"] = nil
 				stats.Restored++
 			} else {
 				stats.Unchanged++
 			}
+			if strings.TrimSpace(record.APIKey) != key {
+				updates["api_key"] = key
+				updatedEntry = true
+			}
 			if !sameOptionalUint(record.UserID, userID) {
 				updates["user_id"] = userID
-				updatedBindings = true
+				updatedEntry = true
 			}
 			if entry.Channels != nil {
 				currentChannels, errCurrent := apiKeyChannelsFromJSON(record.Channels)
@@ -625,7 +877,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 				}
 				if !reflect.DeepEqual(currentChannels, normalizeChannelGroupIDs(*entry.Channels)) {
 					updates["channels"] = channelsJSON
-					updatedBindings = true
+					updatedEntry = true
 				}
 			}
 			if entry.ModelGroups != nil {
@@ -635,10 +887,10 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 				}
 				if !reflect.DeepEqual(currentModelGroups, normalizeModelGroupIDs(*entry.ModelGroups)) {
 					updates["model_groups"] = modelGroupsJSON
-					updatedBindings = true
+					updatedEntry = true
 				}
 			}
-			if updatedBindings && !record.DeletedAt.Valid {
+			if updatedEntry && !record.DeletedAt.Valid {
 				stats.Updated++
 				stats.Unchanged--
 			}
@@ -653,23 +905,21 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 			continue
 		}
 
-		if errCreate := tx.WithContext(contextOrBackground(ctx)).Create(&APIKeyRecord{
+		created := APIKeyRecord{
 			APIKey:      key,
 			UserID:      userID,
 			Channels:    channelsJSON,
 			ModelGroups: modelGroupsJSON,
-		}).Error; errCreate != nil {
+		}
+		if errCreate := tx.WithContext(contextOrBackground(ctx)).Create(&created).Error; errCreate != nil {
 			return APIKeyUpsertStats{}, errCreate
 		}
+		keepIDs[created.ID] = struct{}{}
 		stats.Created++
 	}
 
 	for _, record := range existing {
-		key := strings.TrimSpace(record.APIKey)
-		if key == "" {
-			continue
-		}
-		if _, ok := keep[key]; ok {
+		if _, ok := keepIDs[record.ID]; ok {
 			continue
 		}
 		if record.DeletedAt.Valid {
@@ -698,7 +948,7 @@ func normalizeAPIKeyEntryUpdates(entries []APIKeyEntryUpdate) []APIKeyEntryUpdat
 			continue
 		}
 		seen[key] = struct{}{}
-		next := APIKeyEntryUpdate{APIKey: key}
+		next := APIKeyEntryUpdate{ID: entry.ID, APIKey: key}
 		next.UserID = normalizeOptionalUserID(entry.UserID)
 		if entry.Channels != nil {
 			channels := normalizeChannelGroupIDs(*entry.Channels)
@@ -726,6 +976,7 @@ func apiKeyEntryFromRecord(record *APIKeyRecord) (APIKeyEntry, error) {
 		return APIKeyEntry{}, errModelGroups
 	}
 	return APIKeyEntry{
+		ID:          record.ID,
 		APIKey:      strings.TrimSpace(record.APIKey),
 		UserID:      normalizeOptionalUserID(record.UserID),
 		Channels:    channels,

--- a/internal/cluster/management/api_keys.go
+++ b/internal/cluster/management/api_keys.go
@@ -26,6 +26,9 @@ type apiKeyEntryBody struct {
 }
 
 type apiKeyPatchBody struct {
+	ID              *uint           `json:"id"`
+	APIKeyID        *uint           `json:"api_key_id"`
+	APIKeyIDDash    *uint           `json:"api-key-id"`
 	Old             *string         `json:"old"`
 	New             *string         `json:"new"`
 	Index           *int            `json:"index"`
@@ -58,6 +61,8 @@ func apiKeyEntriesResponse(entries []cluster.APIKeyEntry) gin.H {
 		}
 		keys = append(keys, key)
 		items = append(items, gin.H{
+			"id":           entry.ID,
+			"api_key_id":   entry.ID,
 			"api-key":      key,
 			"api_key":      key,
 			"user-id":      optionalUserIDValue(entry.UserID),
@@ -158,69 +163,58 @@ func (b apiKeyEntryBody) userID() *uint {
 	return b.UserIDDash
 }
 
+func (h *Handler) createAPIKeyEntry(c *gin.Context) {
+	data, errData := c.GetRawData()
+	if errData != nil {
+		respondError(c, http.StatusBadRequest, "invalid_body", errData)
+		return
+	}
+	entry, errEntry := decodeAPIKeyEntry(data)
+	if errEntry != nil || strings.TrimSpace(entry.APIKey) == "" {
+		respondError(c, http.StatusBadRequest, "invalid_body", errEntry)
+		return
+	}
+
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	record, errCreate := h.repo.CreateAPIKey(ctx, entry)
+	if errCreate != nil {
+		respondAPIKeyMutationError(c, errCreate)
+		return
+	}
+	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+		return
+	}
+	responseEntry, errResponseEntry := clusterAPIKeyEntryFromRecord(record)
+	if errResponseEntry != nil {
+		respondError(c, http.StatusInternalServerError, "api_key_load_failed", errResponseEntry)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"api_key": apiKeyEntryToMap(responseEntry)})
+}
+
 func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 	var body apiKeyPatchBody
 	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
 		return fmt.Errorf("invalid body")
 	}
+	if body.id() != nil && (body.Index != nil || body.Old != nil) {
+		return fmt.Errorf("invalid api key selector")
+	}
 
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
 
-	userID := body.userID()
-	modelGroups := body.modelGroups()
-	if userID != nil || body.Channels != nil || modelGroups != nil {
-		key := body.apiKey()
-		if key == "" && len(body.Value) > 0 {
-			if entry, errEntry := decodeAPIKeyEntry(body.Value); errEntry == nil {
-				key = strings.TrimSpace(entry.APIKey)
-				if userID == nil {
-					userID = entry.UserID
-				}
-				if body.Channels == nil {
-					body.Channels = entry.Channels
-				}
-				if modelGroups == nil {
-					modelGroups = entry.ModelGroups
-				}
-			}
-		}
-		if key == "" {
-			return fmt.Errorf("missing api_key")
-		}
-		record, errUpdate := h.repo.UpdateAPIKeyBindings(ctx, key, userID, body.Channels, modelGroups)
-		if errUpdate != nil {
-			if errors.Is(errUpdate, cluster.ErrUserNotFound) {
-				respondError(c, http.StatusNotFound, "user_not_found", errUpdate)
-				return nil
-			}
-			if errors.Is(errUpdate, gorm.ErrRecordNotFound) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "api key not found"})
-				return nil
-			}
-			respondError(c, http.StatusInternalServerError, "write_failed", errUpdate)
-			return nil
-		}
-		entry, errEntry := clusterAPIKeyEntryFromRecord(record)
-		if errEntry != nil {
-			respondError(c, http.StatusInternalServerError, "api_key_load_failed", errEntry)
-			return nil
-		}
-		c.JSON(http.StatusOK, gin.H{"api_key": apiKeyEntryToMap(entry)})
-		return nil
-	}
+	selector := cluster.APIKeySelector{}
+	update := cluster.APIKeyAdminUpdate{}
+	appendIfMissing := false
 
-	entries, errEntries := h.repo.ListAPIKeyEntries(ctx)
-	if errEntries != nil {
-		respondError(c, http.StatusInternalServerError, "api_keys_load_failed", errEntries)
-		return nil
-	}
-
-	changed := false
 	if body.Index != nil && len(body.Value) > 0 {
-		if *body.Index < 0 || *body.Index >= len(entries) {
+		if *body.Index < 0 {
 			return fmt.Errorf("invalid index")
 		}
+		selector.Index = body.Index
 		next, errEntry := decodeAPIKeyEntry(body.Value)
 		if errEntry != nil {
 			return fmt.Errorf("invalid value")
@@ -228,53 +222,107 @@ func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 		if strings.TrimSpace(next.APIKey) == "" {
 			return fmt.Errorf("invalid value")
 		}
-		if next.Channels == nil {
-			channels := append([]uint(nil), entries[*body.Index].Channels...)
-			next.Channels = &channels
-		}
-		if next.ModelGroups == nil {
-			modelGroups := append([]uint(nil), entries[*body.Index].ModelGroups...)
-			next.ModelGroups = &modelGroups
-		}
-		if next.UserID == nil {
-			next.UserID = entries[*body.Index].UserID
-		}
-		entries[*body.Index] = cluster.APIKeyEntry{
-			APIKey:      strings.TrimSpace(next.APIKey),
-			UserID:      normalizeAPIKeyEntryUserID(next.UserID),
-			Channels:    uintsOrEmpty(next.Channels),
-			ModelGroups: uintsOrEmpty(next.ModelGroups),
-		}
-		changed = true
+		applyAPIKeyEntryUpdate(&update, next)
 	} else if body.Old != nil && body.New != nil {
 		oldKey := strings.TrimSpace(*body.Old)
 		newKey := strings.TrimSpace(*body.New)
 		if oldKey == "" || newKey == "" {
 			return fmt.Errorf("missing fields")
 		}
-		for i := range entries {
-			if strings.TrimSpace(entries[i].APIKey) != oldKey {
-				continue
+		selector.APIKey = oldKey
+		update.APIKey = &newKey
+		appendIfMissing = true
+	} else {
+		if id := body.id(); id != nil {
+			if *id == 0 {
+				return fmt.Errorf("invalid id")
 			}
-			entries[i].APIKey = newKey
-			changed = true
-			break
+			selector.ID = *id
+			selector.APIKey = body.apiKey()
+		} else {
+			selector.APIKey = body.apiKey()
 		}
-		if !changed {
-			entries = append(entries, cluster.APIKeyEntry{APIKey: newKey})
-			changed = true
+		if len(body.Value) > 0 {
+			next, errEntry := decodeAPIKeyEntry(body.Value)
+			if errEntry != nil {
+				return fmt.Errorf("invalid value")
+			}
+			applyAPIKeyEntryUpdate(&update, next)
 		}
-	}
-	if !changed {
-		return fmt.Errorf("missing fields")
+		if body.New != nil {
+			newKey := strings.TrimSpace(*body.New)
+			if newKey == "" {
+				return fmt.Errorf("invalid new value")
+			}
+			update.APIKey = &newKey
+		}
+		if userID := body.userID(); userID != nil {
+			update.UserID = userID
+		}
+		if body.Channels != nil {
+			update.Channels = body.Channels
+		}
+		if modelGroups := body.modelGroups(); modelGroups != nil {
+			update.ModelGroups = modelGroups
+		}
 	}
 
-	if _, errReplace := h.repo.ReplaceAPIKeyEntries(ctx, apiKeyEntryUpdatesFromEntries(entries)); errReplace != nil {
-		if errors.Is(errReplace, cluster.ErrUserNotFound) {
-			respondError(c, http.StatusNotFound, "user_not_found", errReplace)
-			return nil
+	if update.APIKey == nil && update.UserID == nil && update.Channels == nil && update.ModelGroups == nil {
+		return fmt.Errorf("missing fields")
+	}
+	if selector.ID == 0 && selector.Index == nil && strings.TrimSpace(selector.APIKey) == "" {
+		return fmt.Errorf("missing api key selector")
+	}
+
+	record, errUpdate := h.repo.UpdateAPIKey(ctx, selector, update)
+	if errUpdate != nil && appendIfMissing && errors.Is(errUpdate, gorm.ErrRecordNotFound) {
+		record, errUpdate = h.repo.CreateAPIKey(ctx, cluster.APIKeyEntryUpdate{APIKey: *update.APIKey})
+	}
+	if errUpdate != nil {
+		respondAPIKeyMutationError(c, errUpdate)
+		return nil
+	}
+	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+		return nil
+	}
+	responseEntry, errResponseEntry := clusterAPIKeyEntryFromRecord(record)
+	if errResponseEntry != nil {
+		respondError(c, http.StatusInternalServerError, "api_key_load_failed", errResponseEntry)
+		return nil
+	}
+	c.JSON(http.StatusOK, gin.H{"api_key": apiKeyEntryToMap(responseEntry)})
+	return nil
+}
+
+func (h *Handler) deleteAPIKeyEntry(c *gin.Context) error {
+	selector := cluster.APIKeySelector{}
+	if idRaw := firstNonEmptyQuery(c, "id", "api_key_id", "api-key-id"); idRaw != "" {
+		id, errID := strconv.ParseUint(idRaw, 10, 64)
+		if errID != nil || id == 0 {
+			return fmt.Errorf("invalid id")
 		}
-		respondError(c, http.StatusInternalServerError, "write_failed", errReplace)
+		selector.ID = uint(id)
+		selector.APIKey = firstNonEmptyQuery(c, "value", "api_key", "api-key", "key")
+	}
+	if idxRaw := c.Query("index"); idxRaw != "" {
+		index, errIndex := strconv.Atoi(idxRaw)
+		if errIndex != nil || index < 0 {
+			return fmt.Errorf("invalid index")
+		}
+		selector.Index = &index
+	}
+	if selector.ID == 0 && selector.Index == nil {
+		selector.APIKey = firstNonEmptyQuery(c, "value", "api_key", "api-key", "key")
+	}
+	if selector.ID == 0 && selector.Index == nil && strings.TrimSpace(selector.APIKey) == "" {
+		return fmt.Errorf("missing id, index, or value")
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+
+	if errDelete := h.repo.DeleteAPIKey(ctx, selector); errDelete != nil {
+		respondAPIKeyMutationError(c, errDelete)
 		return nil
 	}
 	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
@@ -285,52 +333,37 @@ func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 	return nil
 }
 
-func (h *Handler) deleteAPIKeyEntry(c *gin.Context) error {
-	ctx, cancel := h.requestContext(c)
-	defer cancel()
+func applyAPIKeyEntryUpdate(update *cluster.APIKeyAdminUpdate, entry cluster.APIKeyEntryUpdate) {
+	if update == nil {
+		return
+	}
+	if key := strings.TrimSpace(entry.APIKey); key != "" {
+		update.APIKey = &key
+	}
+	if entry.UserID != nil {
+		update.UserID = entry.UserID
+	}
+	if entry.Channels != nil {
+		update.Channels = entry.Channels
+	}
+	if entry.ModelGroups != nil {
+		update.ModelGroups = entry.ModelGroups
+	}
+}
 
-	entries, errEntries := h.repo.ListAPIKeyEntries(ctx)
-	if errEntries != nil {
-		respondError(c, http.StatusInternalServerError, "api_keys_load_failed", errEntries)
-		return nil
+func respondAPIKeyMutationError(c *gin.Context, err error) {
+	switch {
+	case cluster.IsAPIKeyConflictError(err):
+		respondError(c, http.StatusConflict, "api_key_exists", err)
+	case errors.Is(err, cluster.ErrUserNotFound):
+		respondError(c, http.StatusNotFound, "user_not_found", err)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		respondError(c, http.StatusNotFound, "api_key_not_found", err)
+	case errors.Is(err, cluster.ErrAPIKeySelectorMismatch):
+		respondError(c, http.StatusBadRequest, "invalid_api_key_selector", err)
+	default:
+		respondError(c, http.StatusInternalServerError, "write_failed", err)
 	}
-
-	deleted := false
-	if idxRaw := c.Query("index"); idxRaw != "" {
-		index, errIndex := strconv.Atoi(idxRaw)
-		if errIndex == nil && index >= 0 && index < len(entries) {
-			entries = append(entries[:index], entries[index+1:]...)
-			deleted = true
-		}
-	}
-	if !deleted {
-		key := firstNonEmptyQuery(c, "value", "api_key", "api-key", "key")
-		if key != "" {
-			next := make([]cluster.APIKeyEntry, 0, len(entries))
-			for _, entry := range entries {
-				if strings.TrimSpace(entry.APIKey) == key {
-					deleted = true
-					continue
-				}
-				next = append(next, entry)
-			}
-			entries = next
-		}
-	}
-	if !deleted {
-		return fmt.Errorf("missing index or value")
-	}
-
-	if _, errReplace := h.repo.ReplaceAPIKeyEntries(ctx, apiKeyEntryUpdatesFromEntries(entries)); errReplace != nil {
-		respondError(c, http.StatusInternalServerError, "write_failed", errReplace)
-		return nil
-	}
-	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
-		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
-		return nil
-	}
-	respondOK(c)
-	return nil
 }
 
 func (b apiKeyPatchBody) apiKey() string {
@@ -343,32 +376,6 @@ func (b apiKeyPatchBody) apiKey() string {
 		}
 	}
 	return ""
-}
-
-func apiKeyEntryUpdatesFromEntries(entries []cluster.APIKeyEntry) []cluster.APIKeyEntryUpdate {
-	updates := make([]cluster.APIKeyEntryUpdate, 0, len(entries))
-	for _, entry := range entries {
-		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
-			continue
-		}
-		channels := append([]uint(nil), entry.Channels...)
-		modelGroups := append([]uint(nil), entry.ModelGroups...)
-		updates = append(updates, cluster.APIKeyEntryUpdate{
-			APIKey:      key,
-			UserID:      normalizeAPIKeyEntryUserID(entry.UserID),
-			Channels:    &channels,
-			ModelGroups: &modelGroups,
-		})
-	}
-	return updates
-}
-
-func uintsOrEmpty(values *[]uint) []uint {
-	if values == nil {
-		return nil
-	}
-	return append([]uint(nil), *values...)
 }
 
 func clusterAPIKeyEntryFromRecord(record *cluster.APIKeyRecord) (cluster.APIKeyEntry, error) {
@@ -385,6 +392,8 @@ func apiKeyEntryToMap(entry cluster.APIKeyEntry) gin.H {
 		modelGroups = []uint{}
 	}
 	return gin.H{
+		"id":           entry.ID,
+		"api_key_id":   entry.ID,
 		"api-key":      strings.TrimSpace(entry.APIKey),
 		"api_key":      strings.TrimSpace(entry.APIKey),
 		"user-id":      optionalUserIDValue(entry.UserID),
@@ -406,6 +415,15 @@ func (b apiKeyPatchBody) userID() *uint {
 		return b.UserID
 	}
 	return b.UserIDDash
+}
+
+func (b apiKeyPatchBody) id() *uint {
+	for _, value := range []*uint{b.ID, b.APIKeyID, b.APIKeyIDDash} {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
 }
 
 func normalizeAPIKeyEntryUserID(userID *uint) *uint {

--- a/internal/cluster/management/config_compat.go
+++ b/internal/cluster/management/config_compat.go
@@ -434,6 +434,11 @@ func (h *Handler) GetAPIKeys(c *gin.Context) {
 	c.JSON(http.StatusOK, apiKeyEntriesResponse(entries))
 }
 
+// PostAPIKeys creates one API key.
+func (h *Handler) PostAPIKeys(c *gin.Context) {
+	h.createAPIKeyEntry(c)
+}
+
 // PutAPIKeys replaces an api keys.
 func (h *Handler) PutAPIKeys(c *gin.Context) {
 	data, errData := c.GetRawData()
@@ -449,6 +454,10 @@ func (h *Handler) PutAPIKeys(c *gin.Context) {
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
 	if _, errReplace := h.repo.ReplaceAPIKeyEntries(ctx, entries); errReplace != nil {
+		if cluster.IsAPIKeyConflictError(errReplace) {
+			respondError(c, http.StatusConflict, "api_key_exists", errReplace)
+			return
+		}
 		if errors.Is(errReplace, cluster.ErrUserNotFound) {
 			respondError(c, http.StatusNotFound, "user_not_found", errReplace)
 			return

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -192,6 +192,7 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodPatch, "/quota-exceeded/switch-preview-model", handler.PutSwitchPreviewModel)
 
 	r.Set(http.MethodGet, "/api-keys", handler.GetAPIKeys)
+	r.Set(http.MethodPost, "/api-keys", handler.PostAPIKeys)
 	r.Set(http.MethodPut, "/api-keys", handler.PutAPIKeys)
 	r.Set(http.MethodPatch, "/api-keys", handler.PatchAPIKeys)
 	r.Set(http.MethodDelete, "/api-keys", handler.DeleteAPIKeys)

--- a/internal/managementhttp/server_test.go
+++ b/internal/managementhttp/server_test.go
@@ -115,6 +115,7 @@ func TestClusterManagementAPIKeyUsageRouteRegistered(t *testing.T) {
 
 	for _, route := range []RouteKey{
 		{Method: http.MethodGet, Path: "/api-key-usage"},
+		{Method: http.MethodPost, Path: "/api-keys"},
 		{Method: http.MethodGet, Path: "/xai-api-key"},
 		{Method: http.MethodPut, Path: "/xai-api-key"},
 		{Method: http.MethodPatch, Path: "/xai-api-key"},


### PR DESCRIPTION
## Summary

- expose stable `id` and `api_key_id` fields in structured API key responses
- add `POST /api-keys` for atomic single-key creation
- restore soft-deleted keys with their original stable identifiers
- update `PATCH /api-keys` and `DELETE /api-keys` to support targeted mutations by stable ID
- return explicit conflict, not-found, and selector-mismatch error responses
- update the English and Chinese Management API documentation

## Compatibility

- preserve the existing raw `api-keys` response list and field aliases
- retain legacy `index`, raw-key, and `old`/`new` selectors
- keep `PUT /api-keys` as a full-list replacement operation
- preserve identifiers for unchanged key values during full replacement
- continue refreshing the database-backed runtime configuration after successful mutations

## API behavior

- duplicate active keys return `409 api_key_exists`
- unknown IDs return `404 api_key_not_found`
- missing users return `404 user_not_found`
- mismatched ID and key selectors return `400 invalid_api_key_selector`
- recreating an identical soft-deleted key restores the original record and ID

## Validation

- `gofmt -w .`
- `go build -o test-output ./cmd/home && rm test-output`
- `git diff --check`