### PR TITLE
fix(models): expose billing provider identities

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3093,6 +3093,16 @@ Response: file attachment.
 
 Returns model definitions from either the current runtime registry or the static model catalog.
 
+Each model includes `providers`, the authoritative provider identifiers used by `usage.provider`
+and Billing model-price rules. Clients must create one candidate per `(provider, model)` pair and
+must not derive Billing providers from `type`, `owned_by`, or a static catalog group name.
+Clients must omit model records whose `providers` field is absent or empty because they do not have
+a safe Billing identity.
+
+Provider implementations must register every executor identifier that can appear in
+`usage.provider` under the same normalized runtime registry provider key. Adding or renaming an
+executor identifier requires updating the registry mapping and this model contract together.
+
 Query parameters:
 
 | Query | Type | Required | Description |
@@ -3119,6 +3129,7 @@ Example available response:
       "created": 1704067200,
       "owned_by": "openai",
       "type": "openai",
+      "providers": ["codex"],
       "display_name": "GPT-5.5"
     }
   ]
@@ -3138,6 +3149,7 @@ Example static response:
         "created": 1704067200,
         "owned_by": "openai",
         "type": "openai",
+        "providers": ["codex"],
         "display_name": "GPT-5.5"
       }
     ]
@@ -3148,6 +3160,7 @@ Example static response:
 ### GET `/model-definitions/:channel`
 
 Returns static model metadata for one channel.
+Returned model entries include the same authoritative `providers` field described above.
 
 Supported channels:
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3063,6 +3063,16 @@ Query 参数：
 
 从当前 runtime registry 或静态模型目录返回模型定义。
 
+每个模型都包含 `providers`，其值是 `usage.provider` 和 Billing 模型价格规则使用的权威
+provider 标识。客户端必须按每个 `(provider, model)` 组合生成一个候选项，不能从 `type`、
+`owned_by` 或静态目录分组名称推导 Billing provider。
+如果模型记录缺少 `providers` 或数组为空，客户端必须忽略该记录，因为它没有安全的 Billing
+匹配标识。
+
+Provider 实现必须把所有可能写入 `usage.provider` 的 executor 标识，以相同的归一化 provider
+key 注册到 runtime registry。新增或重命名 executor 标识时，必须同步更新 registry 映射和本模型
+契约。
+
 Query 参数：
 
 | Query | 类型 | 必填 | 说明 |
@@ -3089,6 +3099,7 @@ Query 参数：
       "created": 1704067200,
       "owned_by": "openai",
       "type": "openai",
+      "providers": ["codex"],
       "display_name": "GPT-5.5"
     }
   ]
@@ -3108,6 +3119,7 @@ Query 参数：
         "created": 1704067200,
         "owned_by": "openai",
         "type": "openai",
+        "providers": ["codex"],
         "display_name": "GPT-5.5"
       }
     ]
@@ -3118,6 +3130,7 @@ Query 参数：
 ### GET `/model-definitions/:channel`
 
 返回指定 channel 的静态模型 metadata。
+返回的模型记录同样包含上文所述的权威 `providers` 字段。
 
 支持的 channel：
 

