### PR TITLE
fix(billing): group reports by requested timezone

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1464,7 +1464,9 @@ Unknown IDs return `404 api_key_not_found`. If an ID and key selector are both s
 
 All paths in this section are relative to the Management API base URL, for example `/v0/management/billing/overview` or `/v0/management/proxy/proxy-pools`. They are not `/user` routes and require the management key.
 
-Only `/billing/overview`, `/billing/charges`, and `/billing/balance-records` parse `from` and `to` as `YYYY-MM-DD`, RFC3339, or Unix seconds. Date-only values use UTC calendar dates, and a date-only `to` includes the whole ending UTC day. Explicit timestamp `to` values are inclusive exact instants and are not expanded. Clients that need a full natural day outside UTC should send RFC3339 boundaries with the intended timezone offset through the final nanosecond. Pagination with `limit` and `offset` applies only to `/billing/charges` and `/billing/balance-records`; those routes use `limit` default `50`, max `200`, and normalize negative `offset` values to `0`. `/billing/model-prices` supports only `provider`, `model`, and `enabled` query parameters. `/proxy/proxy-pools` currently does not parse query parameters.
+Only `/billing/overview`, `/billing/charges`, and `/billing/balance-records` parse `from` and `to` as `YYYY-MM-DD`, RFC3339, or Unix seconds. The optional `timezone` parameter defaults to `UTC` and must be an IANA timezone name. Date-only values use calendar dates in `timezone`, and a date-only `to` includes the whole ending day in that timezone. Explicit timestamps are exact instants and are not shifted or expanded by `timezone`. `/billing/overview` also uses `timezone` for `range` calendar dates and `daily_trend` buckets, so one natural day is not split at UTC midnight. Pagination with `limit` and `offset` applies only to `/billing/charges` and `/billing/balance-records`; those routes use `limit` default `50`, max `200`, and normalize negative `offset` values to `0`. `/billing/model-prices` supports only `provider`, `model`, and `enabled` query parameters. `/proxy/proxy-pools` currently does not parse query parameters.
+
+Unsupported timezone names return `400 invalid_timezone`. A `from` value after `to` returns `400 invalid_time_range`.
 
 ### GET `/billing/overview`
 
@@ -1475,7 +1477,8 @@ Query parameters:
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `from` | string | Optional start time: `YYYY-MM-DD`, RFC3339, or Unix seconds. |
-| `to` | string | Optional end time. Date-only values include the full UTC day. |
+| `to` | string | Optional inclusive end time. Date-only values include the full ending day in `timezone`. |
+| `timezone` | string | IANA timezone for date-only boundaries, response range dates, and daily trend buckets. Default `UTC`. |
 | `user` | string | Optional username, user text, or user ID filter. Aliases: `user_text`, `username`. |
 | `user_id` | integer | Optional exact user ID filter. Alias: `uid`. |
 | `provider` | string | Optional provider filter. |
@@ -1485,7 +1488,7 @@ Response fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `range` | object | Applied `from` and `to` range. |
+| `range` | object | Applied calendar `from`, `to`, and `timezone` range. |
 | `total_charge_amount` | number | Total charged amount. |
 | `total_recharge_amount` | number | Total recharge amount. |
 | `total_deduct_amount` | number | Total manual deduction amount. |
@@ -1495,7 +1498,7 @@ Response fields:
 | `output_tokens` | integer | Total output tokens. |
 | `cache_tokens` | integer | Total cache tokens. |
 | `active_user_count` | integer | Number of users with charges in the range. |
-| `daily_trend[]` | array | Daily charge amount and request count. |
+| `daily_trend[]` | array | Daily charge amount and request count grouped in `range.timezone`. |
 | `top_users[]` | array | Top users with `id`, `label`, `amount`, and `request_count`. |
 | `top_models[]` | array | Top models with `id`, `label`, `amount`, and `request_count`. |
 | `top_providers[]` | array | Top providers with `id`, `label`, `amount`, and `request_count`. |
@@ -1509,7 +1512,8 @@ Query parameters:
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `from` | string | Optional start time: `YYYY-MM-DD`, RFC3339, or Unix seconds. |
-| `to` | string | Optional end time. Date-only values include the full UTC day. |
+| `to` | string | Optional inclusive end time. Date-only values include the full ending day in `timezone`. |
+| `timezone` | string | IANA timezone for date-only boundaries. Default `UTC`. |
 | `user` | string | Optional username, user text, or user ID filter. Aliases: `user_text`, `username`. |
 | `user_id` | integer | Optional exact user ID filter. Alias: `uid`. |
 | `provider` | string | Optional provider filter. |
@@ -1559,7 +1563,8 @@ Query parameters:
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `from` | string | Optional start time: `YYYY-MM-DD`, RFC3339, or Unix seconds. |
-| `to` | string | Optional end time. Date-only values include the full UTC day. |
+| `to` | string | Optional inclusive end time. Date-only values include the full ending day in `timezone`. |
+| `timezone` | string | IANA timezone for date-only boundaries. Default `UTC`. |
 | `user` | string | Optional username, user text, or user ID filter. Aliases: `user_text`, `username`. |
 | `user_id` | integer | Optional exact user ID filter. Alias: `uid`. |
 | `limit` | integer | Optional page size. Default `50`, max `200`. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1464,7 +1464,9 @@ Query 参数：
 
 本节所有路径都相对于 Management API 基础 URL，例如 `/v0/management/billing/overview` 或 `/v0/management/proxy/proxy-pools`。这些不是 `/user` 路由，调用时需要管理密钥。
 
