### PR TITLE
Fix/billing model provider contract

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3093,6 +3093,16 @@ Response: file attachment.
 
 Returns model definitions from either the current runtime registry or the static model catalog.
 
+Each model includes `providers`, the authoritative provider identifiers used by `usage.provider`
+and Billing model-price rules. Clients must create one candidate per `(provider, model)` pair and
+must not derive Billing providers from `type`, `owned_by`, or a static catalog group name.
+Clients must omit model records whose `providers` field is absent or empty because they do not have
+a safe Billing identity.
+
+Provider implementations must register every executor identifier that can appear in
+`usage.provider` under the same normalized runtime registry provider key. Adding or renaming an
+executor identifier requires updating the registry mapping and this model contract together.
+
 Query parameters:
 
 | Query | Type | Required | Description |
@@ -3119,6 +3129,7 @@ Example available response:
       "created": 1704067200,
       "owned_by": "openai",
       "type": "openai",
+      "providers": ["codex"],
       "display_name": "GPT-5.5"
     }
   ]
@@ -3138,6 +3149,7 @@ Example static response:
         "created": 1704067200,
         "owned_by": "openai",
         "type": "openai",
+        "providers": ["codex"],
         "display_name": "GPT-5.5"
       }
     ]
@@ -3148,6 +3160,7 @@ Example static response:
 ### GET `/model-definitions/:channel`
 
 Returns static model metadata for one channel.
+Returned model entries include the same authoritative `providers` field described above.
 
 Supported channels:
 

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3167,7 +3167,9 @@ Supported channels:
 ```text
 claude
 gemini
+gemini-interactions
 vertex
+aistudio
 codex
 codex-free
 codex-team

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3063,6 +3063,16 @@ Query 参数：
 
 从当前 runtime registry 或静态模型目录返回模型定义。
 
+每个模型都包含 `providers`，其值是 `usage.provider` 和 Billing 模型价格规则使用的权威
+provider 标识。客户端必须按每个 `(provider, model)` 组合生成一个候选项，不能从 `type`、
+`owned_by` 或静态目录分组名称推导 Billing provider。
+如果模型记录缺少 `providers` 或数组为空，客户端必须忽略该记录，因为它没有安全的 Billing
+匹配标识。
+
+Provider 实现必须把所有可能写入 `usage.provider` 的 executor 标识，以相同的归一化 provider
+key 注册到 runtime registry。新增或重命名 executor 标识时，必须同步更新 registry 映射和本模型
+契约。
+
 Query 参数：
 
 | Query | 类型 | 必填 | 说明 |
@@ -3089,6 +3099,7 @@ Query 参数：
       "created": 1704067200,
       "owned_by": "openai",
       "type": "openai",
+      "providers": ["codex"],
       "display_name": "GPT-5.5"
     }
   ]
@@ -3108,6 +3119,7 @@ Query 参数：
         "created": 1704067200,
         "owned_by": "openai",
         "type": "openai",
+        "providers": ["codex"],
         "display_name": "GPT-5.5"
       }
     ]
@@ -3118,6 +3130,7 @@ Query 参数：
 ### GET `/model-definitions/:channel`
 
 返回指定 channel 的静态模型 metadata。
+返回的模型记录同样包含上文所述的权威 `providers` 字段。
 
 支持的 channel：
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3137,7 +3137,9 @@ Query 参数：
 ```text
 claude
 gemini
+gemini-interactions
 vertex
+aistudio
 codex
 codex-free
 codex-team