--- a/internal/registry/model_billing_providers_test.go
+++ b/internal/registry/model_billing_providers_test.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestGetAvailableModelDefinitionsIncludesBillingProviders(t *testing.T) {
+	modelRegistry := &ModelRegistry{
+		models:           make(map[string]*ModelRegistration),
+		clientModels:     make(map[string][]string),
+		clientModelInfos: make(map[string]map[string]*ModelInfo),
+		clientProviders:  make(map[string]string),
+		mutex:            &sync.RWMutex{},
+	}
+	model := &ModelInfo{ID: "gpt-5.5", Type: "openai", OwnedBy: "openai"}
+
+	modelRegistry.RegisterClient("codex-client", "codex", []*ModelInfo{model})
+	modelRegistry.RegisterClient("compat-client", "OpenRouter", []*ModelInfo{model})
+
+	models := modelRegistry.GetAvailableModelDefinitions()
+	if len(models) != 1 {
+		t.Fatalf("GetAvailableModelDefinitions() returned %d models, want 1", len(models))
+	}
+	wantProviders := []string{"codex", "openrouter"}
+	if !reflect.DeepEqual(models[0].Providers, wantProviders) {
+		t.Fatalf("providers = %#v, want %#v", models[0].Providers, wantProviders)
+	}
+	if models[0].Type != "openai" {
+		t.Fatalf("type = %q, want openai", models[0].Type)
+	}
+
+	modelRegistry.UnregisterClient("compat-client")
+	models = modelRegistry.GetAvailableModelDefinitions()
+	if len(models) != 1 {
+		t.Fatalf("GetAvailableModelDefinitions() after unregister returned %d models, want 1", len(models))
+	}
+	wantProviders = []string{"codex"}
+	if !reflect.DeepEqual(models[0].Providers, wantProviders) {
+		t.Fatalf("providers after unregister = %#v, want %#v", models[0].Providers, wantProviders)
+	}
+}
+
+func TestStaticModelDefinitionsExposeCanonicalBillingProviders(t *testing.T) {
+	tests := []struct {
+		channel  string
+		provider string
+	}{
+		{channel: "claude", provider: "claude"},
+		{channel: "gemini", provider: "gemini"},
+		{channel: "vertex", provider: "vertex"},
+		{channel: "codex-free", provider: "codex"},
+		{channel: "codex-pro", provider: "codex"},
+		{channel: "kimi", provider: "kimi"},
+		{channel: "antigravity", provider: "antigravity"},
+		{channel: "xai", provider: "xai"},
+		{channel: "x-ai", provider: "xai"},
+		{channel: "grok", provider: "xai"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.channel, func(t *testing.T) {
+			models := GetStaticModelDefinitionsByChannel(test.channel)
+			if len(models) == 0 {
+				t.Fatalf("GetStaticModelDefinitionsByChannel(%q) returned no models", test.channel)
+			}
+			for _, model := range models {
+				if model == nil {
+					continue
+				}
+				wantProviders := []string{test.provider}
+				if !reflect.DeepEqual(model.Providers, wantProviders) {
+					t.Fatalf("model %q providers = %#v, want %#v", model.ID, model.Providers, wantProviders)
+				}
+			}
+		})
+	}
+}
+
+func TestModelRegistrationProvidersNormalizesAndFiltersCounts(t *testing.T) {
+	registration := &ModelRegistration{Providers: map[string]int{
+		"Codex":        2,
+		" codex ":      1,
+		" OpenRouter ": 1,
+		"zero":         0,
+		"negative":     -1,
+		"":             1,
+	}}
+
+	wantProviders := []string{"codex", "openrouter"}
+	if providers := modelRegistrationProviders(registration); !reflect.DeepEqual(providers, wantProviders) {
+		t.Fatalf("modelRegistrationProviders() = %#v, want %#v", providers, wantProviders)
+	}
+}
+
+func TestAllStaticModelDefinitionsUseCanonicalCodexProvider(t *testing.T) {
+	modelsByChannel := GetAllStaticModelDefinitions()
+	for _, channel := range []string{"codex-free", "codex-team", "codex-plus", "codex-pro"} {
+		models := modelsByChannel[channel]
+		if len(models) == 0 {
+			t.Fatalf("channel %q returned no models", channel)
+		}
+		for _, model := range models {
+			if model == nil {
+				continue
+			}
+			wantProviders := []string{"codex"}
+			if !reflect.DeepEqual(model.Providers, wantProviders) {
+				t.Fatalf("channel %q model %q providers = %#v, want %#v", channel, model.ID, model.Providers, wantProviders)
+			}
+		}
+	}
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -3,6 +3,7 @@
 package registry
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -80,18 +81,53 @@ func GetXAIModels() []*ModelInfo {
 
 // GetAllStaticModelDefinitions returns static model definitions grouped by channel.
 func GetAllStaticModelDefinitions() map[string][]*ModelInfo {
-	return map[string][]*ModelInfo{
-		"claude":      GetClaudeModels(),
-		"gemini":      GetGeminiModels(),
-		"vertex":      GetGeminiVertexModels(),
-		"codex-free":  GetCodexFreeModels(),
-		"codex-team":  GetCodexTeamModels(),
-		"codex-plus":  GetCodexPlusModels(),
-		"codex-pro":   GetCodexProModels(),
-		"kimi":        GetKimiModels(),
-		"antigravity": GetAntigravityModels(),
-		"xai":         GetXAIModels(),
+	channels := []string{
+		"claude",
+		"gemini",
+		"vertex",
+		"codex-free",
+		"codex-team",
+		"codex-plus",
+		"codex-pro",
+		"kimi",
+		"antigravity",
+		"xai",
 	}
+	definitions := make(map[string][]*ModelInfo, len(channels))
+	for _, channel := range channels {
+		definitions[channel] = GetStaticModelDefinitionsByChannel(channel)
+	}
+	return definitions
+}
+
+// withStaticModelProviders annotates management-facing static definitions with billing providers.
+func withStaticModelProviders(models []*ModelInfo, providers ...string) []*ModelInfo {
+	if len(models) == 0 {
+		return models
+	}
+
+	normalizedProviders := make([]string, 0, len(providers))
+	seen := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider == "" {
+			continue
+		}
+		if _, exists := seen[provider]; exists {
+			continue
+		}
+		seen[provider] = struct{}{}
+		normalizedProviders = append(normalizedProviders, provider)
+	}
+	sort.Strings(normalizedProviders)
+
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		model.Providers = append([]string(nil), normalizedProviders...)
+	}
+	return models
 }
 
 // WithCodexBuiltins injects hard-coded Codex-only model definitions that should
@@ -250,30 +286,38 @@ func cloneModelInfos(models []*ModelInfo) []*ModelInfo {
 func GetStaticModelDefinitionsByChannel(channel string) []*ModelInfo {
 	// Normalize source data before building the derived payload.
 	key := strings.ToLower(strings.TrimSpace(channel))
+	provider := key
+	var models []*ModelInfo
 	switch key {
 	case "claude":
-		return GetClaudeModels()
+		models = GetClaudeModels()
 	case "gemini":
-		return GetGeminiModels()
+		models = GetGeminiModels()
 	case "vertex":
-		return GetGeminiVertexModels()
+		models = GetGeminiVertexModels()
 	case "codex", "codex-pro":
-		return GetCodexProModels()
+		models = GetCodexProModels()
+		provider = "codex"
 	case "codex-plus":
-		return GetCodexPlusModels()
+		models = GetCodexPlusModels()
+		provider = "codex"
 	case "codex-team":
-		return GetCodexTeamModels()
+		models = GetCodexTeamModels()
+		provider = "codex"
 	case "codex-free":
-		return GetCodexFreeModels()
+		models = GetCodexFreeModels()
+		provider = "codex"
 	case "kimi":
-		return GetKimiModels()
+		models = GetKimiModels()
 	case "antigravity":
-		return GetAntigravityModels()
+		models = GetAntigravityModels()
 	case "xai", "x-ai", "grok":
-		return GetXAIModels()
+		models = GetXAIModels()
+		provider = "xai"
 	default:
 		return nil
 	}
+	return withStaticModelProviders(models, provider)
 }
 
 // LookupStaticModelInfo searches all static model definitions for a model by ID.

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -25,6 +25,8 @@ type ModelInfo struct {
 	OwnedBy string `json:"owned_by"`
 	// Type indicates the model type (e.g., "claude", "gemini", "openai")
 	Type string `json:"type"`
+	// Providers lists the exact provider identifiers used by usage records and billing rules.
+	Providers []string `json:"providers,omitempty"`
 	// DisplayName is the human-readable name for the model
 	DisplayName string `json:"display_name,omitempty"`
 	// Name is used for Gemini-style model names
@@ -466,6 +468,9 @@ func cloneModelInfo(model *ModelInfo) *ModelInfo {
 	if len(model.SupportedOutputModalities) > 0 {
 		copyModel.SupportedOutputModalities = append([]string(nil), model.SupportedOutputModalities...)
 	}
+	if len(model.Providers) > 0 {
+		copyModel.Providers = append([]string(nil), model.Providers...)
+	}
 	if model.Thinking != nil {
 		copyThinking := *model.Thinking
 		if len(model.Thinking.Levels) > 0 {
@@ -664,10 +669,38 @@ func (r *ModelRegistry) GetAvailableModelDefinitions() []*ModelInfo {
 		if !available || registration == nil || registration.Info == nil {
 			continue
 		}
-		models = append(models, cloneModelInfo(registration.Info))
+		model := cloneModelInfo(registration.Info)
+		model.Providers = modelRegistrationProviders(registration)
+		models = append(models, model)
 	}
 	sortModelInfosByID(models)
 	return models
+}
+
+// modelRegistrationProviders returns stable billing provider identifiers for a model registration.
+func modelRegistrationProviders(registration *ModelRegistration) []string {
+	if registration == nil || len(registration.Providers) == 0 {
+		return nil
+	}
+
+	providerSet := make(map[string]struct{}, len(registration.Providers))
+	for provider, count := range registration.Providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider == "" || count <= 0 {
+			continue
+		}
+		providerSet[provider] = struct{}{}
+	}
+	if len(providerSet) == 0 {
+		return nil
+	}
+
+	providers := make([]string, 0, len(providerSet))
+	for provider := range providerSet {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return providers
 }
 
 // modelRegistrationAvailability applies the registry visibility rules to one model registration.


### PR DESCRIPTION
## Summary

Expose the authoritative provider identifiers used by usage records and billing rules in Management API model responses.

## Problem

Model responses previously exposed protocol metadata such as `type`, but did not expose the actual provider identifier used by `usage.provider`.

This forced clients to infer billing providers from model metadata. That inference is unreliable:

- Codex models use `type: "openai"` while their usage provider is `codex`.
- OpenAI-compatible channels may use arbitrary user-defined provider names.
- Incorrect inference can create price rules that never match real usage, resulting in default zero-price charges.

## Changes

- Add an optional `providers` field to model metadata.
- Track provider identifiers for each registered model.
- Return normalized active provider identifiers from `/models?scope=available`.
- Annotate static model definitions with canonical billing providers.
- Normalize Codex plan channels to the `codex` billing provider.
- Normalize xAI aliases to the `xai` billing provider.
- Preserve provider metadata when cloning model definitions.
- Add coverage for:
  - multiple providers serving the same model;
  - provider removal and reference counts;
  - provider normalization and invalid-count filtering;
  - canonical static provider mappings.
- Update the English and Chinese Management API documentation.

## Compatibility

This is an additive API change. Existing clients that do not consume `providers` remain unaffected.

This PR intentionally does not restore AI Studio or Gemini Interactions support. Those providers require complete Home credential and scheduling lifecycles and should be handled separately.

## Validation

- `gofmt`
- `git diff --check`
- `go build -o test-output ./cmd/home && rm test-output`