-只有 `/billing/overview`、`/billing/charges` 和 `/billing/balance-records` 会将 `from` 和 `to` 解析为 `YYYY-MM-DD`、RFC3339 或 Unix 秒。纯日期值使用 UTC 日历日期，只有日期的 `to` 会包含结束 UTC 日期的完整一天。显式时间戳形式的 `to` 是包含在结果内的精确时刻，不会自动扩展。需要查询完整非 UTC 自然日的客户端应发送带目标时区偏移且覆盖到最后一纳秒的 RFC3339 边界。分页参数 `limit` 和 `offset` 仅适用于 `/billing/charges` 和 `/billing/balance-records`；这些路由的 `limit` 默认值为 `50`，最大值为 `200`，负数 `offset` 会规范化为 `0`。`/billing/model-prices` 仅支持 `provider`、`model` 和 `enabled` 查询参数。`/proxy/proxy-pools` 当前不解析查询参数。
+只有 `/billing/overview`、`/billing/charges` 和 `/billing/balance-records` 会将 `from` 和 `to` 解析为 `YYYY-MM-DD`、RFC3339 或 Unix 秒。可选的 `timezone` 参数默认为 `UTC`，并且必须是 IANA 时区名称。纯日期值使用 `timezone` 中的日历日期，纯日期形式的 `to` 会包含该时区结束日期的完整一天。显式时间戳表示精确时刻，不会因 `timezone` 被移动或扩展。`/billing/overview` 还使用 `timezone` 生成 `range` 日历日期和 `daily_trend` 分桶，因此一个自然日不会在 UTC 午夜被拆成两天。分页参数 `limit` 和 `offset` 仅适用于 `/billing/charges` 和 `/billing/balance-records`；这些路由的 `limit` 默认值为 `50`，最大值为 `200`，负数 `offset` 会规范化为 `0`。`/billing/model-prices` 仅支持 `provider`、`model` 和 `enabled` 查询参数。`/proxy/proxy-pools` 当前不解析查询参数。
+
+不支持的时区名称返回 `400 invalid_timezone`。`from` 晚于 `to` 时返回 `400 invalid_time_range`。
 
 ### GET `/billing/overview`
 
@@ -1475,7 +1477,8 @@ Query 参数：
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
 | `from` | string | 可选开始时间：`YYYY-MM-DD`、RFC3339 或 Unix 秒。 |
-| `to` | string | 可选结束时间；只有日期时包含完整 UTC 当天。 |
+| `to` | string | 可选结束时间，包含该时刻；纯日期值包含 `timezone` 中结束日期的完整一天。 |
+| `timezone` | string | 用于纯日期边界、响应范围日期和每日趋势分桶的 IANA 时区；默认 `UTC`。 |
 | `user` | string | 可选用户名、用户文本或用户 ID 过滤；别名：`user_text`、`username`。 |
 | `user_id` | integer | 可选精确用户 ID 过滤；别名：`uid`。 |
 | `provider` | string | 可选 provider 过滤。 |
@@ -1485,7 +1488,7 @@ Query 参数：
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `range` | object | 实际使用的 `from` 和 `to` 范围。 |
+| `range` | object | 实际使用的日历 `from`、`to` 和 `timezone` 范围。 |
 | `total_charge_amount` | number | 总扣费金额。 |
 | `total_recharge_amount` | number | 总充值金额。 |
 | `total_deduct_amount` | number | 总手工扣减金额。 |
@@ -1495,7 +1498,7 @@ Query 参数：
 | `output_tokens` | integer | output token 总数。 |
 | `cache_tokens` | integer | cache token 总数。 |
 | `active_user_count` | integer | 范围内有扣费记录的用户数量。 |
-| `daily_trend[]` | array | 每日扣费金额和请求数量。 |
+| `daily_trend[]` | array | 按 `range.timezone` 分组的每日扣费金额和请求数量。 |
 | `top_users[]` | array | 用户排行，字段为 `id`、`label`、`amount`、`request_count`。 |
 | `top_models[]` | array | 模型排行，字段为 `id`、`label`、`amount`、`request_count`。 |
 | `top_providers[]` | array | Provider 排行，字段为 `id`、`label`、`amount`、`request_count`。 |
@@ -1509,7 +1512,8 @@ Query 参数：
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
 | `from` | string | 可选开始时间：`YYYY-MM-DD`、RFC3339 或 Unix 秒。 |
-| `to` | string | 可选结束时间；只有日期时包含完整 UTC 当天。 |
+| `to` | string | 可选结束时间，包含该时刻；纯日期值包含 `timezone` 中结束日期的完整一天。 |
+| `timezone` | string | 用于纯日期边界的 IANA 时区；默认 `UTC`。 |
 | `user` | string | 可选用户名、用户文本或用户 ID 过滤；别名：`user_text`、`username`。 |
 | `user_id` | integer | 可选精确用户 ID 过滤；别名：`uid`。 |
 | `provider` | string | 可选 provider 过滤。 |
@@ -1559,7 +1563,8 @@ Query 参数：
 | 参数 | 类型 | 说明 |
 | --- | --- | --- |
 | `from` | string | 可选开始时间：`YYYY-MM-DD`、RFC3339 或 Unix 秒。 |