--- a/internal/home/model_provider_registration_test.go
+++ b/internal/home/model_provider_registration_test.go
@@ -1,0 +1,44 @@
+package home
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
+)
+
+func TestRegisterModelsForAuthSupportsCPAProviderIdentifiers(t *testing.T) {
+	runtime := &Runtime{cfg: &config.Config{}}
+	tests := []string{"aistudio", "gemini-interactions"}
+
+	for _, provider := range tests {
+		t.Run(provider, func(t *testing.T) {
+			authID := "provider-registration-" + provider
+			defer registry.GetGlobalRegistry().UnregisterClient(authID)
+
+			runtime.registerModelsForAuth(&coreauth.Auth{ID: authID, Provider: provider})
+			models := registry.GetGlobalRegistry().GetModelsForClient(authID)
+			if len(models) == 0 {
+				t.Fatalf("provider %q registered no models", provider)
+			}
+
+			modelID := models[0].ID
+			foundProvider := false
+			for _, model := range registry.GetGlobalRegistry().GetAvailableModelDefinitions() {
+				if model == nil || model.ID != modelID {
+					continue
+				}
+				for _, registeredProvider := range model.Providers {
+					if registeredProvider == provider {
+						foundProvider = true
+						break
+					}
+				}
+			}
+			if !foundProvider {
+				t.Fatalf("model %q did not expose provider %q", modelID, provider)
+			}
+		})
+	}
+}

--- a/internal/home/models.go
+++ b/internal/home/models.go
@@ -185,6 +185,12 @@ func (r *Runtime) registerModelsForAuth(a *coreauth.Auth) {
 			}
 		}
 		models = applyExcludedModels(models, excluded)
+	case "gemini-interactions":
+		models = registry.GetGeminiModels()
+		if len(configModels) > 0 {
+			models = configModels
+		}
+		models = applyExcludedModels(models, excluded)
 	case "vertex":
 		models = registry.GetGeminiVertexModels()
 		if len(configModels) > 0 {
@@ -196,6 +202,12 @@ func (r *Runtime) registerModelsForAuth(a *coreauth.Auth) {
 			if authKind == "apikey" {
 				excluded = entry.ExcludedModels
 			}
+		}
+		models = applyExcludedModels(models, excluded)
+	case "aistudio":
+		models = registry.GetAIStudioModels()
+		if len(configModels) > 0 {
+			models = configModels
 		}
 		models = applyExcludedModels(models, excluded)
 	case "antigravity":

--- a/internal/registry/model_billing_providers_test.go
+++ b/internal/registry/model_billing_providers_test.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestGetAvailableModelDefinitionsIncludesBillingProviders(t *testing.T) {
+	modelRegistry := &ModelRegistry{
+		models:           make(map[string]*ModelRegistration),
+		clientModels:     make(map[string][]string),
+		clientModelInfos: make(map[string]map[string]*ModelInfo),
+		clientProviders:  make(map[string]string),
+		mutex:            &sync.RWMutex{},
+	}
+	model := &ModelInfo{ID: "gpt-5.5", Type: "openai", OwnedBy: "openai"}
+
+	modelRegistry.RegisterClient("codex-client", "codex", []*ModelInfo{model})
+	modelRegistry.RegisterClient("compat-client", "OpenRouter", []*ModelInfo{model})
+
+	models := modelRegistry.GetAvailableModelDefinitions()
+	if len(models) != 1 {
+		t.Fatalf("GetAvailableModelDefinitions() returned %d models, want 1", len(models))
+	}
+	wantProviders := []string{"codex", "openrouter"}
+	if !reflect.DeepEqual(models[0].Providers, wantProviders) {
+		t.Fatalf("providers = %#v, want %#v", models[0].Providers, wantProviders)
+	}
+	if models[0].Type != "openai" {
+		t.Fatalf("type = %q, want openai", models[0].Type)
+	}
+
+	modelRegistry.UnregisterClient("compat-client")
+	models = modelRegistry.GetAvailableModelDefinitions()
+	if len(models) != 1 {
+		t.Fatalf("GetAvailableModelDefinitions() after unregister returned %d models, want 1", len(models))
+	}
+	wantProviders = []string{"codex"}
+	if !reflect.DeepEqual(models[0].Providers, wantProviders) {
+		t.Fatalf("providers after unregister = %#v, want %#v", models[0].Providers, wantProviders)
+	}
+}
+
+func TestStaticModelDefinitionsExposeCanonicalBillingProviders(t *testing.T) {
+	tests := []struct {
+		channel  string
+		provider string
+	}{
+		{channel: "claude", provider: "claude"},
+		{channel: "gemini", provider: "gemini"},
+		{channel: "vertex", provider: "vertex"},
+		{channel: "codex-free", provider: "codex"},
+		{channel: "codex-pro", provider: "codex"},
+		{channel: "kimi", provider: "kimi"},
+		{channel: "antigravity", provider: "antigravity"},
+		{channel: "xai", provider: "xai"},
+		{channel: "x-ai", provider: "xai"},
+		{channel: "grok", provider: "xai"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.channel, func(t *testing.T) {
+			models := GetStaticModelDefinitionsByChannel(test.channel)
+			if len(models) == 0 {
+				t.Fatalf("GetStaticModelDefinitionsByChannel(%q) returned no models", test.channel)
+			}
+			for _, model := range models {
+				if model == nil {
+					continue
+				}
+				wantProviders := []string{test.provider}
+				if !reflect.DeepEqual(model.Providers, wantProviders) {
+					t.Fatalf("model %q providers = %#v, want %#v", model.ID, model.Providers, wantProviders)
+				}
+			}
+		})
+	}
+}
+
+func TestModelRegistrationProvidersNormalizesAndFiltersCounts(t *testing.T) {
+	registration := &ModelRegistration{Providers: map[string]int{
+		"Codex":        2,
+		" codex ":      1,
+		" OpenRouter ": 1,
+		"zero":         0,
+		"negative":     -1,
+		"":             1,
+	}}
+
+	wantProviders := []string{"codex", "openrouter"}
+	if providers := modelRegistrationProviders(registration); !reflect.DeepEqual(providers, wantProviders) {
+		t.Fatalf("modelRegistrationProviders() = %#v, want %#v", providers, wantProviders)
+	}
+}
+
+func TestAllStaticModelDefinitionsUseCanonicalCodexProvider(t *testing.T) {
+	modelsByChannel := GetAllStaticModelDefinitions()
+	for _, channel := range []string{"codex-free", "codex-team", "codex-plus", "codex-pro"} {
+		models := modelsByChannel[channel]
+		if len(models) == 0 {
+			t.Fatalf("channel %q returned no models", channel)
+		}
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			wantProviders := []string{"codex"}
+			if !reflect.DeepEqual(model.Providers, wantProviders) {
+				t.Fatalf("channel %q model %q providers = %#v, want %#v", channel, model.ID, model.Providers, wantProviders)
+			}
+		}
+	}
+}

--- a/internal/registry/model_billing_providers_test.go
+++ b/internal/registry/model_billing_providers_test.go
@@ -49,7 +49,9 @@ func TestStaticModelDefinitionsExposeCanonicalBillingProviders(t *testing.T) {
 	}{
 		{channel: "claude", provider: "claude"},
 		{channel: "gemini", provider: "gemini"},
+		{channel: "gemini-interactions", provider: "gemini-interactions"},
 		{channel: "vertex", provider: "vertex"},
+		{channel: "aistudio", provider: "aistudio"},
 		{channel: "codex-free", provider: "codex"},
 		{channel: "codex-pro", provider: "codex"},
 		{channel: "kimi", provider: "kimi"},
@@ -78,6 +80,22 @@ func TestStaticModelDefinitionsExposeCanonicalBillingProviders(t *testing.T) {
 	}
 }
 
+func TestDetectChangedProvidersIncludesCPAProviderAliases(t *testing.T) {
+	oldData := &staticModelsJSON{
+		Gemini:   []*ModelInfo{{ID: "gemini-old"}},
+		AIStudio: []*ModelInfo{{ID: "aistudio-old"}},
+	}
+	newData := &staticModelsJSON{
+		Gemini:   []*ModelInfo{{ID: "gemini-new"}},
+		AIStudio: []*ModelInfo{{ID: "aistudio-new"}},
+	}
+
+	wantProviders := []string{"gemini", "gemini-interactions", "aistudio"}
+	if providers := detectChangedProviders(oldData, newData); !reflect.DeepEqual(providers, wantProviders) {
+		t.Fatalf("detectChangedProviders() = %#v, want %#v", providers, wantProviders)
+	}
+}
+
 func TestModelRegistrationProvidersNormalizesAndFiltersCounts(t *testing.T) {
 	registration := &ModelRegistration{Providers: map[string]int{
 		"Codex":        2,
@@ -94,20 +112,32 @@ func TestModelRegistrationProvidersNormalizesAndFiltersCounts(t *testing.T) {
 	}
 }
 
-func TestAllStaticModelDefinitionsUseCanonicalCodexProvider(t *testing.T) {
+func TestAllStaticModelDefinitionsUseCanonicalProviders(t *testing.T) {
 	modelsByChannel := GetAllStaticModelDefinitions()
-	for _, channel := range []string{"codex-free", "codex-team", "codex-plus", "codex-pro"} {
-		models := modelsByChannel[channel]
+	tests := []struct {
+		channel  string
+		provider string
+	}{
+		{channel: "gemini-interactions", provider: "gemini-interactions"},
+		{channel: "aistudio", provider: "aistudio"},
+		{channel: "codex-free", provider: "codex"},
+		{channel: "codex-team", provider: "codex"},
+		{channel: "codex-plus", provider: "codex"},
+		{channel: "codex-pro", provider: "codex"},
+	}
+
+	for _, test := range tests {
+		models := modelsByChannel[test.channel]
 		if len(models) == 0 {
-			t.Fatalf("channel %q returned no models", channel)
+			t.Fatalf("channel %q returned no models", test.channel)
 		}
 		for _, model := range models {
 			if model == nil {
 				continue
 			}
-			wantProviders := []string{"codex"}
+			wantProviders := []string{test.provider}
 			if !reflect.DeepEqual(model.Providers, wantProviders) {
-				t.Fatalf("channel %q model %q providers = %#v, want %#v", channel, model.ID, model.Providers, wantProviders)
+				t.Fatalf("channel %q model %q providers = %#v, want %#v", test.channel, model.ID, model.Providers, wantProviders)
 			}
 		}
 	}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -3,6 +3,7 @@
 package registry
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -80,18 +81,53 @@ func GetXAIModels() []*ModelInfo {
 
 // GetAllStaticModelDefinitions returns static model definitions grouped by channel.
 func GetAllStaticModelDefinitions() map[string][]*ModelInfo {
-	return map[string][]*ModelInfo{
-		"claude":      GetClaudeModels(),
-		"gemini":      GetGeminiModels(),
-		"vertex":      GetGeminiVertexModels(),
-		"codex-free":  GetCodexFreeModels(),
-		"codex-team":  GetCodexTeamModels(),
-		"codex-plus":  GetCodexPlusModels(),
-		"codex-pro":   GetCodexProModels(),
-		"kimi":        GetKimiModels(),
-		"antigravity": GetAntigravityModels(),
-		"xai":         GetXAIModels(),
+	channels := []string{
+		"claude",
+		"gemini",
+		"vertex",
+		"codex-free",
+		"codex-team",
+		"codex-plus",
+		"codex-pro",
+		"kimi",
+		"antigravity",
+		"xai",
 	}
+	definitions := make(map[string][]*ModelInfo, len(channels))
+	for _, channel := range channels {
+		definitions[channel] = GetStaticModelDefinitionsByChannel(channel)
+	}
+	return definitions
+}
+
+// withStaticModelProviders annotates management-facing static definitions with billing providers.
+func withStaticModelProviders(models []*ModelInfo, providers ...string) []*ModelInfo {
+	if len(models) == 0 {
+		return models
+	}
+
+	normalizedProviders := make([]string, 0, len(providers))
+	seen := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider == "" {
+			continue
+		}
+		if _, exists := seen[provider]; exists {
+			continue
+		}
+		seen[provider] = struct{}{}
+		normalizedProviders = append(normalizedProviders, provider)
+	}
+	sort.Strings(normalizedProviders)
+
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		model.Providers = append([]string(nil), normalizedProviders...)
+	}
+	return models
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -250,30 +286,38 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	// Normalize source data before building the derived payload.
 	key := strings.ToLower(strings.TrimSpace(channel))
+	provider := key
+	var models []*ModelInfo
 	switch key {
 	case "claude":
-		return GetClaudeModels()
+		models = GetClaudeModels()
 	case "gemini":
-		return GetGeminiModels()
+		models = GetGeminiModels()
 	case "vertex":
-		return GetGeminiVertexModels()
+		models = GetGeminiVertexModels()
 	case "codex", "codex-pro":
-		return GetCodexProModels()
+		models = GetCodexProModels()
+		provider = "codex"
 	case "codex-plus":
-		return GetCodexPlusModels()
+		models = GetCodexPlusModels()
+		provider = "codex"
 	case "codex-team":
-		return GetCodexTeamModels()
+		models = GetCodexTeamModels()
+		provider = "codex"
 	case "codex-free":
-		return GetCodexFreeModels()
+		models = GetCodexFreeModels()
+		provider = "codex"
 	case "kimi":
-		return GetKimiModels()
+		models = GetKimiModels()
 	case "antigravity":
-		return GetAntigravityModels()
+		models = GetAntigravityModels()
 	case "xai", "x-ai", "grok":
-		return GetXAIModels()
+		models = GetXAIModels()
+		provider = "xai"
 	default:
 		return nil
 	}
+	return withStaticModelProviders(models, provider)
 }
 
 // LookupStaticModelInfo searches all static model definitions for a model by ID.

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -20,6 +20,7 @@ type staticModelsJSON struct {
 	Claude      []*ModelInfo `json:"claude"`
 	Gemini      []*ModelInfo `json:"gemini"`
 	Vertex      []*ModelInfo `json:"vertex"`
+	AIStudio    []*ModelInfo `json:"aistudio"`
 	CodexFree   []*ModelInfo `json:"codex-free"`
 	CodexTeam   []*ModelInfo `json:"codex-team"`
 	CodexPlus   []*ModelInfo `json:"codex-plus"`
@@ -42,6 +43,11 @@ func GetGeminiModels() []*ModelInfo {
 // GetGeminiVertexModels returns Gemini model definitions for Vertex AI.
 func GetGeminiVertexModels() []*ModelInfo {
 	return cloneModelInfos(getModels().Vertex)
+}
+
+// GetAIStudioModels returns model definitions for AI Studio.
+func GetAIStudioModels() []*ModelInfo {
+	return cloneModelInfos(getModels().AIStudio)
 }
 
 // GetCodexFreeModels returns model definitions for the Codex free plan tier.
@@ -84,7 +90,9 @@ func GetAllStaticModelDefinitions() map[string][]*ModelInfo {
 	channels := []string{
 		"claude",
 		"gemini",
+		"gemini-interactions",
 		"vertex",
+		"aistudio",
 		"codex-free",
 		"codex-team",
 		"codex-plus",
@@ -278,7 +286,9 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 // Supported channels:
 //   - claude
 //   - gemini
+//   - gemini-interactions
 //   - vertex
+//   - aistudio
 //   - codex
 //   - kimi
 //   - antigravity
@@ -293,8 +303,12 @@ func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 		models = GetClaudeModels()
 	case "gemini":
 		models = GetGeminiModels()
+	case "gemini-interactions":
+		models = GetGeminiModels()
 	case "vertex":
 		models = GetGeminiVertexModels()
+	case "aistudio":
+		models = GetAIStudioModels()
 	case "codex", "codex-pro":
 		models = GetCodexProModels()
 		provider = "codex"
@@ -333,6 +347,7 @@ func LookupStaticModelInfo(modelID string) *ModelInfo {
 		data.Claude,
 		data.Gemini,
 		data.Vertex,
+		data.AIStudio,
 		data.CodexPro,
 		data.Kimi,
 		data.Antigravity,

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -25,6 +25,8 @@ type ModelInfo struct {
 	OwnedBy string `json:"owned_by"`
 	// Type indicates the model type (e.g., "claude", "gemini", "openai")
 	Type string `json:"type"`
+	// Providers lists the exact provider identifiers used by usage records and billing rules.
+	Providers []string `json:"providers,omitempty"`
 	// DisplayName is the human-readable name for the model
 	DisplayName string `json:"display_name,omitempty"`
 	// Name is used for Gemini-style model names
@@ -466,6 +468,9 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 	if len(model.SupportedOutputModalities) > 0 {
 		copyModel.SupportedOutputModalities = append([]string(nil), model.SupportedOutputModalities...)
 	}
+	if len(model.Providers) > 0 {
+		copyModel.Providers = append([]string(nil), model.Providers...)
+	}
 	if model.Thinking != nil {
 		copyThinking := *model.Thinking
 		if len(model.Thinking.Levels) > 0 {
@@ -664,10 +669,38 @@ func (r *ModelRegistry) GetAvailableModelDefinitions() []*ModelInfo {
 		if !available || registration == nil || registration.Info == nil {
 			continue
 		}
-		models = append(models, cloneModelInfo(registration.Info))
+		model := cloneModelInfo(registration.Info)
+		model.Providers = modelRegistrationProviders(registration)
+		models = append(models, model)
 	}
 	sortModelInfosByID(models)
 	return models
+}
+
+// modelRegistrationProviders returns stable billing provider identifiers for a model registration.
+func modelRegistrationProviders(registration *ModelRegistration) []string {
+	if registration == nil || len(registration.Providers) == 0 {
+		return nil
+	}
+
+	providerSet := make(map[string]struct{}, len(registration.Providers))
+	for provider, count := range registration.Providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider == "" || count <= 0 {
+			continue
+		}
+		providerSet[provider] = struct{}{}
+	}
+	if len(providerSet) == 0 {
+		return nil
+	}
+
+	providers := make([]string, 0, len(providerSet))
+	for provider := range providerSet {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return providers
 }
 
 // modelRegistrationAvailability applies the registry visibility rules to one model registration.

--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -216,7 +216,9 @@ func detectChangedProviders(oldData, newData *staticModelsJSON) []string {
 	sections := []section{
 		{"claude", oldData.Claude, newData.Claude},
 		{"gemini", oldData.Gemini, newData.Gemini},
+		{"gemini-interactions", oldData.Gemini, newData.Gemini},
 		{"vertex", oldData.Vertex, newData.Vertex},
+		{"aistudio", oldData.AIStudio, newData.AIStudio},
 		{"codex", oldData.CodexFree, newData.CodexFree},
 		{"codex", oldData.CodexTeam, newData.CodexTeam},
 		{"codex", oldData.CodexPlus, newData.CodexPlus},
@@ -343,6 +345,7 @@ func validateModelsCatalog(data *staticModelsJSON) error {
 		{name: "claude", models: data.Claude},
 		{name: "gemini", models: data.Gemini},
 		{name: "vertex", models: data.Vertex},
+		{name: "aistudio", models: data.AIStudio},
 		{name: "codex-free", models: data.CodexFree},
 		{name: "codex-team", models: data.CodexTeam},
 		{name: "codex-plus", models: data.CodexPlus},

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -740,6 +740,304 @@
       ]
     }
   ],
+  "aistudio": [
+    {
+      "id": "gemini-2.5-pro",
+      "object": "model",
+      "created": 1750118400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 2.5 Pro",
+      "name": "models/gemini-2.5-pro",
+      "version": "2.5",
+      "description": "Stable release (June 17th, 2025) of Gemini 2.5 Pro",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "object": "model",
+      "created": 1750118400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 2.5 Flash",
+      "name": "models/gemini-2.5-flash",
+      "version": "001",
+      "description": "Stable version of Gemini 2.5 Flash, our mid-size multimodal model that supports up to 1 million tokens, released in June of 2025.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "max": 24576,
+        "zero_allowed": true,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-2.5-flash-lite",
+      "object": "model",
+      "created": 1753142400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 2.5 Flash Lite",
+      "name": "models/gemini-2.5-flash-lite",
+      "version": "2.5",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "max": 24576,
+        "zero_allowed": true,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-3-pro-preview",
+      "object": "model",
+      "created": 1737158400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3 Pro Preview",
+      "name": "models/gemini-3-pro-preview",
+      "version": "3.0",
+      "description": "Gemini 3 Pro Preview",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-3.1-pro-preview",
+      "object": "model",
+      "created": 1771459200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Pro Preview",
+      "name": "models/gemini-3.1-pro-preview",
+      "version": "3.1",
+      "description": "Gemini 3.1 Pro Preview",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-3-flash-preview",
+      "object": "model",
+      "created": 1765929600,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3 Flash Preview",
+      "name": "models/gemini-3-flash-preview",
+      "version": "3.0",
+      "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-3.1-flash-lite-preview",
+      "object": "model",
+      "created": 1776288000,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.1 Flash Lite Preview",
+      "name": "models/gemini-3.1-flash-lite-preview",
+      "version": "3.1",
+      "description": "Our smallest and most cost effective model, built for at scale usage.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-pro-latest",
+      "object": "model",
+      "created": 1750118400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini Pro Latest",
+      "name": "models/gemini-pro-latest",
+      "version": "2.5",
+      "description": "Latest release of Gemini Pro",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-flash-latest",
+      "object": "model",
+      "created": 1750118400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini Flash Latest",
+      "name": "models/gemini-flash-latest",
+      "version": "2.5",
+      "description": "Latest release of Gemini Flash",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "max": 24576,
+        "zero_allowed": true,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-flash-lite-latest",
+      "object": "model",
+      "created": 1753142400,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini Flash-Lite Latest",
+      "name": "models/gemini-flash-lite-latest",
+      "version": "2.5",
+      "description": "Latest release of Gemini Flash-Lite",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 512,
+        "max": 24576,
+        "zero_allowed": true,
+        "dynamic_allowed": true
+      }
+    },
+    {
+      "id": "gemini-2.5-flash-image",
+      "object": "model",
+      "created": 1759363200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 2.5 Flash Image",
+      "name": "models/gemini-2.5-flash-image",
+      "version": "2.5",
+      "description": "State-of-the-art image generation and editing model.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 8192,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ]
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "object": "model",
+      "created": 1779235200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "models/gemini-3.5-flash",
+      "version": "3.5",
+      "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    }
+  ],
   "codex-free": [
     {
       "id": "gpt-5.2",


### PR DESCRIPTION
## Summary

- expose an authoritative `providers` field on management-facing model definitions
- derive available-model providers from live registry registrations
- annotate static model definitions with the canonical provider identifiers used by `usage.provider`
- align AI Studio and Gemini Interactions model registration with their CPA executor identifiers
- document the provider identity contract for `/models` and `/model-definitions/:channel`
- add registry and runtime invariant tests for provider normalization and static mappings

## Motivation

Billing price rules are matched using the exact `(usage.provider, model)` pair.

The existing `/models` response only exposed model protocol metadata such as `type`, `owned_by`, and static catalog group names. Those fields do not reliably identify the provider recorded in usage data:

- Codex models use the OpenAI protocol, but their usage provider is `codex`
- OpenAI-compatible channels may use user-defined provider identifiers
- static channel aliases do not necessarily match CPA executor identifiers

As a result, clients could create price rules that never match real traffic, causing charges to silently fall back to `default:zero`.

## API contract

Model entries returned by `GET /models?scope=available|static` now include:

```json
{
  "id": "gpt-5.5",
  "type": "openai",
  "providers": ["codex"]
}
```

providers contains the normalized identifiers that may appear in usage.provider.

Clients should:

- create one candidate for every (provider, model) pair
- not derive billing providers from type, owned_by, or static catalog group names
- omit model records whose providers field is absent or empty

The response change is additive and remains compatible with existing clients that ignore unknown fields.

## Additional alignment

This PR also registers model definitions for:

- aistudio
- gemini-interactions

This keeps the runtime registry provider namespace aligned with CPA executor identifiers and prevents the same mismatch from recurring when these providers are used.

## Testing

go test ./internal/registry ./internal/home
go build -o test-output ./cmd/home && rm test-output
```