-| `to` | string | 可选结束时间；只有日期时包含完整 UTC 当天。 |
+| `to` | string | 可选结束时间，包含该时刻；纯日期值包含 `timezone` 中结束日期的完整一天。 |
+| `timezone` | string | 用于纯日期边界的 IANA 时区；默认 `UTC`。 |
 | `user` | string | 可选用户名、用户文本或用户 ID 过滤；别名：`user_text`、`username`。 |
 | `user_id` | integer | 可选精确用户 ID 过滤；别名：`uid`。 |
 | `limit` | integer | 可选分页大小；默认 `50`，最大 `200`。 |

--- a/internal/cluster/billing.go
+++ b/internal/cluster/billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -144,6 +145,7 @@ type BillingBalanceUpdate struct {
 type BillingOverviewQuery struct {
 	From     *time.Time
 	To       *time.Time
+	Timezone string
 	UserText string
 	UserID   *uint
 	Provider string
@@ -168,8 +170,9 @@ type BillingOverview struct {
 }
 
 type BillingRange struct {
-	From string
-	To   string
+	From     string
+	To       string
+	Timezone string
 }
 
 type BillingTrendPoint struct {
@@ -475,6 +478,8 @@ func (r *Repository) BillingOverview(ctx context.Context, query BillingOverviewQ
 		OutputTokens      int64
 		CacheTokens       int64
 		ActiveUserCount   int64
+		MinCreatedAt      sql.NullString `gorm:"column:min_created_at"`
+		MaxCreatedAt      sql.NullString `gorm:"column:max_created_at"`
 	}
 	if errScan := chargeScope.Select(`
 		COALESCE(SUM("billing_charge"."amount"), 0) AS total_charge_amount,
@@ -482,7 +487,9 @@ func (r *Repository) BillingOverview(ctx context.Context, query BillingOverviewQ
 		COALESCE(SUM("billing_charge"."input_tokens"), 0) AS input_tokens,
 		COALESCE(SUM("billing_charge"."output_tokens"), 0) AS output_tokens,
 		COALESCE(SUM("billing_charge"."cache_tokens"), 0) AS cache_tokens,
-		COUNT(DISTINCT "billing_charge"."user_id") AS active_user_count`,
+		COUNT(DISTINCT "billing_charge"."user_id") AS active_user_count,
+		MIN("billing_charge"."created_at") AS min_created_at,
+		MAX("billing_charge"."created_at") AS max_created_at`,
 	).Scan(&chargeTotals).Error; errScan != nil {
 		return BillingOverview{}, errScan
 	}
@@ -493,7 +500,10 @@ func (r *Repository) BillingOverview(ctx context.Context, query BillingOverviewQ
 		return BillingOverview{}, errBalance
 	}
 
-	dailyTrend, errDailyTrend := billingDailyTrend(ctx, db, chargeQuery)
+	dailyTrend, errDailyTrend := billingDailyTrend(ctx, db, chargeQuery, query.Timezone, billingTrendBounds{
+		MinCreatedAt: chargeTotals.MinCreatedAt,
+		MaxCreatedAt: chargeTotals.MaxCreatedAt,
+	})
 	if errDailyTrend != nil {
 		return BillingOverview{}, errDailyTrend
 	}
@@ -515,7 +525,7 @@ func (r *Repository) BillingOverview(ctx context.Context, query BillingOverviewQ
 	}
 
 	return BillingOverview{
-		Range:               billingRange(query.From, query.To),
+		Range:               billingRange(query.From, query.To, query.Timezone),
 		TotalChargeAmount:   chargeTotals.TotalChargeAmount,
 		TotalRechargeAmount: ledgerTotals.RechargeAmount,
 		TotalDeductAmount:   ledgerTotals.DeductAmount,
@@ -849,13 +859,19 @@ type billingLedgerSummary struct {
 	DeductAmount   float64
 }
 
-func billingRange(from *time.Time, to *time.Time) BillingRange {
-	result := BillingRange{}
+type billingTrendBounds struct {
+	MinCreatedAt sql.NullString
+	MaxCreatedAt sql.NullString
+}
+
+func billingRange(from *time.Time, to *time.Time, timezone string) BillingRange {
+	timezone, location := billingTimezoneLocation(timezone)
+	result := BillingRange{Timezone: timezone}
 	if from != nil {
-		result.From = from.UTC().Format("2006-01-02")
+		result.From = from.UTC().In(location).Format(time.DateOnly)
 	}
 	if to != nil {
-		result.To = to.UTC().Format("2006-01-02")
+		result.To = to.UTC().In(location).Format(time.DateOnly)
 	}
 	return result
 }
@@ -890,11 +906,11 @@ func billingLedgerTotals(ctx context.Context, db *gorm.DB, query BillingOverview
 	return summary, nil
 }
 
-func billingDailyTrend(ctx context.Context, db *gorm.DB, query BillingChargeQuery) ([]BillingTrendPoint, error) {
+func billingDailyTrend(ctx context.Context, db *gorm.DB, query BillingChargeQuery, timezone string, bounds billingTrendBounds) ([]BillingTrendPoint, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database connection is nil")
 	}
-	dateExpr := billingDateExpression(db, `"billing_charge"."created_at"`)
+	dateExpr, dateArgs := billingDateExpression(db, `"billing_charge"."created_at"`, timezone, bounds)
 	scope := billingChargeQueryScope(db.WithContext(contextOrBackground(ctx)).Model(&BillingChargeRecord{}), query)
 	var rows []struct {
 		Date         string
@@ -904,7 +920,7 @@ func billingDailyTrend(ctx context.Context, db *gorm.DB, query BillingChargeQuer
 	if errScan := scope.Select(fmt.Sprintf(
 		`%s AS date, COALESCE(SUM("billing_charge"."amount"), 0) AS charge_amount, COUNT(*) AS request_count`,
 		dateExpr,
-	)).Group(dateExpr).Order("date ASC").Scan(&rows).Error; errScan != nil {
+	), dateArgs...).Group("date").Order("date ASC").Scan(&rows).Error; errScan != nil {
 		return nil, errScan
 	}
 	out := make([]BillingTrendPoint, 0, len(rows))
@@ -1053,11 +1069,67 @@ func billingUserBalanceQueryScope(scope *gorm.DB, query BillingOverviewQuery) *g
 	return scope
 }
 
-func billingDateExpression(db *gorm.DB, column string) string {
+func billingDateExpression(db *gorm.DB, column string, timezone string, bounds billingTrendBounds) (string, []any) {
+	timezone, location := billingTimezoneLocation(timezone)
 	if db != nil && db.Dialector != nil && db.Dialector.Name() == "postgres" {
-		return fmt.Sprintf("TO_CHAR(%s, 'YYYY-MM-DD')", column)
+		return fmt.Sprintf("TO_CHAR(timezone(?, %s), 'YYYY-MM-DD')", column), []any{timezone}
 	}
-	return fmt.Sprintf("strftime('%%Y-%%m-%%d', %s)", column)
+	start, end := billingTrendRange(bounds)
+	reference := start
+	if reference.IsZero() {
+		reference = end
+	}
+	if reference.IsZero() {
+		reference = time.Now().UTC()
+	}
+	_, offsetSeconds := reference.In(location).Zone()
+	fallback := fmt.Sprintf("strftime('%%Y-%%m-%%d', %s, '%+d seconds')", column, offsetSeconds)
+	if start.IsZero() || end.IsZero() || !usageObservabilityTimezoneOffsetChanges(location, start, end) {
+		return fallback, nil
+	}
+	segments := usageObservabilityTrendBucketCaseSegments("day", location, start, end)
+	if len(segments) == 0 {
+		return fallback, nil
+	}
+	unixExpr := fmt.Sprintf("CAST(strftime('%%s', %s) AS INTEGER)", column)
+	var builder strings.Builder
+	builder.WriteString("CASE")
+	for _, segment := range segments {
+		date := time.Unix(segment.BucketUnix, 0).UTC().In(location).Format(time.DateOnly)
+		builder.WriteString(fmt.Sprintf(" WHEN %s >= %d AND %s < %d THEN '%s'", unixExpr, segment.StartUnix, unixExpr, segment.EndUnix, date))
+	}
+	builder.WriteString(" ELSE ")
+	builder.WriteString(fallback)
+	builder.WriteString(" END")
+	return builder.String(), nil
+}
+
+func billingTimezoneLocation(timezone string) (string, *time.Location) {
+	value := strings.TrimSpace(timezone)
+	if value == "" {
+		return "UTC", time.UTC
+	}
+	location, errLoad := time.LoadLocation(value)
+	if errLoad != nil {
+		return "UTC", time.UTC
+	}
+	return value, location
+}
+
+func billingTrendRange(bounds billingTrendBounds) (time.Time, time.Time) {
+	var start time.Time
+	var end time.Time
+	if bounds.MinCreatedAt.Valid {
+		if parsedStart, ok := usageObservabilityAggregateTime(bounds.MinCreatedAt.String); ok {
+			start = parsedStart.UTC()
+		}
+	}
+	if bounds.MaxCreatedAt.Valid {
+		if parsedEnd, ok := usageObservabilityAggregateTime(bounds.MaxCreatedAt.String); ok {
+			end = parsedEnd.UTC()
+		}
+	}
+	return start, end
 }
 
 func billingBalanceQueryScope(scope *gorm.DB, query BillingBalanceQuery) *gorm.DB {

--- a/internal/cluster/billing_test.go
+++ b/internal/cluster/billing_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -1069,6 +1070,9 @@ func TestBillingOverviewAggregatesChargesAndBalances(t *testing.T) {
 	if overview.Range.To != "2026-12-31" {
 		t.Fatalf("range to = %q, want 2026-12-31", overview.Range.To)
 	}
+	if overview.Range.Timezone != "UTC" {
+		t.Fatalf("range timezone = %q, want UTC", overview.Range.Timezone)
+	}
 	if overview.TotalRechargeAmount != 50 {
 		t.Fatalf("total recharge = %v, want 50", overview.TotalRechargeAmount)
 	}
@@ -1101,6 +1105,102 @@ func TestBillingOverviewAggregatesChargesAndBalances(t *testing.T) {
 	}
 	if overview.TopProviders[0].ID != "openai" || overview.TopProviders[0].Label != "openai" || overview.TopProviders[0].Amount != 2 || overview.TopProviders[0].RequestCount != 1 {
 		t.Fatalf("top provider = %#v, want openai amount 2 request count 1", overview.TopProviders[0])
+	}
+}
+
+func TestBillingOverviewGroupsDailyTrendByTimezone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	username := "timezone@example.com"
+	credits := 100.0
+	user, errCreateUser := repo.CreateUser(ctx, UserUpdate{Username: &username, Credits: &credits})
+	if errCreateUser != nil {
+		t.Fatalf("CreateUser() error = %v", errCreateUser)
+	}
+	key := "timezone-client-key"
+	if _, errKey := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{APIKey: &key}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	if _, errPrice := repo.CreateBillingModelPrice(ctx, BillingModelPriceUpdate{Provider: "openai", Model: "gpt-4.1-mini", RequestPrice: 1, Enabled: true}); errPrice != nil {
+		t.Fatalf("CreateBillingModelPrice() error = %v", errPrice)
+	}
+
+	payloads := []string{
+		`{"timestamp":"2026-06-09T17:00:00Z","provider":"openai","model":"gpt-4.1-mini","api_key":"timezone-client-key","request_id":"req-local-morning","tokens":{"input_tokens":1,"total_tokens":1}}`,
+		`{"timestamp":"2026-06-10T09:00:00Z","provider":"openai","model":"gpt-4.1-mini","api_key":"timezone-client-key","request_id":"req-local-evening","tokens":{"input_tokens":1,"total_tokens":1}}`,
+		`{"timestamp":"2026-03-08T09:00:00Z","provider":"openai","model":"gpt-4.1-mini","api_key":"timezone-client-key","request_id":"req-dst-before","tokens":{"input_tokens":1,"total_tokens":1}}`,
+		`{"timestamp":"2026-03-08T10:30:00Z","provider":"openai","model":"gpt-4.1-mini","api_key":"timezone-client-key","request_id":"req-dst-after","tokens":{"input_tokens":1,"total_tokens":1}}`,
+	}
+	for _, payload := range payloads {
+		if _, errUsage := repo.AppendUsage(ctx, payload, "192.0.2.10"); errUsage != nil {
+			t.Fatalf("AppendUsage() error = %v", errUsage)
+		}
+	}
+
+	from := time.Date(2026, time.June, 9, 16, 0, 0, 0, time.UTC)
+	to := time.Date(2026, time.June, 10, 15, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+	overview, errOverview := repo.BillingOverview(ctx, BillingOverviewQuery{From: &from, To: &to, Timezone: "Asia/Shanghai"})
+	if errOverview != nil {
+		t.Fatalf("BillingOverview(Asia/Shanghai) error = %v", errOverview)
+	}
+	if overview.RequestCount != 2 || overview.TotalChargeAmount != 2 {
+		t.Fatalf("overview totals = requests %d amount %v, want 2 and 2", overview.RequestCount, overview.TotalChargeAmount)
+	}
+	if overview.Range.From != "2026-06-10" || overview.Range.To != "2026-06-10" || overview.Range.Timezone != "Asia/Shanghai" {
+		t.Fatalf("overview range = %#v, want 2026-06-10 in Asia/Shanghai", overview.Range)
+	}
+	if len(overview.DailyTrend) != 1 {
+		t.Fatalf("daily trend count = %d, want 1; trend = %#v", len(overview.DailyTrend), overview.DailyTrend)
+	}
+	if overview.DailyTrend[0].Date != "2026-06-10" || overview.DailyTrend[0].ChargeAmount != 2 || overview.DailyTrend[0].RequestCount != 2 {
+		t.Fatalf("daily trend = %#v, want 2026-06-10 amount 2 request count 2", overview.DailyTrend[0])
+	}
+
+	utcOverview, errUTCOverview := repo.BillingOverview(ctx, BillingOverviewQuery{From: &from, To: &to})
+	if errUTCOverview != nil {
+		t.Fatalf("BillingOverview(UTC) error = %v", errUTCOverview)
+	}
+	if len(utcOverview.DailyTrend) != 2 {
+		t.Fatalf("UTC daily trend count = %d, want 2; trend = %#v", len(utcOverview.DailyTrend), utcOverview.DailyTrend)
+	}
+	if utcOverview.DailyTrend[0].Date != "2026-06-09" || utcOverview.DailyTrend[1].Date != "2026-06-10" {
+		t.Fatalf("UTC daily trend = %#v, want June 9 and June 10", utcOverview.DailyTrend)
+	}
+
+	dstFrom := time.Date(2026, time.March, 8, 8, 0, 0, 0, time.UTC)
+	dstTo := time.Date(2026, time.March, 9, 6, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+	dstOverview, errDSTOverview := repo.BillingOverview(ctx, BillingOverviewQuery{From: &dstFrom, To: &dstTo, Timezone: "America/Los_Angeles"})
+	if errDSTOverview != nil {
+		t.Fatalf("BillingOverview(America/Los_Angeles) error = %v", errDSTOverview)
+	}
+	if dstOverview.RequestCount != 2 || len(dstOverview.DailyTrend) != 1 {
+		t.Fatalf("DST overview = requests %d trend %#v, want 2 requests in one day", dstOverview.RequestCount, dstOverview.DailyTrend)
+	}
+	if dstOverview.Range.From != "2026-03-08" || dstOverview.Range.To != "2026-03-08" || dstOverview.DailyTrend[0].Date != "2026-03-08" {
+		t.Fatalf("DST range/trend = range %#v trend %#v, want March 8", dstOverview.Range, dstOverview.DailyTrend)
+	}
+}
+
+func TestBillingDateExpressionUsesPostgresTimezone(t *testing.T) {
+	t.Parallel()
+
+	db, errOpen := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=127.0.0.1 user=cliproxy dbname=cliproxy_home sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{DisableAutomaticPing: true})
+	if errOpen != nil {
+		t.Fatalf("open postgres dry-run db: %v", errOpen)
+	}
+	expression, args := billingDateExpression(db, `"billing_charge"."created_at"`, "Asia/Shanghai", billingTrendBounds{})
+	if expression != `TO_CHAR(timezone(?, "billing_charge"."created_at"), 'YYYY-MM-DD')` {
+		t.Fatalf("expression = %q", expression)
+	}
+	if len(args) != 1 || args[0] != "Asia/Shanghai" {
+		t.Fatalf("args = %#v, want Asia/Shanghai", args)
 	}
 }
 

--- a/internal/cluster/management/billing.go
+++ b/internal/cluster/management/billing.go
@@ -483,8 +483,9 @@ func billingOverviewResponse(overview cluster.BillingOverview) gin.H {
 	}
 	return gin.H{
 		"range": gin.H{
-			"from": overview.Range.From,
-			"to":   overview.Range.To,
+			"from":     overview.Range.From,
+			"to":       overview.Range.To,
+			"timezone": overview.Range.Timezone,
 		},
 		"total_charge_amount":   overview.TotalChargeAmount,
 		"total_recharge_amount": overview.TotalRechargeAmount,
@@ -533,7 +534,7 @@ func billingBalanceRecordResponse(record *cluster.BillingBalanceRecord) gin.H {
 }
 
 func billingOverviewQueryFromRequest(c *gin.Context) (cluster.BillingOverviewQuery, bool) {
-	from, to, ok := billingRangeQueryFromRequest(c)
+	from, to, timezone, ok := billingRangeQueryFromRequest(c)
 	if !ok {
 		return cluster.BillingOverviewQuery{}, false
 	}
@@ -544,6 +545,7 @@ func billingOverviewQueryFromRequest(c *gin.Context) (cluster.BillingOverviewQue
 	return cluster.BillingOverviewQuery{
 		From:     from,
 		To:       to,
+		Timezone: timezone,
 		UserText: firstNonEmptyQuery(c, "user", "user_text", "username"),
 		UserID:   userID,
 		Provider: firstNonEmptyQuery(c, "provider"),
@@ -552,7 +554,7 @@ func billingOverviewQueryFromRequest(c *gin.Context) (cluster.BillingOverviewQue
 }
 
 func billingChargeQueryFromRequest(c *gin.Context) (cluster.BillingChargeQuery, bool) {
-	from, to, ok := billingRangeQueryFromRequest(c)
+	from, to, _, ok := billingRangeQueryFromRequest(c)
 	if !ok {
 		return cluster.BillingChargeQuery{}, false
 	}
@@ -577,7 +579,7 @@ func billingChargeQueryFromRequest(c *gin.Context) (cluster.BillingChargeQuery, 
 }
 
 func billingBalanceQueryFromRequest(c *gin.Context) (cluster.BillingBalanceQuery, bool) {
-	from, to, ok := billingRangeQueryFromRequest(c)
+	from, to, _, ok := billingRangeQueryFromRequest(c)
 	if !ok {
 		return cluster.BillingBalanceQuery{}, false
 	}
@@ -612,28 +614,37 @@ func clusterBillingPagination(limit int, offset int) (int, int) {
 	return limit, offset
 }
 
-func billingRangeQueryFromRequest(c *gin.Context) (*time.Time, *time.Time, bool) {
-	from, _, ok := billingTimeQuery(c, "from")
-	if !ok {
-		return nil, nil, false
+func billingRangeQueryFromRequest(c *gin.Context) (*time.Time, *time.Time, string, bool) {
+	location, timezone, errTimezone := parseUsageTimezone(c.Query("timezone"))
+	if errTimezone != nil {
+		respondUsageHTTPError(c, errTimezone)
+		return nil, nil, "", false
 	}
-	to, toDateOnly, ok := billingTimeQuery(c, "to")
+	from, _, ok := billingTimeQuery(c, "from", location)
 	if !ok {
-		return nil, nil, false
+		return nil, nil, "", false
+	}
+	to, toDateOnly, ok := billingTimeQuery(c, "to", location)
+	if !ok {
+		return nil, nil, "", false
 	}
 	if to != nil && toDateOnly {
-		normalized := endOfBillingDate(*to)
+		normalized := endOfBillingDate(*to, location)
 		to = &normalized
 	}
-	return from, to, true
+	if from != nil && to != nil && from.After(*to) {
+		respondError(c, http.StatusBadRequest, "invalid_time_range", fmt.Errorf("from must not be after to"))
+		return nil, nil, "", false
+	}
+	return from, to, timezone, true
 }
 
-func billingTimeQuery(c *gin.Context, key string) (*time.Time, bool, bool) {
+func billingTimeQuery(c *gin.Context, key string, location *time.Location) (*time.Time, bool, bool) {
 	raw := strings.TrimSpace(c.Query(key))
 	if raw == "" {
 		return nil, false, true
 	}
-	parsed, dateOnly, errParse := parseBillingTime(raw)
+	parsed, dateOnly, errParse := parseBillingTime(raw, location)
 	if errParse != nil {
 		respondError(c, http.StatusBadRequest, "invalid_"+key, errParse)
 		return nil, false, false
@@ -641,9 +652,12 @@ func billingTimeQuery(c *gin.Context, key string) (*time.Time, bool, bool) {
 	return &parsed, dateOnly, true
 }
 
-func parseBillingTime(raw string) (time.Time, bool, error) {
+func parseBillingTime(raw string, location *time.Location) (time.Time, bool, error) {
 	raw = strings.TrimSpace(raw)
-	if parsed, errDate := time.ParseInLocation("2006-01-02", raw, time.UTC); errDate == nil {
+	if location == nil {
+		location = time.UTC
+	}
+	if parsed, errDate := time.ParseInLocation("2006-01-02", raw, location); errDate == nil {
 		return parsed.UTC(), true, nil
 	}
 	if parsed, errRFC3339 := time.Parse(time.RFC3339Nano, raw); errRFC3339 == nil {
@@ -656,9 +670,12 @@ func parseBillingTime(raw string) (time.Time, bool, error) {
 	return time.Time{}, false, fmt.Errorf("time must be YYYY-MM-DD, RFC3339, or unix seconds")
 }
 
-func endOfBillingDate(value time.Time) time.Time {
-	utc := value.UTC()
-	return time.Date(utc.Year(), utc.Month(), utc.Day(), 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+func endOfBillingDate(value time.Time, location *time.Location) time.Time {
+	if location == nil {
+		location = time.UTC
+	}
+	local := value.In(location)
+	return time.Date(local.Year(), local.Month(), local.Day(), 23, 59, 59, int(time.Second-time.Nanosecond), location).UTC()
 }
 
 func billingPaginationQuery(c *gin.Context) (int, int, bool) {

--- a/internal/cluster/management/billing_test.go
+++ b/internal/cluster/management/billing_test.go
@@ -633,6 +633,57 @@ func TestGetBillingOverviewReturnsTotals(t *testing.T) {
 	if overview["total_recharge_amount"] != float64(50) {
 		t.Fatalf("overview.total_recharge_amount = %v, want 50", overview["total_recharge_amount"])
 	}
+	rangeValue, ok := overview["range"].(map[string]any)
+	if !ok {
+		t.Fatalf("overview.range = %T, want object", overview["range"])
+	}
+	if rangeValue["timezone"] != "UTC" {
+		t.Fatalf("overview.range.timezone = %v, want UTC", rangeValue["timezone"])
+	}
+}
+
+func TestGetBillingOverviewGroupsRequestedTimezone(t *testing.T) {
+	t.Parallel()
+
+	handler, closeRepo := newBillingManagementTestHandler(t)
+	defer closeRepo()
+	seedBillingManagementCharge(t, handler)
+	payload := `{"timestamp":"2026-06-09T17:00:00Z","provider":"openai","model":"gpt-4.1-mini","api_key":"client-key","request_id":"req-2","tokens":{"input_tokens":1,"total_tokens":1}}`
+	if _, errUsage := handler.repo.AppendUsage(context.Background(), payload, "192.0.2.10"); errUsage != nil {
+		t.Fatalf("AppendUsage() error = %v", errUsage)
+	}
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/billing/overview?from=2026-06-09T16%3A00%3A00Z&to=2026-06-10T15%3A59%3A59.999Z&timezone=Asia%2FShanghai", nil)
+	handler.GetBillingOverview(ctx)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var response map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &response); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	overview, ok := response["overview"].(map[string]any)
+	if !ok {
+		t.Fatalf("overview = %T, want object", response["overview"])
+	}
+	if overview["request_count"] != float64(2) || overview["total_charge_amount"] != float64(4) {
+		t.Fatalf("overview totals = requests %v amount %v, want 2 and 4", overview["request_count"], overview["total_charge_amount"])
+	}
+	trend, ok := overview["daily_trend"].([]any)
+	if !ok || len(trend) != 1 {
+		t.Fatalf("daily_trend = %#v, want one point", overview["daily_trend"])
+	}
+	point, ok := trend[0].(map[string]any)
+	if !ok || point["date"] != "2026-06-10" || point["request_count"] != float64(2) {
+		t.Fatalf("daily_trend[0] = %#v, want June 10 with 2 requests", trend[0])
+	}
+	rangeValue, ok := overview["range"].(map[string]any)
+	if !ok || rangeValue["from"] != "2026-06-10" || rangeValue["to"] != "2026-06-10" || rangeValue["timezone"] != "Asia/Shanghai" {
+		t.Fatalf("range = %#v, want June 10 in Asia/Shanghai", overview["range"])
+	}
 }
 
 func TestListBillingChargesReturnsItems(t *testing.T) {
@@ -691,6 +742,77 @@ func TestBillingChargeQueryDateOnlyToNormalizesEndOfDay(t *testing.T) {
 	want := time.Date(2026, time.June, 10, 23, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
 	if !query.To.Equal(want) {
 		t.Fatalf("query.To = %s, want %s", query.To.Format(time.RFC3339Nano), want.Format(time.RFC3339Nano))
+	}
+}
+
+func TestBillingOverviewQueryUsesTimezoneForDateOnlyRange(t *testing.T) {
+	t.Parallel()
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/billing/overview?from=2026-07-19&to=2026-07-19&timezone=Asia%2FShanghai", nil)
+
+	query, ok := billingOverviewQueryFromRequest(ctx)
+	if !ok {
+		t.Fatalf("billingOverviewQueryFromRequest() ok = false, status=%d body=%s", resp.Code, resp.Body.String())
+	}
+	if query.Timezone != "Asia/Shanghai" {
+		t.Fatalf("query.Timezone = %q, want Asia/Shanghai", query.Timezone)
+	}
+	if query.From == nil || query.To == nil {
+		t.Fatalf("query range = %v to %v, want both boundaries", query.From, query.To)
+	}
+	wantFrom := time.Date(2026, time.July, 18, 16, 0, 0, 0, time.UTC)
+	wantTo := time.Date(2026, time.July, 19, 15, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+	if !query.From.Equal(wantFrom) || !query.To.Equal(wantTo) {
+		t.Fatalf("query range = %s to %s, want %s to %s", query.From.Format(time.RFC3339Nano), query.To.Format(time.RFC3339Nano), wantFrom.Format(time.RFC3339Nano), wantTo.Format(time.RFC3339Nano))
+	}
+
+	dstResp := httptest.NewRecorder()
+	dstCtx, _ := gin.CreateTestContext(dstResp)
+	dstCtx.Request = httptest.NewRequest(http.MethodGet, "/billing/overview?from=2026-03-08&to=2026-03-08&timezone=America%2FLos_Angeles", nil)
+	dstQuery, ok := billingOverviewQueryFromRequest(dstCtx)
+	if !ok || dstQuery.From == nil || dstQuery.To == nil {
+		t.Fatalf("DST query = %#v ok=%v, status=%d body=%s", dstQuery, ok, dstResp.Code, dstResp.Body.String())
+	}
+	wantDSTFrom := time.Date(2026, time.March, 8, 8, 0, 0, 0, time.UTC)
+	wantDSTTo := time.Date(2026, time.March, 9, 6, 59, 59, int(time.Second-time.Nanosecond), time.UTC)
+	if !dstQuery.From.Equal(wantDSTFrom) || !dstQuery.To.Equal(wantDSTTo) {
+		t.Fatalf("DST query range = %s to %s, want %s to %s", dstQuery.From.Format(time.RFC3339Nano), dstQuery.To.Format(time.RFC3339Nano), wantDSTFrom.Format(time.RFC3339Nano), wantDSTTo.Format(time.RFC3339Nano))
+	}
+}
+
+func TestBillingRangeQueryRejectsInvalidTimezoneAndInvertedRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		path      string
+		wantError string
+	}{
+		{name: "invalid timezone", path: "/billing/overview?timezone=Invalid%2FTimezone", wantError: "invalid_timezone"},
+		{name: "inverted range", path: "/billing/overview?from=2026-07-20&to=2026-07-19", wantError: "invalid_time_range"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(resp)
+			ctx.Request = httptest.NewRequest(http.MethodGet, tt.path, nil)
+
+			if _, ok := billingOverviewQueryFromRequest(ctx); ok {
+				t.Fatal("billingOverviewQueryFromRequest() ok = true, want false")
+			}
+			if resp.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400", resp.Code, resp.Body.String())
+			}
+			var payload map[string]any
+			if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+				t.Fatalf("decode response: %v", errDecode)
+			}
+			if payload["error"] != tt.wantError {
+				t.Fatalf("error = %v, want %s", payload["error"], tt.wantError)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add an optional IANA `timezone` parameter to Management Billing range queries.
- Parse date-only `from` and `to` values in the requested timezone.
- Group Billing Overview `daily_trend` records by the requested timezone.
- Return `range.from`, `range.to`, and `range.timezone` using the same calendar timezone.
- Preserve explicit RFC3339 timestamps as exact instants.
- Support fixed-offset and DST-aware grouping in SQLite and parameterized timezone grouping in PostgreSQL.
- Add invalid timezone and inverted range validation.
- Update the English and Chinese Management API documentation.

## Problem

A browser-local natural day can cross two UTC calendar dates.

For example, `2026-07-19` in `Asia/Shanghai` covers:

```text
2026-07-18T16:00:00Z
through
2026-07-19T15:59:59.999Z

The previous Billing query correctly filtered this 24-hour range, but daily_trend and the returned range were grouped and formatted in UTC. As a result, one selected local day appeared as two report dates.

## API Behavior

Management Billing endpoints now accept:

timezone=Asia/Shanghai

Date-only values use that timezone:

from=2026-07-19
to=2026-07-19
timezone=Asia/Shanghai

Billing Overview returns:

{
  "overview": {
    "range": {
      "from": "2026-07-19",
      "to": "2026-07-19",
      "timezone": "Asia/Shanghai"
    },
    "daily_trend": [
      {
        "date": "2026-07-19",
        "charge_amount": 2,
        "request_count": 2
      }
    ]
  }
}

## Compatibility

- timezone remains optional and defaults to UTC.
- Existing date-only clients retain their previous UTC behavior.
- Explicit RFC3339 timestamps remain exact and are not shifted or expanded by timezone.
- Unix-second time ranges remain supported.

Invalid timezone names return:

{
  "error": "invalid_timezone"
}

A from value after to returns:

{
  "error": "invalid_time_range"
}

## Database Support

- PostgreSQL uses parameterized timezone conversion for daily grouping.
- SQLite supports fixed timezone offsets and DST transitions.
- Regression coverage includes UTC, Asia/Shanghai, and America/Los_Angeles.

## Validation

- go test -count=1 ./internal/cluster ./internal/cluster/management ./internal/userapi
- go build -o test-output ./cmd/home
- git diff --check
```