### PR TITLE
feat(user): add verified email recovery

### DIFF
--- a/cmd/home/main.go
+++ b/cmd/home/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPIHome/internal/protocolmux"
 	quotacollector "github.com/router-for-me/CLIProxyAPIHome/internal/quota"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/respserver"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/usermail"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 	"gorm.io/gorm"
@@ -286,6 +287,8 @@ func run() int {
 		log.Errorf("failed to start runtime: %v", errStart)
 		return 1
 	}
+	userMailService := usermail.NewService(repo, func() *config.Config { return rt.Config() })
+	userMailService.Start(runCtx)
 	quotaHomeID := net.JoinHostPort(clusterClientAddr, strconv.Itoa(clusterAdvertisedPort))
 	quotaCollector := quotacollector.NewCollector(repo, quotacollector.Options{
 		HomeID: quotaHomeID,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,6 +19,11 @@ tls:
   cert: ""
   key: ""
 
+# Reverse-proxy IPs or CIDRs allowed to supply forwarded client addresses.
+# Keep empty when Home is directly exposed. Add only the exact Nginx/Caddy/load-balancer peers;
+# trust-all ranges such as 0.0.0.0/0 and ::/0 are rejected. Changes require a restart.
+trusted-proxies: []
+
 # Management API settings
 remote-management:
   # Whether to allow remote (non-localhost) management access.
@@ -38,6 +43,27 @@ remote-management:
 
   # Legacy compatibility field for tracking the embedded panel source repository.
   panel-github-repository: "https://github.com/router-for-me/Home-Management-Center"
+
+# Optional verified user email and password recovery.
+# Leave disabled to keep username-only registration and login behavior.
+user-email:
+  enabled: false
+  # Absolute public URL of the embedded user panel. Production deployments should use HTTPS.
+  public-user-url: "https://home.example.com/user.html"
+  from-address: "no-reply@example.com"
+  from-name: "CLIProxyAPIHome"
+  sender:
+    type: "smtp"
+    smtp:
+      host: "smtp.example.com"
+      port: 587
+      username: "smtp-user"
+      # The SMTP password is read from this environment variable and is never stored in config.yaml.
+      password-env: "HOME_USER_EMAIL_SMTP_PASSWORD"
+      # Required for every non-loopback SMTP host. Implicit TLS on port 465 is not supported.
+      starttls: true
+  verification-token-ttl: "24h"
+  reset-token-ttl: "30m"
 
 # Authentication directory used by explicit import/export file format (supports ~ for home directory).
 # Runtime state is stored in the database after importing.

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1133,6 +1133,7 @@ Example request:
 
 All request fields are optional, but `username`, if present, must not be empty. `credits`, if present, replaces the user's current credit balance. For billing workflows, prefer `/billing/balance-records/recharge` and `/billing/balance-records/deduct` so balance changes have ledger records.
 Set `credits_unlimited` to `true` when the user should have unlimited total balance but still be constrained by configured period limits.
+When `password` is present, a successful update increments the user's session version and invalidates all previously issued User API bearer tokens. The Management API does not issue a replacement user session.
 
 Response: same shape as `GET /users/:id`.
 
@@ -3688,11 +3689,24 @@ These fields are accepted by Home YAML config. `PUT /config.yaml` accepts non-cr
 | `tls.enable` | boolean | Enable HTTPS. |
 | `tls.cert` | string | TLS certificate path. |
 | `tls.key` | string | TLS private key path. |
+| `trusted-proxies` | array of string | Explicit reverse-proxy IP/CIDR allowlist used for forwarded client addresses. Empty trusts none; trust-all networks are rejected; restart after changes. |
 | `remote-management.allow-remote` | boolean | Allows non-localhost Management API requests when true. |
 | `remote-management.secret-key` | string | Management key. In local config mode, plaintext is hashed at startup. |
 | `remote-management.disable-control-panel` | boolean | Disables the embedded panel routes: `/`, `/index.html`, `/management.html`, `/user.html`, and `/assets/*`. |
 | `remote-management.disable-auto-update-panel` | boolean | Legacy compatibility flag; embedded panel assets are not updated at runtime. |
 | `remote-management.panel-github-repository` | string | Legacy compatibility field for the embedded panel source repository. |
+| `user-email.enabled` | boolean | Enables verified-email registration and password recovery when all mail settings are valid. |
+| `user-email.public-user-url` | string | Absolute public user-panel URL used in verify/reset links; production requires HTTPS. |
+| `user-email.from-address` | string | SMTP envelope/header mailbox without a display name. |
+| `user-email.from-name` | string | Optional safe display name for user email. |
+| `user-email.sender.type` | string | Mail sender type; currently only `smtp`. |
+| `user-email.sender.smtp.host` | string | SMTP host. Non-loopback hosts require STARTTLS. |
+| `user-email.sender.smtp.port` | integer | SMTP port; implicit TLS port `465` is unsupported. |
+| `user-email.sender.smtp.username` | string | Optional SMTP username. |
+| `user-email.sender.smtp.password-env` | string | Environment variable containing the SMTP password; the secret is not stored in config. |
+| `user-email.sender.smtp.starttls` | boolean | Requires STARTTLS with TLS 1.2 or newer. |
+| `user-email.verification-token-ttl` | string | Positive Go duration for verification tokens. |
+| `user-email.reset-token-ttl` | string | Positive Go duration for password-reset tokens. |
 | `auth-dir` | string | Local auth token directory. |
 | `proxy-url` | string | Global outbound proxy URL. |
 | `disable-image-generation` | boolean or `"chat"` | `false` enables image generation; `true` disables it globally; `"chat"` disables injection for non-image endpoints. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1133,6 +1133,7 @@ Path 参数：
 
 所有字段均可选；如果出现 `username`，则不能为空。`credits` 如果出现，会替换用户当前点数余额。对于计费工作流，优先使用 `/billing/balance-records/recharge` 和 `/billing/balance-records/deduct`，以便余额变更拥有分类账记录。
 当用户需要无限总余额、但仍受独立周期限额约束时，将 `credits_unlimited` 设为 `true`。
+请求中出现 `password` 且更新成功时，会递增用户 session version，使此前签发的所有 User API bearer token 失效。Management API 不会签发替换用户 session。
 
 输出：与 `GET /users/:id` 相同。
 
@@ -3658,11 +3659,24 @@ DELETE query：
 | `tls.enable` | boolean | 启用 HTTPS。 |
 | `tls.cert` | string | TLS certificate 路径。 |
 | `tls.key` | string | TLS private key 路径。 |
+| `trusted-proxies` | array of string | 允许提供转发客户端地址的明确反向代理 IP/CIDR 列表；空列表表示全部不信任，trust-all 网段会被拒绝，修改后需重启。 |
 | `remote-management.allow-remote` | boolean | 为 `true` 时允许非 localhost Management API 请求。 |
 | `remote-management.secret-key` | string | Management key；本地配置模式下明文会在启动时 hash。 |
 | `remote-management.disable-control-panel` | boolean | 禁用内嵌 panel routes：`/`、`/index.html`、`/management.html`、`/user.html`、`/assets/*`。 |
 | `remote-management.disable-auto-update-panel` | boolean | 兼容旧配置的字段；内嵌 panel assets 不会在运行时更新。 |
 | `remote-management.panel-github-repository` | string | 兼容旧配置的内嵌 panel 源仓库字段。 |
+| `user-email.enabled` | boolean | 邮件配置全部有效时启用已验证邮箱注册与密码找回。 |
+| `user-email.public-user-url` | string | verify/reset 链接使用的绝对公开用户面板 URL；生产环境要求 HTTPS。 |
+| `user-email.from-address` | string | 不带 display name 的 SMTP envelope/header 邮箱。 |
+| `user-email.from-name` | string | 用户邮件的可选安全 display name。 |
+| `user-email.sender.type` | string | 邮件 sender 类型；当前仅支持 `smtp`。 |
+| `user-email.sender.smtp.host` | string | SMTP host；非回环地址必须启用 STARTTLS。 |
+| `user-email.sender.smtp.port` | integer | SMTP 端口；不支持 implicit TLS 的 `465` 端口。 |
+| `user-email.sender.smtp.username` | string | 可选 SMTP username。 |
+| `user-email.sender.smtp.password-env` | string | 保存 SMTP 密码的环境变量名；secret 不写入 config。 |
+| `user-email.sender.smtp.starttls` | boolean | 要求使用 TLS 1.2 或更高版本的 STARTTLS。 |
+| `user-email.verification-token-ttl` | string | 验证 token 的正数 Go duration。 |
+| `user-email.reset-token-ttl` | string | 密码重置 token 的正数 Go duration。 |
 | `auth-dir` | string | 本地 auth token 目录。 |
 | `proxy-url` | string | 全局出站代理 URL。 |
 | `disable-image-generation` | boolean or `"chat"` | `false` 启用图像生成；`true` 全局禁用；`"chat"` 只对非 image endpoints 禁用注入。 |

--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -12,9 +12,42 @@ Home examples usually use port `8327`. The effective listen address comes from r
 
 ## Runtime Model
 
-User records, API keys, TOTP settings, and passkey entries are stored in the database-backed cluster repository. The `/user/*` route group is registered only when Home is running with the database-backed runtime route set.
+User records, optional email state, one-time security tokens, mail jobs, API keys, TOTP settings, and passkey entries are stored in the database-backed cluster repository. The `/user/*` route group is registered only when Home is running with the database-backed runtime route set.
 
 API key changes made through the User API update the same `api_key` table used by Home dispatch and publish a config refresh event.
+
+## User Email Configuration
+
+Verified email and password recovery are optional and disabled by default. A usable configuration enables all three capability flags returned by `GET /capabilities`.
+
+```yaml
+user-email:
+  enabled: true
+  public-user-url: "https://home.example.com/user.html"
+  from-address: "no-reply@example.com"
+  from-name: "CLIProxyAPIHome"
+  sender:
+    type: "smtp"
+    smtp:
+      host: "smtp.example.com"
+      port: 587
+      username: "smtp-user"
+      password-env: "HOME_USER_EMAIL_SMTP_PASSWORD"
+      starttls: true
+  verification-token-ttl: "24h"
+  reset-token-ttl: "30m"
+```
+
+Configuration rules:
+
+- `public-user-url` must be an absolute HTTPS URL. Plain HTTP is accepted only for `localhost` or a loopback IP.
+- `from-address` must be one mailbox without a display name.
+- The first sender implementation is SMTP. Every non-loopback SMTP host must use `starttls: true`; Home requires TLS 1.2 or newer and does not support implicit TLS on port 465. If `username` is configured, `password-env` must name a non-empty environment variable; the password is not stored in `config.yaml`.
+- `verification-token-ttl` and `reset-token-ttl` must be positive Go duration strings.
+- Missing or invalid settings keep the email capability disabled without preventing Home from starting.
+- `user-email` is Home-only configuration and is not forwarded to downstream CPA nodes.
+- Home ignores forwarded client-IP headers by default. When an explicit reverse proxy fronts Home, list only that proxy's exact IP addresses or CIDRs in top-level `trusted-proxies`; trust-all networks are rejected, and changes require a restart. This keeps IP-based registration and recovery limits correct without allowing direct clients to spoof their address.
+- Disabling the feature keeps existing email state in the database but stops new email changes, verification requests, and recovery requests. Previously issued verify/reset tokens can still be consumed until they expire or are invalidated.
 
 ## Authentication
 
@@ -22,14 +55,20 @@ Public routes:
 
 | Method | Path | Description |
 | --- | --- | --- |
+| `GET` | `/capabilities` | Reports optional User API capabilities. |
 | `POST` | `/register` | Creates a user and returns a bearer token. |
 | `POST` | `/login` | Password login for users without passkey and without TOTP. |
 | `POST` | `/login/totp` | Password plus TOTP login for users with TOTP enabled. |
 | `POST` | `/login/passkey` | Passkey login. |
+| `POST` | `/email/verify` | Consumes an email-verification token. |
+| `POST` | `/password/forgot` | Accepts a generic password-recovery request. |
+| `POST` | `/password/reset` | Consumes a reset token and sets a new password. |
 
 All other `/user/*` routes require a bearer token returned by a successful register or login response.
 The bearer token is an RS256 JWT signed with the cluster root CA private key and verified with the cluster root CA public key. Replacing the cluster root CA invalidates previously issued User API tokens.
-Password values are hashed and verified exactly as provided; leading and trailing whitespace is not trimmed.
+Bearer tokens also carry the user's current session version. A successful password change, password reset, or Management API password update increments that version and invalidates older bearer tokens. Authenticated password changes return a replacement bearer session for the current client; password reset does not log the user in.
+Password values are hashed and verified exactly as provided; leading and trailing whitespace is not trimmed. New bcrypt passwords are limited to 72 UTF-8 bytes.
+User API JSON request bodies are limited to 1 MiB.
 
 Supported request headers:
 
@@ -74,6 +113,12 @@ Successful login and register responses return:
     "credits": 0,
     "totp_enabled": false,
     "passkey_count": 0,
+    "email_status": {
+      "configured": true,
+      "verified": false,
+      "masked": "a***@example.com",
+      "recovery_ready": false
+    },
     "created_at": "2026-06-02T10:00:00Z",
     "updated_at": "2026-06-02T10:00:00Z"
   }
@@ -85,6 +130,8 @@ User API handlers usually return both a machine-readable `error` code and a huma
 ```json
 { "error": "invalid_credentials", "message": "invalid credentials" }
 ```
+
+Validation and authentication failures keep specific safe messages. Server-side `5xx` failures retain their machine-readable code but use the generic message `internal server error` so database and implementation details are not exposed publicly.
 
 Common errors:
 
@@ -102,6 +149,7 @@ The table below is extracted from the User API route group registered by `intern
 
 | Method | Path |
 | --- | --- |
+| `GET` | `/capabilities` |
 | `POST` | `/register` |
 | `POST` | `/login` |
 | `POST` | `/login/passkey/begin` |
@@ -111,6 +159,12 @@ The table below is extracted from the User API route group registered by `intern
 | `GET` | `/me` |
 | `PATCH` | `/password` |
 | `POST` | `/password` |
+| `POST` | `/password/forgot` |
+| `POST` | `/password/reset` |
+| `PUT` | `/email` |
+| `DELETE` | `/email` |
+| `POST` | `/email/verification` |
+| `POST` | `/email/verify` |
 | `GET` | `/totp` |
 | `POST` | `/totp` |
 | `POST` | `/totp/show` |
@@ -142,6 +196,29 @@ The table below is extracted from the User API route group registered by `intern
 
 ## Account
 
+### GET `/capabilities`
+
+Reports whether the current Home configuration supports optional email registration, email verification, and password recovery. This route does not expose SMTP settings or user data.
+
+Example response:
+
+```json
+{
+  "capabilities": {
+    "email_registration": true,
+    "email_verification": true,
+    "password_recovery": true
+  },
+  "server_info": {
+    "home_version": "v1.2.3",
+    "home_commit": "abcdef0",
+    "home_build_date": "2026-07-20"
+  }
+}
+```
+
+All three flags are `false` when `user-email.enabled` is false or the mail configuration is incomplete or invalid. Older Home versions may return `404` because this route does not exist.
+
 ### POST `/register`
 
 Creates a user account, stores a bcrypt password hash, and returns a bearer token.
@@ -151,7 +228,8 @@ Example request:
 ```json
 {
   "username": "alice",
-  "password": "secret"
+  "password": "secret",
+  "email": "alice@example.com"
 }
 ```
 
@@ -161,14 +239,22 @@ Fields:
 | --- | --- | --- | --- |
 | `username` | string | yes | Username. Aliases: `user_name`, `user-name`. |
 | `password` | string | yes | Plaintext password used to create the stored password hash. |
+| `email` | string | no | Optional email. Accepted only when `email_registration` is true. It is normalized and starts unverified; it does not reserve ownership until verification succeeds. |
 
-Response: login response shape.
+Response: login response shape. When an email is supplied, Home applies verification-delivery limits and attempts to queue a message asynchronously; an already-owned address or a limited request is accepted without sending. Registration success does not mean the email is verified or ready for recovery.
+
+All registration attempts are limited per source IP and globally, including username-only registration. Verification delivery has its own target-email limits. A limited response is `429 registration_rate_limited` with `Retry-After`.
 
 Common errors:
 
 ```json
 { "error": "user_exists", "message": "user already exists" }
+{ "error": "email_feature_unavailable", "message": "email feature is unavailable" }
+{ "error": "invalid_email", "message": "email is invalid" }
 { "error": "invalid_body", "message": "password is required" }
+{ "error": "invalid_password", "message": "password exceeds the 72-byte bcrypt limit" }
+{ "error": "request_too_large", "message": "request body exceeds 1048576 bytes" }
+{ "error": "registration_rate_limited", "message": "registration rate limit exceeded" }
 ```
 
 ### POST `/login`
@@ -281,6 +367,12 @@ Example response:
     "credits": 0,
     "totp_enabled": false,
     "passkey_count": 1,
+    "email_status": {
+      "configured": true,
+      "verified": true,
+      "masked": "a***@example.com",
+      "recovery_ready": true
+    },
     "passkeys": [
       {
         "id": "passkey-1",
@@ -326,20 +418,124 @@ Fields:
 | --- | --- | --- | --- |
 | `new_password` | string | yes | New plaintext password. Alias: `new-password`. |
 
-Example response:
+Response: login response shape with a new `token` and `expires_at`. The password update increments the user session version, so the bearer token used for this request and all other older bearer tokens become invalid. The client must replace its current session atomically with the returned session.
+
+TOTP and passkey data are not changed.
+
+## Email Verification and Password Recovery
+
+Email addresses are optional. Home stores a normalized lowercase address, but User API responses expose only `email_status`:
+
+Only a verified email is a unique ownership claim. Multiple active accounts may temporarily hold the same unverified address, so an unauthenticated registration cannot permanently squat somebody else's email and registration/update responses do not reveal whether another account already owns it. Home returns the normal accepted result but suppresses verification mail when another active account already owns the address. The first account that verifies an unclaimed address owns it atomically; later conflicting verification links receive the same generic invalid-or-expired response.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `configured` | boolean | An email is currently stored. |
+| `verified` | boolean | Ownership of the current email version has been verified. |
+| `masked` | string | Privacy-safe display value such as `a***@example.com`; empty when no email is configured. |
+| `recovery_ready` | boolean | The email is verified and the current mail configuration is usable. |
+
+Changing the email immediately clears verification, increments the email version, invalidates outstanding verify/reset tokens, and supersedes pending mail jobs. Submitting the exact same normalized address is idempotent and preserves verification.
+
+### PUT `/email`
+
+Adds or replaces the authenticated user's email. Requires a bearer token and an enabled email capability.
+
+```json
+{ "email": "new@example.com" }
+```
+
+Success returns `200` with `{ "status": "ok", "user": ... }`. The returned user contains the new unverified `email_status`. This route stores the address but does not itself queue a message; call `/email/verification` next.
+
+Common errors:
+
+```json
+{ "error": "invalid_email", "message": "email is invalid" }
+{ "error": "email_feature_unavailable", "message": "email feature is unavailable" }
+{ "error": "email_update_rate_limited", "message": "email update rate limit exceeded" }
+```
+
+### DELETE `/email`
+
+Removes the authenticated user's stored email. This route remains available when the email capability is disabled so a user can always remove optional personal data. Removing an email increments the email version, invalidates outstanding verify/reset tokens, supersedes pending mail jobs, and releases the address for another active user.
+
+Success returns `200 { "status": "ok", "user": ... }`. Repeating the request when no email is configured is idempotent.
+
+### POST `/email/verification`
+
+Queues a verification message for the authenticated user's current unverified email. No request body is required.
+
+Success:
+
+```http
+HTTP/1.1 202 Accepted
+```
+
+```json
+{ "status": "accepted" }
+```
+
+An already verified address returns an idempotent `200 { "status": "ok" }`. Registration's initial verification message and manual resends share the same limiter. Requests have a true 60-second cooldown and are additionally limited per user, target email, source IP, and globally. A limited manual resend returns `429 verification_rate_limited` with an exact `Retry-After` value.
+
+```json
+{ "error": "email_not_configured", "message": "email is not configured" }
+{ "error": "verification_rate_limited", "message": "verification request rate limit exceeded" }
+```
+
+### POST `/email/verify`
+
+Consumes a short-lived, single-use email-verification token. The emailed UI link should first show an explicit confirmation screen and only call this POST after the user confirms, so link scanners do not consume the token.
+
+```json
+{ "token": "base64url-token" }
+```
+
+Success: `200 { "status": "ok" }`.
+
+Expired, used, unknown, superseded, wrong-email-version, or already-owned-address tokens all use the same response:
+
+```json
+{ "error": "invalid_or_expired_token", "message": "verification link is invalid or expired" }
+```
+
+### POST `/password/forgot`
+
+Accepts an email address and, when an eligible verified account matches, queues a reset message. Once email capability is enabled, every parseable request receives the same status and body whether the address is missing, invalid, unknown, unverified, rate-limited, or temporarily unable to enqueue mail.
+
+```json
+{ "email": "alice@example.com" }
+```
+
+```http
+HTTP/1.1 202 Accepted
+```
 
 ```json
 {
-  "status": "ok",
-  "user": {
-    "id": 1,
-    "username": "alice",
-    "totp_enabled": false,
-    "passkey_count": 0,
-    "created_at": "2026-06-02T10:00:00Z",
-    "updated_at": "2026-06-02T10:10:00Z"
-  }
+  "status": "accepted",
+  "message": "If an eligible account matches, password reset instructions will be sent."
 }
+```
+
+Home applies a five-minute target-email cooldown plus per-IP, per-email-hourly, and global limits before enqueueing recovery mail. It also pads accepted responses to a minimum processing duration to reduce timing differences between eligible and ineligible accounts. Clients must still show the same confirmation UI for every accepted response. When the global email capability is disabled, this route returns `404 email_feature_unavailable`.
+
+### POST `/password/reset`
+
+Consumes a short-lived, single-use reset token and sets a new password.
+
+```json
+{
+  "token": "base64url-token",
+  "new_password": "new-secret"
+}
+```
+
+`new-password` is accepted as an alias. Success returns `200 { "status": "ok" }`, increments the session version, and invalidates all older User API bearer tokens, outstanding reset tokens, and queued reset-mail jobs. Any authenticated or Management API password update performs the same reset-token and queued-job revocation. Password reset does not return a login session. TOTP and passkeys remain unchanged and continue to apply on the next login.
+
+Invalid, expired, used, superseded, or wrong-email-version tokens all return:
+
+```json
+{ "error": "invalid_or_expired_token", "message": "password reset link is invalid or expired" }
 ```
 
 ## TOTP

--- a/docs/user/api_CN.md
+++ b/docs/user/api_CN.md
@@ -12,9 +12,42 @@ Home 示例端口通常为 `8327`。实际监听地址来自 runtime config、`c
 
 ## Runtime 模型
 
-用户记录、API key、TOTP 配置和 passkey entries 存储在 database-backed cluster repository 中。`/user/*` route group 只会在 Home 使用 database-backed runtime route set 时注册。
+用户记录、可选邮箱状态、一次性安全 token、邮件任务、API key、TOTP 配置和 passkey entries 存储在 database-backed cluster repository 中。`/user/*` route group 只会在 Home 使用 database-backed runtime route set 时注册。
 
 通过 User API 修改 API key 会更新 Home dispatch 使用的同一张 `api_key` 表，并发布 config refresh event。
+
+## 用户邮箱配置
+
+邮箱验证与密码找回是可选能力，默认关闭。只有配置完整且可用时，`GET /capabilities` 返回的三个 capability flag 才会启用。
+
+```yaml
+user-email:
+  enabled: true
+  public-user-url: "https://home.example.com/user.html"
+  from-address: "no-reply@example.com"
+  from-name: "CLIProxyAPIHome"
+  sender:
+    type: "smtp"
+    smtp:
+      host: "smtp.example.com"
+      port: 587
+      username: "smtp-user"
+      password-env: "HOME_USER_EMAIL_SMTP_PASSWORD"
+      starttls: true
+  verification-token-ttl: "24h"
+  reset-token-ttl: "30m"
+```
+
+配置规则：
+
+- `public-user-url` 必须是绝对 HTTPS URL；只有 `localhost` 或回环 IP 可以使用明文 HTTP。
+- `from-address` 必须是单个邮箱地址，不能带 display name。
+- 首个 sender 实现为 SMTP。所有非回环 SMTP host 都必须配置 `starttls: true`；Home 要求 TLS 1.2 或更高版本，暂不支持 465 端口的 implicit TLS。配置 `username` 时，`password-env` 必须指向非空环境变量；密码不会写入 `config.yaml`。
+- `verification-token-ttl` 与 `reset-token-ttl` 必须是正数 Go duration 字符串。
+- 配置缺失或无效时，邮箱 capability 保持关闭，但不会阻止 Home 启动。
+- `user-email` 只属于 Home，不会下发到 CPA 节点。
+- Home 默认忽略转发的客户端 IP header。若 Home 前面有明确的反向代理，只在顶层 `trusted-proxies` 中填写该 Nginx/Caddy/负载均衡器的精确 IP 或 CIDR；系统拒绝 trust-all 网段，修改后需要重启。这样既能让注册与找回限流识别真实来源，又不会允许直连客户端伪造地址。
+- 关闭功能会保留数据库中的邮箱状态，但停止新的邮箱修改、验证请求和找回请求。此前签发的 verify/reset token 在过期或被撤销前仍可消费。
 
 ## 认证
 
@@ -22,14 +55,20 @@ Home 示例端口通常为 `8327`。实际监听地址来自 runtime config、`c
 
 | Method | Path | 说明 |
 | --- | --- | --- |
+| `GET` | `/capabilities` | 返回可选 User API capability。 |
 | `POST` | `/register` | 创建用户并返回 bearer token。 |
 | `POST` | `/login` | 用户未启用 passkey 和 TOTP 时的密码登录。 |
 | `POST` | `/login/totp` | 用户启用 TOTP 时的密码 + TOTP 登录。 |
 | `POST` | `/login/passkey` | Passkey 登录。 |
+| `POST` | `/email/verify` | 消费邮箱验证 token。 |
+| `POST` | `/password/forgot` | 接收通用密码找回请求。 |
+| `POST` | `/password/reset` | 消费重置 token 并设置新密码。 |
 
 其他所有 `/user/*` route 都需要注册或登录成功后返回的 bearer token。
 Bearer token 是使用集群根 CA 私钥签名、并使用集群根 CA 公钥验证的 RS256 JWT。替换集群根 CA 后，之前签发的 User API token 会失效。
-密码会按照原始输入值进行 hash 和校验，不会去除首尾空白字符。
+Bearer token 还包含用户当前 session version。密码修改、密码重置或 Management API 管理员更新密码成功后都会递增该版本，使旧 bearer token 失效。已认证修改密码会为当前客户端返回替换 session；密码重置不会自动登录。
+密码会按照原始输入值进行 hash 和校验，不会去除首尾空白字符。新 bcrypt 密码最多为 72 个 UTF-8 字节。
+User API JSON 请求体最大为 1 MiB。
 
 支持的请求头：
 
@@ -74,6 +113,12 @@ Home User API 会额外写入以下响应头：
     "credits": 0,
     "totp_enabled": false,
     "passkey_count": 0,
+    "email_status": {
+      "configured": true,
+      "verified": false,
+      "masked": "a***@example.com",
+      "recovery_ready": false
+    },
     "created_at": "2026-06-02T10:00:00Z",
     "updated_at": "2026-06-02T10:00:00Z"
   }
@@ -85,6 +130,8 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 ```json
 { "error": "invalid_credentials", "message": "invalid credentials" }
 ```
+
+校验与认证失败会保留具体且安全的提示；服务端 `5xx` 错误仍保留机器可读 code，但统一使用 `internal server error`，避免向公网暴露数据库或实现细节。
 
 常见错误：
 
@@ -102,6 +149,7 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 
 | Method | Path |
 | --- | --- |
+| `GET` | `/capabilities` |
 | `POST` | `/register` |
 | `POST` | `/login` |
 | `POST` | `/login/passkey/begin` |
@@ -111,6 +159,12 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `GET` | `/me` |
 | `PATCH` | `/password` |
 | `POST` | `/password` |
+| `POST` | `/password/forgot` |
+| `POST` | `/password/reset` |
+| `PUT` | `/email` |
+| `DELETE` | `/email` |
+| `POST` | `/email/verification` |
+| `POST` | `/email/verify` |
 | `GET` | `/totp` |
 | `POST` | `/totp` |
 | `POST` | `/totp/show` |
@@ -142,6 +196,29 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 
 ## 账号
 
+### GET `/capabilities`
+
+返回当前 Home 配置是否支持可选邮箱注册、邮箱验证与密码找回。该 route 不暴露 SMTP 配置或用户数据。
+
+响应示例：
+
+```json
+{
+  "capabilities": {
+    "email_registration": true,
+    "email_verification": true,
+    "password_recovery": true
+  },
+  "server_info": {
+    "home_version": "v1.2.3",
+    "home_commit": "abcdef0",
+    "home_build_date": "2026-07-20"
+  }
+}
+```
+
+当 `user-email.enabled` 为 false，或邮件配置不完整/无效时，三个 flag 都为 `false`。旧版 Home 可能因没有该 route 而返回 `404`。
+
 ### POST `/register`
 
 创建用户账号，保存 bcrypt password hash，并返回 bearer token。
@@ -151,7 +228,8 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 ```json
 {
   "username": "alice",
-  "password": "secret"
+  "password": "secret",
+  "email": "alice@example.com"
 }
 ```
 
@@ -161,14 +239,22 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 | --- | --- | --- | --- |
 | `username` | string | yes | 用户名。Aliases: `user_name`, `user-name`。 |
 | `password` | string | yes | 用于生成存储密码 hash 的明文密码。 |
+| `email` | string | no | 可选邮箱。仅在 `email_registration` 为 true 时接受；会先归一化并以未验证状态保存，验证成功前不会占用唯一所有权。 |
 
-响应：登录响应结构。
+响应：登录响应结构。提供邮箱时，Home 会先执行验证投递限流，再尝试异步排队；地址已被拥有或请求已受限时仍接受注册，但不会发送邮件。注册成功不代表邮箱已验证或已可用于找回。
+
+所有注册尝试（包括不带邮箱的 username-only 注册）都会按来源 IP 和全局维度限流；验证邮件投递另有目标邮箱维度限制。被限制时返回 `429 registration_rate_limited` 与 `Retry-After`。
 
 常见错误：
 
 ```json
 { "error": "user_exists", "message": "user already exists" }
+{ "error": "email_feature_unavailable", "message": "email feature is unavailable" }
+{ "error": "invalid_email", "message": "email is invalid" }
 { "error": "invalid_body", "message": "password is required" }
+{ "error": "invalid_password", "message": "password exceeds the 72-byte bcrypt limit" }
+{ "error": "request_too_large", "message": "request body exceeds 1048576 bytes" }
+{ "error": "registration_rate_limited", "message": "registration rate limit exceeded" }
 ```
 
 ### POST `/login`
@@ -281,6 +367,12 @@ Authorization: Bearer user.jwt.token
     "credits": 0,
     "totp_enabled": false,
     "passkey_count": 1,
+    "email_status": {
+      "configured": true,
+      "verified": true,
+      "masked": "a***@example.com",
+      "recovery_ready": true
+    },
     "passkeys": [
       {
         "id": "passkey-1",
@@ -326,20 +418,124 @@ Authorization: Bearer user.jwt.token
 | --- | --- | --- | --- |
 | `new_password` | string | yes | 新明文密码。Alias: `new-password`。 |
 
-示例响应：
+响应：登录响应结构，包含新的 `token` 与 `expires_at`。密码更新会递增用户 session version，因此本次请求使用的 bearer token 和其他所有旧 bearer token 都会失效；客户端必须原子替换为返回的新 session。
+
+TOTP 与 passkey 数据不会被修改。
+
+## 邮箱验证与密码找回
+
+邮箱是可选字段。Home 保存归一化后的小写地址，但 User API 响应只暴露 `email_status`：
+
+只有已验证邮箱才构成唯一所有权声明。多个 active account 可以暂时保存同一个未验证地址，因此匿名注册不能永久抢占他人的邮箱，注册/更新响应也不会泄露该地址是否已被其他账号拥有。若地址已由其他 active account 拥有，Home 仍返回正常 accepted 结果，但不会发送验证邮件。首个成功验证尚未被占用地址的账号会原子取得所有权；之后发生冲突的验证链接统一返回“无效或已过期”。
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `configured` | boolean | 当前是否已保存邮箱。 |
+| `verified` | boolean | 当前 email version 是否已完成所有权验证。 |
+| `masked` | string | 例如 `a***@example.com` 的隐私安全展示值；未配置时为空。 |
+| `recovery_ready` | boolean | 邮箱已验证且当前邮件配置可用。 |
+
+修改邮箱会立即清除验证状态、递增 email version、撤销未完成的 verify/reset token，并将待处理邮件任务标记为 superseded。提交完全相同的归一化地址是幂等操作，不会清除验证状态。
+
+### PUT `/email`
+
+添加或替换当前认证用户的邮箱。需要 bearer token，并要求邮箱 capability 已启用。
+
+```json
+{ "email": "new@example.com" }
+```
+
+成功返回 `200` 和 `{ "status": "ok", "user": ... }`。返回用户中的新邮箱状态为未验证。该 route 只保存地址，不直接排队发送邮件；随后调用 `/email/verification`。
+
+常见错误：
+
+```json
+{ "error": "invalid_email", "message": "email is invalid" }
+{ "error": "email_feature_unavailable", "message": "email feature is unavailable" }
+{ "error": "email_update_rate_limited", "message": "email update rate limit exceeded" }
+```
+
+### DELETE `/email`
+
+删除当前认证用户保存的邮箱。即使邮箱 capability 已关闭，该 route 仍保持可用，确保用户始终可以删除可选个人信息。删除邮箱会递增 email version、撤销未完成的 verify/reset token、将待处理邮件任务标记为 superseded，并释放该地址供其他 active user 使用。
+
+成功返回 `200 { "status": "ok", "user": ... }`。未配置邮箱时重复调用是幂等操作。
+
+### POST `/email/verification`
+
+为当前认证用户的未验证邮箱排队发送验证邮件。无需请求体。
+
+成功：
+
+```http
+HTTP/1.1 202 Accepted
+```
+
+```json
+{ "status": "accepted" }
+```
+
+邮箱已经验证时，幂等返回 `200 { "status": "ok" }`。注册时的首次验证邮件与手动重发共用同一组限流：严格 60 秒冷却，并同时按 user、目标邮箱、来源 IP 和全局维度限制。手动重发被限制时返回 `429 verification_rate_limited`，`Retry-After` 为实际剩余秒数。
+
+```json
+{ "error": "email_not_configured", "message": "email is not configured" }
+{ "error": "verification_rate_limited", "message": "verification request rate limit exceeded" }
+```
+
+### POST `/email/verify`
+
+消费短时、单次使用的邮箱验证 token。邮件中的 UI 链接应先展示明确确认页面，只有用户确认后才调用此 POST，避免邮件安全扫描器直接消费 token。
+
+```json
+{ "token": "base64url-token" }
+```
+
+成功：`200 { "status": "ok" }`。
+
+过期、已用、未知、已被替代、email version 不匹配，或目标邮箱已由其他账号拥有的 token 都统一返回：
+
+```json
+{ "error": "invalid_or_expired_token", "message": "verification link is invalid or expired" }
+```
+
+### POST `/password/forgot`
+
+接收邮箱地址；如果存在符合条件且已验证的账号，则排队发送重置邮件。邮箱 capability 启用后，所有可解析请求都返回完全相同的状态与响应体，无论邮箱缺失、非法、未知、未验证、已限流，还是邮件暂时无法入队。
+
+```json
+{ "email": "alice@example.com" }
+```
+
+```http
+HTTP/1.1 202 Accepted
+```
 
 ```json
 {
-  "status": "ok",
-  "user": {
-    "id": 1,
-    "username": "alice",
-    "totp_enabled": false,
-    "passkey_count": 0,
-    "created_at": "2026-06-02T10:00:00Z",
-    "updated_at": "2026-06-02T10:10:00Z"
-  }
+  "status": "accepted",
+  "message": "If an eligible account matches, password reset instructions will be sent."
 }
+```
+
+Home 会在入队前执行目标邮箱五分钟冷却，以及 IP、邮箱小时级和全局限流；同时将 accepted 响应补齐到最短处理时长，以降低符合条件与不符合条件账号之间的耗时差异。客户端仍必须对所有 accepted 响应展示同一确认 UI。全局邮箱 capability 关闭时，该 route 返回 `404 email_feature_unavailable`。
+
+### POST `/password/reset`
+
+消费短时、单次使用的 reset token 并设置新密码。
+
+```json
+{
+  "token": "base64url-token",
+  "new_password": "new-secret"
+}
+```
+
+也接受 `new-password` alias。成功返回 `200 { "status": "ok" }`，递增 session version，并撤销所有旧 User API bearer token、其他未使用 reset token 与排队中的密码重置邮件任务。认证用户修改密码或 Management API 管理员更新密码时也会执行相同的 reset token 与队列任务撤销。密码重置不会返回登录 session。TOTP 与 passkey 保持不变，下次登录时仍继续生效。
+
+无效、过期、已用、已被替代或 email version 不匹配统一返回：
+
+```json
+{ "error": "invalid_or_expired_token", "message": "password reset link is invalid or expired" }
 ```
 
 ## TOTP

--- a/internal/cluster/config_snapshot.go
+++ b/internal/cluster/config_snapshot.go
@@ -81,6 +81,11 @@ func RuntimeConfigFromRoot(root map[string]any) (*appconfig.Config, []byte, erro
 		return nil, nil, errUnmarshal
 	}
 	cfg.NormalizePluginsConfig()
+	cfg.NormalizeUserEmailConfig()
+	cfg.NormalizeTrustedProxies()
+	if errTrustedProxies := appconfig.ValidateTrustedProxies(cfg.TrustedProxies); errTrustedProxies != nil {
+		return nil, nil, errTrustedProxies
+	}
 	cfg.SanitizeGeminiKeys()
 	cfg.SanitizeVertexCompatKeys()
 	cfg.SanitizeCodexKeys()

--- a/internal/cluster/config_snapshot_test.go
+++ b/internal/cluster/config_snapshot_test.go
@@ -45,6 +45,50 @@ func TestRuntimeConfigFromRootAppliesHomeModeScalarsAndPreservesRemoteManagement
 	}
 }
 
+func TestRuntimeConfigFromRootPreservesAndNormalizesUserEmailConfig(t *testing.T) {
+	root := map[string]any{
+		"trusted-proxies": []any{" 127.0.0.1 ", "10.0.0.0/8", "127.0.0.1"},
+		"user-email": map[string]any{
+			"enabled":         true,
+			"public-user-url": " https://home.example.com/user.html ",
+			"from-address":    " no-reply@example.com ",
+			"sender": map[string]any{
+				"type": " SMTP ",
+				"smtp": map[string]any{
+					"host":         " smtp.example.com ",
+					"password-env": " HOME_USER_EMAIL_SMTP_PASSWORD ",
+				},
+			},
+		},
+	}
+
+	cfg, payload, errConfig := RuntimeConfigFromRoot(root)
+	if errConfig != nil {
+		t.Fatalf("RuntimeConfigFromRoot() error = %v", errConfig)
+	}
+	if !cfg.UserEmail.Enabled || cfg.UserEmail.PublicUserURL != "https://home.example.com/user.html" || cfg.UserEmail.Sender.Type != "smtp" {
+		t.Fatalf("normalized user email config = %#v", cfg.UserEmail)
+	}
+	if cfg.UserEmail.Sender.SMTP.Port != 587 || cfg.UserEmail.VerificationTokenTTL != "24h" || cfg.UserEmail.ResetTokenTTL != "30m" {
+		t.Fatalf("user email defaults = %#v", cfg.UserEmail)
+	}
+	if len(cfg.TrustedProxies) != 2 || cfg.TrustedProxies[0] != "127.0.0.1" || cfg.TrustedProxies[1] != "10.0.0.0/8" {
+		t.Fatalf("trusted proxies = %#v", cfg.TrustedProxies)
+	}
+	if !strings.Contains(string(payload), "user-email:") || !strings.Contains(string(payload), "HOME_USER_EMAIL_SMTP_PASSWORD") {
+		t.Fatalf("runtime payload lost user email config:\n%s", payload)
+	}
+}
+
+func TestRuntimeConfigFromRootRejectsUnsafeTrustedProxy(t *testing.T) {
+	_, _, errConfig := RuntimeConfigFromRoot(map[string]any{
+		"trusted-proxies": []any{"0.0.0.0/0"},
+	})
+	if errConfig == nil {
+		t.Fatal("RuntimeConfigFromRoot(trust-all proxy) succeeded")
+	}
+}
+
 func TestLoadConfigAsRuntimeConfigProjectsPluginAuthRevisionWithoutStoreAuth(t *testing.T) {
 	db, errOpen := OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
 	if errOpen != nil {

--- a/internal/cluster/db.go
+++ b/internal/cluster/db.go
@@ -123,7 +123,7 @@ func AutoMigrate(db *gorm.DB) error {
 }
 
 func autoMigrate(db *gorm.DB) error {
-	if errMigrate := db.AutoMigrate(&AuthRecord{}, &ConfigRecord{}, &KVRecord{}, &PluginStatusRecord{}, &PluginTaskRecord{}, &PluginStoreAuthRecord{}, &PluginStoreAuthKeyRecord{}, &UserRecord{}, &APIKeyRecord{}, &ChannelGroupRecord{}, &ChannelGroupDetailRecord{}, &ModelGroupRecord{}, &ModelGroupDetailRecord{}, &ClusterNodeRecord{}, &CPANodeRecord{}, &ClusterEventRecord{}, &UsageRecord{}, &QuotaSnapshotRecord{}, &QuotaWindowRecord{}, &BillingModelPriceRecord{}, &BillingModelPriceImportPreviewRecord{}, &BillingModelPriceImportOperationRecord{}, &BillingBalanceRecord{}, &BillingChargeRecord{}, &ProxyPoolRecord{}, &AppLogRecord{}, &OAuthSessionRecord{}, &CertificateRecord{}); errMigrate != nil {
+	if errMigrate := db.AutoMigrate(&AuthRecord{}, &ConfigRecord{}, &KVRecord{}, &PluginStatusRecord{}, &PluginTaskRecord{}, &PluginStoreAuthRecord{}, &PluginStoreAuthKeyRecord{}, &UserRecord{}, &UserSecurityTokenRecord{}, &UserMailJobRecord{}, &UserSecurityThrottleRecord{}, &APIKeyRecord{}, &ChannelGroupRecord{}, &ChannelGroupDetailRecord{}, &ModelGroupRecord{}, &ModelGroupDetailRecord{}, &ClusterNodeRecord{}, &CPANodeRecord{}, &ClusterEventRecord{}, &UsageRecord{}, &QuotaSnapshotRecord{}, &QuotaWindowRecord{}, &BillingModelPriceRecord{}, &BillingModelPriceImportPreviewRecord{}, &BillingModelPriceImportOperationRecord{}, &BillingBalanceRecord{}, &BillingChargeRecord{}, &ProxyPoolRecord{}, &AppLogRecord{}, &OAuthSessionRecord{}, &CertificateRecord{}); errMigrate != nil {
 		return errMigrate
 	}
 	if errMigrate := migrateBillingIndexes(db); errMigrate != nil {
@@ -142,6 +142,9 @@ func autoMigrate(db *gorm.DB) error {
 		return errMigrate
 	}
 	if errMigrate := migrateUserUniqueUsername(db); errMigrate != nil {
+		return errMigrate
+	}
+	if errMigrate := migrateUserUniqueEmail(db); errMigrate != nil {
 		return errMigrate
 	}
 	if errMigrate := migrateAuthNextRetryAfter(db); errMigrate != nil {
@@ -616,6 +619,16 @@ func migrateUserUniqueUsername(db *gorm.DB) error {
 		return fmt.Errorf("database connection is nil")
 	}
 	return db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_username_active_unique ON "user" ("username") WHERE "deleted_at" IS NULL`).Error
+}
+
+func migrateUserUniqueEmail(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	if errCreate := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_user_email_verified_active_unique ON "user" ("email") WHERE "deleted_at" IS NULL AND "email" IS NOT NULL AND "email_verified_at" IS NOT NULL`).Error; errCreate != nil {
+		return errCreate
+	}
+	return db.Exec(`DROP INDEX IF EXISTS idx_user_email_active_unique`).Error
 }
 
 func migrateCertificateFingerprints(db *gorm.DB) error {

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -223,12 +223,16 @@ func (PluginTaskRecord) TableName() string {
 }
 
 type UserRecord struct {
-	ID               uint    `gorm:"column:id;primaryKey;autoIncrement;index:idx_user_active_order,priority:2"`
-	Username         string  `gorm:"column:username;not null;index;index:idx_user_username_active,priority:1"`
-	Password         string  `gorm:"column:password;type:text"`
-	Credits          float64 `gorm:"column:credits;not null;default:0"`
-	CreditsUnlimited bool    `gorm:"column:credits_unlimited;not null;default:false"`
-	Timezone         string  `gorm:"column:timezone;not null;default:Asia/Shanghai"`
+	ID               uint       `gorm:"column:id;primaryKey;autoIncrement;index:idx_user_active_order,priority:2"`
+	Username         string     `gorm:"column:username;not null;index;index:idx_user_username_active,priority:1"`
+	Password         string     `gorm:"column:password;type:text"`
+	Email            *string    `gorm:"column:email;type:text;index"`
+	EmailVerifiedAt  *time.Time `gorm:"column:email_verified_at"`
+	EmailVersion     uint64     `gorm:"column:email_version;not null;default:0"`
+	SessionVersion   uint64     `gorm:"column:session_version;not null;default:0"`
+	Credits          float64    `gorm:"column:credits;not null;default:0"`
+	CreditsUnlimited bool       `gorm:"column:credits_unlimited;not null;default:false"`
+	Timezone         string     `gorm:"column:timezone;not null;default:Asia/Shanghai"`
 	// Period cost limits (null = disabled). Subject is user; all API keys inherit.
 	// window_mode_*: first_use (default; first billable charge opens a duration
 	// window, Claude/Codex-style session), sliding (rolling last-N duration),
@@ -263,6 +267,56 @@ type UserRecord struct {
 // TableName returns the database table name.
 func (UserRecord) TableName() string {
 	return "user"
+}
+
+type UserSecurityTokenRecord struct {
+	ID           uint       `gorm:"column:id;primaryKey;autoIncrement"`
+	UserID       uint       `gorm:"column:user_id;not null;index:idx_user_security_token_user_purpose,priority:1"`
+	Purpose      string     `gorm:"column:purpose;type:varchar(32);not null;index:idx_user_security_token_user_purpose,priority:2"`
+	TokenHash    string     `gorm:"column:token_hash;type:varchar(64);not null;uniqueIndex"`
+	EmailVersion uint64     `gorm:"column:email_version;not null;default:0"`
+	ExpiresAt    time.Time  `gorm:"column:expires_at;not null;index"`
+	UsedAt       *time.Time `gorm:"column:used_at;index"`
+	CreatedAt    time.Time  `gorm:"column:created_at"`
+}
+
+// TableName returns the database table name.
+func (UserSecurityTokenRecord) TableName() string {
+	return "user_security_token"
+}
+
+type UserMailJobRecord struct {
+	ID             uint       `gorm:"column:id;primaryKey;autoIncrement;index:idx_user_mail_job_status_next,priority:3"`
+	UserID         uint       `gorm:"column:user_id;not null;index:idx_user_mail_job_user_purpose,priority:1"`
+	Purpose        string     `gorm:"column:purpose;type:varchar(32);not null;index:idx_user_mail_job_user_purpose,priority:2"`
+	EmailVersion   uint64     `gorm:"column:email_version;not null;default:0"`
+	SessionVersion uint64     `gorm:"column:session_version;not null;default:0"`
+	Status         string     `gorm:"column:status;type:varchar(24);not null;index:idx_user_mail_job_status_next,priority:1"`
+	Attempts       int        `gorm:"column:attempts;not null;default:0"`
+	NextAttemptAt  time.Time  `gorm:"column:next_attempt_at;not null;index:idx_user_mail_job_status_next,priority:2"`
+	ClaimedBy      string     `gorm:"column:claimed_by;type:varchar(128)"`
+	ClaimExpiresAt *time.Time `gorm:"column:claim_expires_at;index"`
+	LastErrorCode  string     `gorm:"column:last_error_code;type:varchar(64)"`
+	SentAt         *time.Time `gorm:"column:sent_at"`
+	CreatedAt      time.Time  `gorm:"column:created_at"`
+	UpdatedAt      time.Time  `gorm:"column:updated_at"`
+}
+
+// TableName returns the database table name.
+func (UserMailJobRecord) TableName() string {
+	return "user_mail_job"
+}
+
+type UserSecurityThrottleRecord struct {
+	Key       string    `gorm:"column:key;type:varchar(160);primaryKey"`
+	Count     int       `gorm:"column:count;not null;default:0"`
+	ExpiresAt time.Time `gorm:"column:expires_at;not null;index"`
+	UpdatedAt time.Time `gorm:"column:updated_at"`
+}
+
+// TableName returns the database table name.
+func (UserSecurityThrottleRecord) TableName() string {
+	return "user_security_throttle"
 }
 
 type APIKeyRecord struct {

--- a/internal/cluster/user_security.go
+++ b/internal/cluster/user_security.go
@@ -1,0 +1,595 @@
+package cluster
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	UserSecurityTokenPurposeEmailVerification = "verify_email"
+	UserSecurityTokenPurposePasswordReset     = "reset_password"
+
+	UserMailJobStatusPending    = "pending"
+	UserMailJobStatusSending    = "sending"
+	UserMailJobStatusSent       = "sent"
+	UserMailJobStatusFailed     = "failed"
+	UserMailJobStatusSuperseded = "superseded"
+)
+
+var ErrUserSecurityTokenInvalid = errors.New("user security token is invalid or expired")
+
+var ErrUserMailJobClaimLost = errors.New("user mail job claim is no longer active")
+
+// HashUserSecurityValue returns a stable SHA-256 hex digest for tokens and throttle scopes.
+func HashUserSecurityValue(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+// ReplaceUserSecurityToken invalidates outstanding tokens for the same purpose and stores a new hash.
+func (r *Repository) ReplaceUserSecurityToken(ctx context.Context, record UserSecurityTokenRecord) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	if record.UserID == 0 || strings.TrimSpace(record.Purpose) == "" || strings.TrimSpace(record.TokenHash) == "" {
+		return fmt.Errorf("user security token fields are required")
+	}
+	if record.ExpiresAt.IsZero() {
+		return fmt.Errorf("user security token expiry is required")
+	}
+	record.Purpose = strings.TrimSpace(record.Purpose)
+	record.TokenHash = strings.TrimSpace(record.TokenHash)
+	record.CreatedAt = record.CreatedAt.UTC()
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+	record.ExpiresAt = record.ExpiresAt.UTC()
+
+	return db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		if errInvalidate := invalidateUserSecurityTokensTx(tx, record.UserID, record.Purpose, record.CreatedAt); errInvalidate != nil {
+			return errInvalidate
+		}
+		return tx.Create(&record).Error
+	})
+}
+
+// ReplaceUserSecurityTokenForMailJob stores a token only while the originating
+// mail job is still claimed by the worker. A concurrent resend or email change
+// supersedes the job and prevents an older worker from replacing the newer token.
+func (r *Repository) ReplaceUserSecurityTokenForMailJob(ctx context.Context, jobID uint, workerID string, record UserSecurityTokenRecord) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	workerID = strings.TrimSpace(workerID)
+	if jobID == 0 || workerID == "" {
+		return fmt.Errorf("user mail job claim is required")
+	}
+	if record.UserID == 0 || strings.TrimSpace(record.Purpose) == "" || strings.TrimSpace(record.TokenHash) == "" {
+		return fmt.Errorf("user security token fields are required")
+	}
+	if record.ExpiresAt.IsZero() {
+		return fmt.Errorf("user security token expiry is required")
+	}
+	record.Purpose = strings.TrimSpace(record.Purpose)
+	record.TokenHash = strings.TrimSpace(record.TokenHash)
+	record.CreatedAt = record.CreatedAt.UTC()
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+	record.ExpiresAt = record.ExpiresAt.UTC()
+
+	return db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		// User mutations lock the user before touching security tokens or mail
+		// jobs. Keep the same order here to avoid PostgreSQL deadlocks with a
+		// concurrent password or email update.
+		user := UserRecord{}
+		if errUser := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", record.UserID).First(&user).Error; errUser != nil {
+			if errors.Is(errUser, gorm.ErrRecordNotFound) {
+				return ErrUserMailJobClaimLost
+			}
+			return errUser
+		}
+		if user.Email == nil || strings.TrimSpace(*user.Email) == "" || user.EmailVersion != record.EmailVersion {
+			return ErrUserMailJobClaimLost
+		}
+		if record.Purpose == UserSecurityTokenPurposePasswordReset && user.EmailVerifiedAt == nil {
+			return ErrUserMailJobClaimLost
+		}
+
+		job := UserMailJobRecord{}
+		errJob := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND status = ? AND claimed_by = ? AND claim_expires_at > ? AND user_id = ? AND purpose = ? AND email_version = ?", jobID, UserMailJobStatusSending, workerID, record.CreatedAt, record.UserID, record.Purpose, record.EmailVersion).
+			First(&job).Error
+		if errors.Is(errJob, gorm.ErrRecordNotFound) {
+			return ErrUserMailJobClaimLost
+		}
+		if errJob != nil {
+			return errJob
+		}
+		if record.Purpose == UserSecurityTokenPurposePasswordReset && job.SessionVersion != user.SessionVersion {
+			return ErrUserMailJobClaimLost
+		}
+		if errInvalidate := invalidateUserSecurityTokensTx(tx, record.UserID, record.Purpose, record.CreatedAt); errInvalidate != nil {
+			return errInvalidate
+		}
+		return tx.Create(&record).Error
+	})
+}
+
+// ConsumeUserEmailVerificationToken verifies an email token and marks the current email as verified.
+func (r *Repository) ConsumeUserEmailVerificationToken(ctx context.Context, tokenHash string, now time.Time) (*UserRecord, error) {
+	return r.consumeUserSecurityToken(ctx, tokenHash, UserSecurityTokenPurposeEmailVerification, "", now)
+}
+
+// ConsumeUserPasswordResetToken updates the password, revokes sessions, and consumes the reset token.
+func (r *Repository) ConsumeUserPasswordResetToken(ctx context.Context, tokenHash string, passwordHash string, now time.Time) (*UserRecord, error) {
+	passwordHash = strings.TrimSpace(passwordHash)
+	if passwordHash == "" {
+		return nil, fmt.Errorf("password hash is required")
+	}
+	return r.consumeUserSecurityToken(ctx, tokenHash, UserSecurityTokenPurposePasswordReset, passwordHash, now)
+}
+
+func (r *Repository) consumeUserSecurityToken(ctx context.Context, tokenHash string, purpose string, passwordHash string, now time.Time) (*UserRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	tokenHash = strings.TrimSpace(tokenHash)
+	if tokenHash == "" {
+		return nil, ErrUserSecurityTokenInvalid
+	}
+	now = now.UTC()
+	candidate := UserSecurityTokenRecord{}
+	errCandidate := db.WithContext(contextOrBackground(ctx)).
+		Select("user_id").
+		Where("token_hash = ? AND purpose = ?", tokenHash, purpose).
+		First(&candidate).Error
+	if errors.Is(errCandidate, gorm.ErrRecordNotFound) {
+		return nil, ErrUserSecurityTokenInvalid
+	}
+	if errCandidate != nil {
+		return nil, errCandidate
+	}
+	record := &UserRecord{}
+	errTransaction := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		// Lock the user first, matching UpdateUser and mail-job token creation.
+		// The token is reloaded under lock below, so a concurrent consume or
+		// invalidation between the lookup and this transaction remains safe.
+		if errUser := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", candidate.UserID).First(record).Error; errUser != nil {
+			if errors.Is(errUser, gorm.ErrRecordNotFound) {
+				return ErrUserSecurityTokenInvalid
+			}
+			return errUser
+		}
+		token := UserSecurityTokenRecord{}
+		errToken := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("token_hash = ? AND purpose = ? AND user_id = ? AND used_at IS NULL AND expires_at > ?", tokenHash, purpose, candidate.UserID, now).
+			First(&token).Error
+		if errors.Is(errToken, gorm.ErrRecordNotFound) {
+			return ErrUserSecurityTokenInvalid
+		}
+		if errToken != nil {
+			return errToken
+		}
+		if record.Email == nil || strings.TrimSpace(*record.Email) == "" || record.EmailVerifiedAt == nil && purpose == UserSecurityTokenPurposePasswordReset {
+			return ErrUserSecurityTokenInvalid
+		}
+		if token.EmailVersion != record.EmailVersion {
+			return ErrUserSecurityTokenInvalid
+		}
+
+		switch purpose {
+		case UserSecurityTokenPurposeEmailVerification:
+			verifiedAt := now
+			record.EmailVerifiedAt = &verifiedAt
+		case UserSecurityTokenPurposePasswordReset:
+			record.Password = passwordHash
+			record.SessionVersion++
+		default:
+			return ErrUserSecurityTokenInvalid
+		}
+		if errSave := tx.Save(record).Error; errSave != nil {
+			return errSave
+		}
+		if purpose == UserSecurityTokenPurposePasswordReset {
+			return invalidateUserPasswordSecurityTx(tx, record.ID, now)
+		}
+		return invalidateUserSecurityTokensTx(tx, record.ID, purpose, now)
+	})
+	if errTransaction != nil {
+		return nil, errTransaction
+	}
+	return record, nil
+}
+
+func invalidateUserSecurityTokensTx(tx *gorm.DB, userID uint, purpose string, now time.Time) error {
+	if tx == nil || userID == 0 {
+		return nil
+	}
+	query := tx.Model(&UserSecurityTokenRecord{}).Where("user_id = ? AND used_at IS NULL", userID)
+	if strings.TrimSpace(purpose) != "" {
+		query = query.Where("purpose = ?", strings.TrimSpace(purpose))
+	}
+	return query.Update("used_at", now.UTC()).Error
+}
+
+// InvalidateUserSecurityTokenHash invalidates one token after a failed delivery attempt.
+func (r *Repository) InvalidateUserSecurityTokenHash(ctx context.Context, tokenHash string, now time.Time) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	return db.WithContext(contextOrBackground(ctx)).Model(&UserSecurityTokenRecord{}).
+		Where("token_hash = ? AND used_at IS NULL", strings.TrimSpace(tokenHash)).
+		Update("used_at", now.UTC()).Error
+}
+
+func invalidateUserEmailSecurityTx(tx *gorm.DB, userID uint, now time.Time) error {
+	if errTokens := invalidateUserSecurityTokensTx(tx, userID, "", now); errTokens != nil {
+		return errTokens
+	}
+	return supersedeUserMailJobsTx(tx, userID, "", now)
+}
+
+func invalidateUserPasswordSecurityTx(tx *gorm.DB, userID uint, now time.Time) error {
+	if errTokens := invalidateUserSecurityTokensTx(tx, userID, UserSecurityTokenPurposePasswordReset, now); errTokens != nil {
+		return errTokens
+	}
+	return supersedeUserMailJobsTx(tx, userID, UserSecurityTokenPurposePasswordReset, now)
+}
+
+func supersedeUserMailJobsTx(tx *gorm.DB, userID uint, purpose string, now time.Time) error {
+	query := tx.Model(&UserMailJobRecord{}).
+		Where("user_id = ? AND status IN ?", userID, []string{UserMailJobStatusPending, UserMailJobStatusSending})
+	if strings.TrimSpace(purpose) != "" {
+		query = query.Where("purpose = ?", strings.TrimSpace(purpose))
+	}
+	return query.Updates(map[string]any{
+		"status":           UserMailJobStatusSuperseded,
+		"claimed_by":       "",
+		"claim_expires_at": nil,
+		"updated_at":       now.UTC(),
+	}).Error
+}
+
+// EnqueueUserMailJob supersedes older pending jobs for the same purpose.
+func (r *Repository) EnqueueUserMailJob(ctx context.Context, userID uint, purpose string, emailVersion uint64, now time.Time) (*UserMailJobRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	purpose = strings.TrimSpace(purpose)
+	if userID == 0 || purpose == "" {
+		return nil, fmt.Errorf("user mail job fields are required")
+	}
+	if purpose != UserSecurityTokenPurposeEmailVerification && purpose != UserSecurityTokenPurposePasswordReset {
+		return nil, fmt.Errorf("user mail job purpose is invalid")
+	}
+	now = now.UTC()
+	record := &UserMailJobRecord{
+		UserID:        userID,
+		Purpose:       purpose,
+		EmailVersion:  emailVersion,
+		Status:        UserMailJobStatusPending,
+		NextAttemptAt: now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	errTransaction := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		user := UserRecord{}
+		if errUser := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", userID).First(&user).Error; errUser != nil {
+			return errUser
+		}
+		if user.Email == nil || strings.TrimSpace(*user.Email) == "" || user.EmailVersion != emailVersion {
+			return fmt.Errorf("user email state changed before mail enqueue")
+		}
+		if purpose == UserSecurityTokenPurposePasswordReset && user.EmailVerifiedAt == nil {
+			return fmt.Errorf("verified user email is required for password reset mail")
+		}
+		record.SessionVersion = user.SessionVersion
+		if errSupersede := tx.Model(&UserMailJobRecord{}).
+			Where("user_id = ? AND purpose = ? AND status IN ?", userID, purpose, []string{UserMailJobStatusPending, UserMailJobStatusSending}).
+			Updates(map[string]any{
+				"status":           UserMailJobStatusSuperseded,
+				"claimed_by":       "",
+				"claim_expires_at": nil,
+				"updated_at":       now,
+			}).Error; errSupersede != nil {
+			return errSupersede
+		}
+		if errInvalidate := invalidateUserSecurityTokensTx(tx, userID, purpose, now); errInvalidate != nil {
+			return errInvalidate
+		}
+		return tx.Create(record).Error
+	})
+	if errTransaction != nil {
+		return nil, errTransaction
+	}
+	return record, nil
+}
+
+// RenewUserMailJobClaim extends an active worker lease before network delivery.
+func (r *Repository) RenewUserMailJobClaim(ctx context.Context, jobID uint, workerID string, now time.Time, lease time.Duration) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	workerID = strings.TrimSpace(workerID)
+	if jobID == 0 || workerID == "" {
+		return fmt.Errorf("user mail job claim is required")
+	}
+	if lease <= 0 {
+		lease = 30 * time.Second
+	}
+	now = now.UTC()
+	result := db.WithContext(contextOrBackground(ctx)).Model(&UserMailJobRecord{}).
+		Where("id = ? AND status = ? AND claimed_by = ? AND claim_expires_at > ?", jobID, UserMailJobStatusSending, workerID, now).
+		Updates(map[string]any{
+			"claim_expires_at": now.Add(lease),
+			"updated_at":       now,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return ErrUserMailJobClaimLost
+	}
+	return nil
+}
+
+// ClaimUserMailJob atomically leases one ready job to a worker.
+func (r *Repository) ClaimUserMailJob(ctx context.Context, workerID string, now time.Time, lease time.Duration) (*UserMailJobRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	workerID = strings.TrimSpace(workerID)
+	if workerID == "" {
+		return nil, fmt.Errorf("worker id is required")
+	}
+	if lease <= 0 {
+		lease = 30 * time.Second
+	}
+	now = now.UTC()
+	claimExpiresAt := now.Add(lease)
+
+	for attempt := 0; attempt < 3; attempt++ {
+		candidate := UserMailJobRecord{}
+		errFind := db.WithContext(contextOrBackground(ctx)).
+			Where("(status = ? AND next_attempt_at <= ?) OR (status = ? AND claim_expires_at <= ?)", UserMailJobStatusPending, now, UserMailJobStatusSending, now).
+			Order("id ASC").
+			First(&candidate).Error
+		if errors.Is(errFind, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		if errFind != nil {
+			return nil, errFind
+		}
+
+		result := db.WithContext(contextOrBackground(ctx)).Model(&UserMailJobRecord{}).
+			Where("id = ? AND ((status = ? AND next_attempt_at <= ?) OR (status = ? AND claim_expires_at <= ?))", candidate.ID, UserMailJobStatusPending, now, UserMailJobStatusSending, now).
+			Updates(map[string]any{
+				"status":           UserMailJobStatusSending,
+				"claimed_by":       workerID,
+				"claim_expires_at": claimExpiresAt,
+				"attempts":         gorm.Expr("attempts + 1"),
+				"updated_at":       now,
+			})
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		if result.RowsAffected == 0 {
+			continue
+		}
+		claimed := UserMailJobRecord{}
+		if errLoad := db.WithContext(contextOrBackground(ctx)).Where("id = ?", candidate.ID).First(&claimed).Error; errLoad != nil {
+			return nil, errLoad
+		}
+		return &claimed, nil
+	}
+	return nil, nil
+}
+
+// CompleteUserMailJob marks a claimed job as sent.
+func (r *Repository) CompleteUserMailJob(ctx context.Context, jobID uint, workerID string, now time.Time) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	now = now.UTC()
+	result := db.WithContext(contextOrBackground(ctx)).Model(&UserMailJobRecord{}).
+		Where("id = ? AND status = ? AND claimed_by = ?", jobID, UserMailJobStatusSending, strings.TrimSpace(workerID)).
+		Updates(map[string]any{
+			"status":           UserMailJobStatusSent,
+			"sent_at":          now,
+			"claimed_by":       "",
+			"claim_expires_at": nil,
+			"last_error_code":  "",
+			"updated_at":       now,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return ErrUserMailJobClaimLost
+	}
+	return nil
+}
+
+// FailUserMailJob releases or terminates a failed claimed job.
+func (r *Repository) FailUserMailJob(ctx context.Context, job *UserMailJobRecord, workerID string, errorCode string, now time.Time, retryAfter time.Duration, maxAttempts int) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	if job == nil || job.ID == 0 {
+		return fmt.Errorf("user mail job is required")
+	}
+	if maxAttempts <= 0 {
+		maxAttempts = 3
+	}
+	if retryAfter <= 0 {
+		retryAfter = time.Minute
+	}
+	now = now.UTC()
+	status := UserMailJobStatusPending
+	nextAttemptAt := now.Add(retryAfter)
+	if job.Attempts >= maxAttempts {
+		status = UserMailJobStatusFailed
+		nextAttemptAt = now
+	}
+	result := db.WithContext(contextOrBackground(ctx)).Model(&UserMailJobRecord{}).
+		Where("id = ? AND status = ? AND claimed_by = ?", job.ID, UserMailJobStatusSending, strings.TrimSpace(workerID)).
+		Updates(map[string]any{
+			"status":           status,
+			"next_attempt_at":  nextAttemptAt,
+			"claimed_by":       "",
+			"claim_expires_at": nil,
+			"last_error_code":  strings.TrimSpace(errorCode),
+			"updated_at":       now,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return ErrUserMailJobClaimLost
+	}
+	return nil
+}
+
+// SupersedeUserMailJob marks a claimed job obsolete.
+func (r *Repository) SupersedeUserMailJob(ctx context.Context, jobID uint, workerID string, now time.Time) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	now = now.UTC()
+	result := db.WithContext(contextOrBackground(ctx)).Model(&UserMailJobRecord{}).
+		Where("id = ? AND status = ? AND claimed_by = ?", jobID, UserMailJobStatusSending, strings.TrimSpace(workerID)).
+		Updates(map[string]any{
+			"status":           UserMailJobStatusSuperseded,
+			"claimed_by":       "",
+			"claim_expires_at": nil,
+			"updated_at":       now,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return ErrUserMailJobClaimLost
+	}
+	return nil
+}
+
+// AllowUserSecurityActionWithRetry increments an anchored-window counter and
+// reports how long a denied caller must wait before the current window resets.
+func (r *Repository) AllowUserSecurityActionWithRetry(ctx context.Context, action string, scopeHash string, limit int, window time.Duration, now time.Time) (bool, time.Duration, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return false, 0, errDB
+	}
+	action = strings.TrimSpace(action)
+	scopeHash = strings.TrimSpace(scopeHash)
+	if action == "" || scopeHash == "" || limit <= 0 || window <= 0 {
+		return false, 0, fmt.Errorf("user security throttle fields are required")
+	}
+	now = now.UTC()
+	key := fmt.Sprintf("%s:%s", action, scopeHash)
+	record := UserSecurityThrottleRecord{
+		Key:       key,
+		Count:     1,
+		ExpiresAt: now.Add(window),
+		UpdatedAt: now,
+	}
+	// Cleanup can delete an expired conflicting row between the insert and the
+	// locked reload. Retry that narrow race once so callers do not see a 500.
+	for attempt := 0; attempt < 2; attempt++ {
+		allowed := false
+		retryAfter := time.Duration(0)
+		errTransaction := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+			result := tx.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "key"}},
+				DoNothing: true,
+			}).Create(&record)
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 1 {
+				allowed = true
+				return nil
+			}
+
+			stored := UserSecurityThrottleRecord{}
+			if errLoad := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("key = ?", key).First(&stored).Error; errLoad != nil {
+				return errLoad
+			}
+			if !stored.ExpiresAt.After(now) {
+				allowed = true
+				return tx.Model(&UserSecurityThrottleRecord{}).Where("key = ?", key).Updates(map[string]any{
+					"count":      1,
+					"expires_at": now.Add(window),
+					"updated_at": now,
+				}).Error
+			}
+
+			nextCount := stored.Count + 1
+			allowed = nextCount <= limit
+			if !allowed {
+				retryAfter = stored.ExpiresAt.Sub(now)
+			}
+			return tx.Model(&UserSecurityThrottleRecord{}).Where("key = ?", key).Updates(map[string]any{
+				"count":      nextCount,
+				"updated_at": now,
+			}).Error
+		})
+		if errTransaction == nil {
+			return allowed, retryAfter, nil
+		}
+		if !errors.Is(errTransaction, gorm.ErrRecordNotFound) || attempt == 1 {
+			return false, 0, errTransaction
+		}
+	}
+	return false, 0, gorm.ErrRecordNotFound
+}
+
+// PurgeExpiredUserSecurity removes old terminal security records.
+func (r *Repository) PurgeExpiredUserSecurity(ctx context.Context, now time.Time, retention time.Duration) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	if retention <= 0 {
+		retention = 7 * 24 * time.Hour
+	}
+	now = now.UTC()
+	cutoff := now.Add(-retention)
+	db = db.WithContext(contextOrBackground(ctx))
+	if errDelete := db.Where("expires_at < ? OR (used_at IS NOT NULL AND used_at < ?)", cutoff, cutoff).Delete(&UserSecurityTokenRecord{}).Error; errDelete != nil {
+		return errDelete
+	}
+	if errDelete := db.Where("status IN ? AND updated_at < ?", []string{UserMailJobStatusSent, UserMailJobStatusFailed, UserMailJobStatusSuperseded}, cutoff).Delete(&UserMailJobRecord{}).Error; errDelete != nil {
+		return errDelete
+	}
+	if errDelete := db.Where(
+		"(status = ? AND created_at < ?) OR (status = ? AND created_at < ? AND (claim_expires_at IS NULL OR claim_expires_at <= ?))",
+		UserMailJobStatusPending,
+		cutoff,
+		UserMailJobStatusSending,
+		cutoff,
+		now,
+	).Delete(&UserMailJobRecord{}).Error; errDelete != nil {
+		return errDelete
+	}
+	return db.Where("expires_at < ?", now).Delete(&UserSecurityThrottleRecord{}).Error
+}

--- a/internal/cluster/user_security_test.go
+++ b/internal/cluster/user_security_test.go
@@ -1,0 +1,441 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestUserEmailUniqueIndexSQLiteClaimsOnlyVerifiedAddresses(t *testing.T) {
+	repo, db := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	email := "alice@example.com"
+	firstName := "alice"
+	first, errCreateFirst := repo.CreateUser(ctx, UserUpdate{Username: &firstName, Email: &email})
+	if errCreateFirst != nil {
+		t.Fatalf("CreateUser(first) error = %v", errCreateFirst)
+	}
+
+	secondName := "bob"
+	second, errCreateSecond := repo.CreateUser(ctx, UserUpdate{Username: &secondName, Email: &email})
+	if errCreateSecond != nil {
+		t.Fatalf("CreateUser(unverified duplicate email) error = %v", errCreateSecond)
+	}
+	firstToken := HashUserSecurityValue("first-verification-token")
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       first.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    firstToken,
+		EmailVersion: first.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("store first verification token: %v", errStore)
+	}
+	if _, errVerify := repo.ConsumeUserEmailVerificationToken(ctx, firstToken, now.Add(time.Second)); errVerify != nil {
+		t.Fatalf("verify first email: %v", errVerify)
+	}
+	owner, errOwner := repo.GetUserByEmail(ctx, email)
+	if errOwner != nil || owner.ID != first.ID {
+		t.Fatalf("verified email owner = %#v, %v; want user %d", owner, errOwner, first.ID)
+	}
+	secondToken := HashUserSecurityValue("second-verification-token")
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       second.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    secondToken,
+		EmailVersion: second.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("store second verification token: %v", errStore)
+	}
+	if _, errVerify := repo.ConsumeUserEmailVerificationToken(ctx, secondToken, now.Add(2*time.Second)); !IsUserEmailConflictError(errVerify) {
+		t.Fatalf("verify duplicate email error = %v, want email conflict", errVerify)
+	}
+	if errDelete := repo.DeleteUser(ctx, first.ID); errDelete != nil {
+		t.Fatalf("DeleteUser() error = %v", errDelete)
+	}
+	if _, errVerify := repo.ConsumeUserEmailVerificationToken(ctx, secondToken, now.Add(3*time.Second)); errVerify != nil {
+		t.Fatalf("verify email after owner deletion: %v", errVerify)
+	}
+	owner, errOwner = repo.GetUserByEmail(ctx, email)
+	if errOwner != nil || owner.ID != second.ID {
+		t.Fatalf("reassigned verified email owner = %#v, %v; want user %d", owner, errOwner, second.ID)
+	}
+
+	var definition string
+	if errIndex := db.Raw("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", "idx_user_email_verified_active_unique").Scan(&definition).Error; errIndex != nil {
+		t.Fatalf("load unique email index: %v", errIndex)
+	}
+	lowerDefinition := strings.ToLower(definition)
+	if !strings.Contains(lowerDefinition, "where") || !strings.Contains(lowerDefinition, "deleted_at") || !strings.Contains(lowerDefinition, "email_verified_at") {
+		t.Fatalf("unique email index definition = %q, want partial verified active-user index", definition)
+	}
+}
+
+func TestUserEmailUniqueIndexPostgresMigrationSQL(t *testing.T) {
+	var logs bytes.Buffer
+	db, errOpen := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=127.0.0.1 user=cliproxy dbname=cliproxy_home sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		DisableAutomaticPing: true,
+		DryRun:               true,
+		Logger: logger.New(log.New(&logs, "", 0), logger.Config{
+			LogLevel: logger.Info,
+		}),
+	})
+	if errOpen != nil {
+		t.Fatalf("open postgres dry-run db: %v", errOpen)
+	}
+	if errMigrate := migrateUserUniqueEmail(db); errMigrate != nil {
+		t.Fatalf("migrateUserUniqueEmail() error = %v", errMigrate)
+	}
+	output := strings.ToLower(logs.String())
+	for _, fragment := range []string{"drop index", "idx_user_email_active_unique", "create unique index", "idx_user_email_verified_active_unique", "deleted_at", "email_verified_at", "is not null"} {
+		if !strings.Contains(output, fragment) {
+			t.Fatalf("postgres migration SQL = %q, missing %q", output, fragment)
+		}
+	}
+}
+
+func TestUserEmailIdempotentUpdatePreservesVerification(t *testing.T) {
+	repo, _ := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	rawToken := "verification-token"
+	if errToken := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    HashUserSecurityValue(rawToken),
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errToken != nil {
+		t.Fatalf("ReplaceUserSecurityToken() error = %v", errToken)
+	}
+	verified, errVerify := repo.ConsumeUserEmailVerificationToken(ctx, HashUserSecurityValue(rawToken), now.Add(time.Second))
+	if errVerify != nil {
+		t.Fatalf("ConsumeUserEmailVerificationToken() error = %v", errVerify)
+	}
+	if verified.EmailVerifiedAt == nil {
+		t.Fatal("verified email timestamp is nil")
+	}
+
+	updated, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{Email: &email})
+	if errUpdate != nil {
+		t.Fatalf("UpdateUser(same email) error = %v", errUpdate)
+	}
+	if updated.EmailVersion != verified.EmailVersion {
+		t.Fatalf("email version = %d, want unchanged %d", updated.EmailVersion, verified.EmailVersion)
+	}
+	if updated.EmailVerifiedAt == nil {
+		t.Fatal("same-address update cleared verification")
+	}
+}
+
+func TestUserSecurityTokenSingleUseAndPasswordResetPreservesMFA(t *testing.T) {
+	repo, db := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	username := "alice"
+	email := "alice@example.com"
+	oldPassword := "old-password-hash"
+	mfa := JSONB(`{"totp":{"secret":"secret"}}`)
+	passkey := JSONB(`[{"id":"credential"}]`)
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &username, Password: &oldPassword, Email: &email, MFA: &mfa, Passkey: &passkey})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+
+	verifyRaw := "verify-raw-token"
+	verifyHash := HashUserSecurityValue(verifyRaw)
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    verifyHash,
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("store verification token: %v", errStore)
+	}
+	var storedVerify UserSecurityTokenRecord
+	if errLoad := db.Where("token_hash = ?", verifyHash).First(&storedVerify).Error; errLoad != nil {
+		t.Fatalf("load verification token: %v", errLoad)
+	}
+	if storedVerify.TokenHash == verifyRaw || strings.Contains(storedVerify.TokenHash, verifyRaw) {
+		t.Fatal("database contains raw verification token")
+	}
+	if _, errVerify := repo.ConsumeUserEmailVerificationToken(ctx, verifyHash, now.Add(time.Second)); errVerify != nil {
+		t.Fatalf("consume verification token: %v", errVerify)
+	}
+	if _, errReuse := repo.ConsumeUserEmailVerificationToken(ctx, verifyHash, now.Add(2*time.Second)); !errors.Is(errReuse, ErrUserSecurityTokenInvalid) {
+		t.Fatalf("reuse verification token error = %v, want invalid token", errReuse)
+	}
+
+	resetRaw := "reset-raw-token"
+	resetHash := HashUserSecurityValue(resetRaw)
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposePasswordReset,
+		TokenHash:    resetHash,
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("store reset token: %v", errStore)
+	}
+	newPassword := "new-password-hash"
+	resetUser, errReset := repo.ConsumeUserPasswordResetToken(ctx, resetHash, newPassword, now.Add(3*time.Second))
+	if errReset != nil {
+		t.Fatalf("ConsumeUserPasswordResetToken() error = %v", errReset)
+	}
+	if resetUser.Password != newPassword || resetUser.SessionVersion != 1 {
+		t.Fatalf("reset user password/session = %q/%d", resetUser.Password, resetUser.SessionVersion)
+	}
+	if string(resetUser.MFA) != string(mfa) || string(resetUser.Passkey) != string(passkey) {
+		t.Fatalf("password reset changed MFA/passkey: mfa=%s passkey=%s", resetUser.MFA, resetUser.Passkey)
+	}
+	if _, errReuse := repo.ConsumeUserPasswordResetToken(ctx, resetHash, "another", now.Add(4*time.Second)); !errors.Is(errReuse, ErrUserSecurityTokenInvalid) {
+		t.Fatalf("reuse reset token error = %v, want invalid token", errReuse)
+	}
+}
+
+func TestUserMailJobSupersedeInvalidatesTokenAndOlderClaim(t *testing.T) {
+	repo, db := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	oldHash := HashUserSecurityValue("old-token")
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    oldHash,
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("store old token: %v", errStore)
+	}
+	firstJob, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, UserSecurityTokenPurposeEmailVerification, user.EmailVersion, now.Add(time.Second))
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob(first) error = %v", errEnqueue)
+	}
+	var invalidated UserSecurityTokenRecord
+	if errLoad := db.Where("token_hash = ?", oldHash).First(&invalidated).Error; errLoad != nil {
+		t.Fatalf("load invalidated token: %v", errLoad)
+	}
+	if invalidated.UsedAt == nil {
+		t.Fatal("enqueue did not invalidate outstanding token")
+	}
+	claimed, errClaim := repo.ClaimUserMailJob(ctx, "worker-old", now.Add(time.Second), time.Minute)
+	if errClaim != nil || claimed == nil || claimed.ID != firstJob.ID {
+		t.Fatalf("ClaimUserMailJob() = %#v, %v", claimed, errClaim)
+	}
+	if _, errEnqueue = repo.EnqueueUserMailJob(ctx, user.ID, UserSecurityTokenPurposeEmailVerification, user.EmailVersion, now.Add(2*time.Second)); errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob(second) error = %v", errEnqueue)
+	}
+	errReplace := repo.ReplaceUserSecurityTokenForMailJob(ctx, claimed.ID, "worker-old", UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    HashUserSecurityValue("stale-worker-token"),
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now.Add(3 * time.Second),
+	})
+	if !errors.Is(errReplace, ErrUserMailJobClaimLost) {
+		t.Fatalf("stale worker token replacement error = %v, want lost claim", errReplace)
+	}
+	if errComplete := repo.CompleteUserMailJob(ctx, claimed.ID, "worker-old", now.Add(3*time.Second)); !errors.Is(errComplete, ErrUserMailJobClaimLost) {
+		t.Fatalf("stale worker completion error = %v, want lost claim", errComplete)
+	}
+}
+
+func TestUserSecurityThrottleUsesAnchoredWindow(t *testing.T) {
+	repo, _ := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	start := time.Date(2026, time.July, 21, 12, 0, 59, 0, time.UTC)
+	scope := HashUserSecurityValue("user:1")
+
+	allowed, retryAfter, errAllow := repo.AllowUserSecurityActionWithRetry(ctx, "verify_email_cooldown", scope, 1, time.Minute, start)
+	if errAllow != nil || !allowed || retryAfter != 0 {
+		t.Fatalf("first throttle decision = %v, %v, %v", allowed, retryAfter, errAllow)
+	}
+	allowed, retryAfter, errAllow = repo.AllowUserSecurityActionWithRetry(ctx, "verify_email_cooldown", scope, 1, time.Minute, start.Add(time.Second))
+	if errAllow != nil || allowed || retryAfter != 59*time.Second {
+		t.Fatalf("cross-minute throttle decision = %v, %v, %v", allowed, retryAfter, errAllow)
+	}
+	allowed, retryAfter, errAllow = repo.AllowUserSecurityActionWithRetry(ctx, "verify_email_cooldown", scope, 1, time.Minute, start.Add(time.Minute))
+	if errAllow != nil || !allowed || retryAfter != 0 {
+		t.Fatalf("expired throttle decision = %v, %v, %v", allowed, retryAfter, errAllow)
+	}
+}
+
+func TestPasswordUpdateInvalidatesResetTokensAndQueuedMail(t *testing.T) {
+	repo, db := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	username := "alice"
+	email := "alice@example.com"
+	oldPassword := "old-password-hash"
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &username, Password: &oldPassword, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	verifiedAt := now
+	if errVerify := db.Model(&UserRecord{}).Where("id = ?", user.ID).Update("email_verified_at", verifiedAt).Error; errVerify != nil {
+		t.Fatalf("mark email verified: %v", errVerify)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, UserSecurityTokenPurposePasswordReset, user.EmailVersion, now)
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	if job.SessionVersion != user.SessionVersion {
+		t.Fatalf("mail job session version = %d, want %d", job.SessionVersion, user.SessionVersion)
+	}
+	tokenHash := HashUserSecurityValue("reset-before-password-change")
+	if errStore := repo.ReplaceUserSecurityToken(ctx, UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      UserSecurityTokenPurposePasswordReset,
+		TokenHash:    tokenHash,
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(time.Hour),
+		CreatedAt:    now,
+	}); errStore != nil {
+		t.Fatalf("ReplaceUserSecurityToken() error = %v", errStore)
+	}
+
+	newPassword := "new-password-hash"
+	updated, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{Password: &newPassword})
+	if errUpdate != nil {
+		t.Fatalf("UpdateUser(password) error = %v", errUpdate)
+	}
+	if updated.SessionVersion != user.SessionVersion+1 {
+		t.Fatalf("session version = %d, want %d", updated.SessionVersion, user.SessionVersion+1)
+	}
+	var storedJob UserMailJobRecord
+	if errLoad := db.Where("id = ?", job.ID).First(&storedJob).Error; errLoad != nil {
+		t.Fatalf("load mail job: %v", errLoad)
+	}
+	if storedJob.Status != UserMailJobStatusSuperseded {
+		t.Fatalf("mail job status = %q, want superseded", storedJob.Status)
+	}
+	var storedToken UserSecurityTokenRecord
+	if errLoad := db.Where("token_hash = ?", tokenHash).First(&storedToken).Error; errLoad != nil {
+		t.Fatalf("load reset token: %v", errLoad)
+	}
+	if storedToken.UsedAt == nil {
+		t.Fatal("password update left reset token active")
+	}
+}
+
+func TestPurgeExpiredUserSecurityRemovesAbandonedAndPreservesActiveMailJobs(t *testing.T) {
+	repo, db := newUserSecurityTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, UserSecurityTokenPurposeEmailVerification, user.EmailVersion, now.Add(-8*24*time.Hour))
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	activeClaimExpiry := now.Add(time.Minute)
+	activeJob := UserMailJobRecord{
+		UserID:         user.ID,
+		Purpose:        UserSecurityTokenPurposePasswordReset,
+		EmailVersion:   user.EmailVersion,
+		Status:         UserMailJobStatusSending,
+		Attempts:       1,
+		NextAttemptAt:  now.Add(-8 * 24 * time.Hour),
+		ClaimedBy:      "active-worker",
+		ClaimExpiresAt: &activeClaimExpiry,
+		CreatedAt:      now.Add(-8 * 24 * time.Hour),
+		UpdatedAt:      now,
+	}
+	if errCreate := db.Create(&activeJob).Error; errCreate != nil {
+		t.Fatalf("create active old mail job: %v", errCreate)
+	}
+	expiredClaimExpiry := now.Add(-time.Minute)
+	expiredJob := UserMailJobRecord{
+		UserID:         user.ID,
+		Purpose:        UserSecurityTokenPurposePasswordReset,
+		EmailVersion:   user.EmailVersion,
+		Status:         UserMailJobStatusSending,
+		Attempts:       1,
+		NextAttemptAt:  now.Add(-8 * 24 * time.Hour),
+		ClaimedBy:      "expired-worker",
+		ClaimExpiresAt: &expiredClaimExpiry,
+		CreatedAt:      now.Add(-8 * 24 * time.Hour),
+		UpdatedAt:      now.Add(-8 * 24 * time.Hour),
+	}
+	if errCreate := db.Create(&expiredJob).Error; errCreate != nil {
+		t.Fatalf("create expired old mail job: %v", errCreate)
+	}
+	if errPurge := repo.PurgeExpiredUserSecurity(ctx, now, 7*24*time.Hour); errPurge != nil {
+		t.Fatalf("PurgeExpiredUserSecurity() error = %v", errPurge)
+	}
+	var count int64
+	if errCount := db.Model(&UserMailJobRecord{}).Where("id = ?", job.ID).Count(&count).Error; errCount != nil {
+		t.Fatalf("count stale mail job: %v", errCount)
+	}
+	if count != 0 {
+		t.Fatalf("stale active mail jobs = %d, want 0", count)
+	}
+	if errCount := db.Model(&UserMailJobRecord{}).Where("id = ?", activeJob.ID).Count(&count).Error; errCount != nil {
+		t.Fatalf("count actively claimed old mail job: %v", errCount)
+	}
+	if count != 1 {
+		t.Fatalf("actively claimed old mail jobs = %d, want 1", count)
+	}
+	if errCount := db.Model(&UserMailJobRecord{}).Where("id = ?", expiredJob.ID).Count(&count).Error; errCount != nil {
+		t.Fatalf("count expired claimed old mail job: %v", errCount)
+	}
+	if count != 0 {
+		t.Fatalf("expired claimed old mail jobs = %d, want 0", count)
+	}
+}
+
+func newUserSecurityTestRepository(t *testing.T) (*Repository, *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	db, errOpen := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	return NewRepository(db), db
+}

--- a/internal/cluster/users.go
+++ b/internal/cluster/users.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // ErrUserNotFound indicates that the referenced user record does not exist.
@@ -29,9 +31,25 @@ func IsUserConflictError(err error) bool {
 	return strings.Contains(message, "duplicate key") && strings.Contains(message, "username")
 }
 
+// IsUserEmailConflictError reports whether an error is a verified active-email ownership conflict.
+func IsUserEmailConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	if strings.Contains(message, "idx_user_email_verified_active_unique") || strings.Contains(message, "idx_user_email_active_unique") {
+		return true
+	}
+	if strings.Contains(message, "unique constraint") && strings.Contains(message, "user") && strings.Contains(message, "email") {
+		return true
+	}
+	return strings.Contains(message, "duplicate key") && strings.Contains(message, "email")
+}
+
 type UserUpdate struct {
 	Username         *string
 	Password         *string
+	Email            *string
 	Credits          *float64
 	CreditsUnlimited *bool
 	MFA              *JSONB
@@ -99,6 +117,24 @@ func (r *Repository) GetUserByUsername(ctx context.Context, username string) (*U
 	return record, nil
 }
 
+// GetUserByEmail returns the active user that owns a verified normalized email.
+func (r *Repository) GetUserByEmail(ctx context.Context, email string) (*UserRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+
+	record := &UserRecord{}
+	if errFirst := db.WithContext(contextOrBackground(ctx)).Where("email = ? AND email_verified_at IS NOT NULL", email).Order("id").First(record).Error; errFirst != nil {
+		return nil, errFirst
+	}
+	return record, nil
+}
+
 // CreateUser creates a user.
 func (r *Repository) CreateUser(ctx context.Context, update UserUpdate) (*UserRecord, error) {
 	db, errDB := r.database()
@@ -119,6 +155,13 @@ func (r *Repository) CreateUser(ctx context.Context, update UserUpdate) (*UserRe
 	defaultUserPeriodLimitFields(record)
 	if update.Password != nil {
 		record.Password = *update.Password
+	}
+	if update.Email != nil {
+		email := strings.TrimSpace(*update.Email)
+		if email != "" {
+			record.Email = &email
+			record.EmailVersion = 1
+		}
 	}
 	if update.Credits != nil {
 		record.Credits = *update.Credits
@@ -154,7 +197,7 @@ func (r *Repository) UpdateUser(ctx context.Context, id uint, update UserUpdate)
 	record := &UserRecord{}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		if errFirst := tx.Where("id = ?", id).First(record).Error; errFirst != nil {
+		if errFirst := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("id = ?", id).First(record).Error; errFirst != nil {
 			return errFirst
 		}
 		if update.Username != nil {
@@ -166,6 +209,29 @@ func (r *Repository) UpdateUser(ctx context.Context, id uint, update UserUpdate)
 		}
 		if update.Password != nil {
 			record.Password = *update.Password
+			record.SessionVersion++
+			if errInvalidate := invalidateUserPasswordSecurityTx(tx, record.ID, time.Now().UTC()); errInvalidate != nil {
+				return errInvalidate
+			}
+		}
+		if update.Email != nil {
+			email := strings.TrimSpace(*update.Email)
+			currentEmail := ""
+			if record.Email != nil {
+				currentEmail = strings.TrimSpace(*record.Email)
+			}
+			if email != currentEmail {
+				if email == "" {
+					record.Email = nil
+				} else {
+					record.Email = &email
+				}
+				record.EmailVerifiedAt = nil
+				record.EmailVersion++
+				if errInvalidate := invalidateUserEmailSecurityTx(tx, record.ID, time.Now().UTC()); errInvalidate != nil {
+					return errInvalidate
+				}
+			}
 		}
 		if update.Credits != nil {
 			record.Credits = *update.Credits

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,11 +40,18 @@ type Config struct {
 	// TLS config controls HTTPS server settings.
 	TLS TLSConfig `yaml:"tls" json:"tls"`
 
+	// TrustedProxies lists reverse-proxy IPs or CIDRs whose forwarded client
+	// address headers the HTTP server may trust. Empty disables forwarded headers.
+	TrustedProxies []string `yaml:"trusted-proxies" json:"-"`
+
 	// RemoteManagement nests management-related options under 'remote-management'.
 	RemoteManagement RemoteManagement `yaml:"remote-management" json:"-"`
 
 	// Plugins configures dynamic plugin distribution for downstream CPA nodes.
 	Plugins PluginsConfig `yaml:"plugins" json:"plugins"`
+
+	// UserEmail configures verified user emails and password-recovery delivery.
+	UserEmail UserEmailConfig `yaml:"user-email" json:"-"`
 
 	// AuthDir is the directory where authentication token files are stored.
 	AuthDir string `yaml:"auth-dir" json:"-"`
@@ -189,6 +196,32 @@ type PprofConfig struct {
 	Enable bool `yaml:"enable" json:"enable"`
 	// Addr is the host:port address for the pprof HTTP server.
 	Addr string `yaml:"addr" json:"addr"`
+}
+
+// UserEmailConfig controls optional verified-email and password-recovery behavior.
+type UserEmailConfig struct {
+	Enabled              bool                  `yaml:"enabled" json:"enabled"`
+	PublicUserURL        string                `yaml:"public-user-url" json:"public-user-url"`
+	FromAddress          string                `yaml:"from-address" json:"from-address"`
+	FromName             string                `yaml:"from-name" json:"from-name"`
+	Sender               UserEmailSenderConfig `yaml:"sender" json:"sender"`
+	VerificationTokenTTL string                `yaml:"verification-token-ttl" json:"verification-token-ttl"`
+	ResetTokenTTL        string                `yaml:"reset-token-ttl" json:"reset-token-ttl"`
+}
+
+// UserEmailSenderConfig selects the configured mail transport.
+type UserEmailSenderConfig struct {
+	Type string              `yaml:"type" json:"type"`
+	SMTP UserEmailSMTPConfig `yaml:"smtp" json:"smtp"`
+}
+
+// UserEmailSMTPConfig configures SMTP delivery without persisting the password itself.
+type UserEmailSMTPConfig struct {
+	Host        string `yaml:"host" json:"host"`
+	Port        int    `yaml:"port" json:"port"`
+	Username    string `yaml:"username" json:"username"`
+	PasswordEnv string `yaml:"password-env" json:"password-env"`
+	StartTLS    bool   `yaml:"starttls" json:"starttls"`
 }
 
 // RemoteManagement holds management API configuration under 'remote-management'.
@@ -626,6 +659,11 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	}
 
 	cfg.NormalizePluginsConfig()
+	cfg.NormalizeUserEmailConfig()
+	cfg.NormalizeTrustedProxies()
+	if errTrustedProxies := ValidateTrustedProxies(cfg.TrustedProxies); errTrustedProxies != nil {
+		return nil, errTrustedProxies
+	}
 
 	normalizedSecret, secretChanged, errNormalizeSecret := NormalizeRemoteManagementSecret(cfg.RemoteManagement.SecretKey)
 	if errNormalizeSecret != nil {

--- a/internal/config/trusted_proxies.go
+++ b/internal/config/trusted_proxies.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// NormalizeTrustedProxies trims, removes empty values, and de-duplicates the
+// explicit reverse-proxy allowlist while preserving its configured order.
+func (cfg *Config) NormalizeTrustedProxies() {
+	if cfg == nil || len(cfg.TrustedProxies) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(cfg.TrustedProxies))
+	normalized := make([]string, 0, len(cfg.TrustedProxies))
+	for _, raw := range cfg.TrustedProxies {
+		value := strings.TrimSpace(raw)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	cfg.TrustedProxies = normalized
+}
+
+// ValidateTrustedProxies accepts only explicit IP addresses and CIDRs, and
+// rejects trust-all networks that would let direct clients spoof their source.
+func ValidateTrustedProxies(values []string) error {
+	for _, value := range values {
+		if strings.Contains(value, "/") {
+			_, network, errCIDR := net.ParseCIDR(value)
+			if errCIDR != nil {
+				return fmt.Errorf("trusted proxy %q is invalid: %w", value, errCIDR)
+			}
+			if trustsEveryAddressInIPFamily(network) {
+				return fmt.Errorf("trusted proxy %q must not trust every address", value)
+			}
+			continue
+		}
+		if net.ParseIP(value) == nil {
+			return fmt.Errorf("trusted proxy %q is not an IP address", value)
+		}
+	}
+	return nil
+}
+
+func trustsEveryAddressInIPFamily(network *net.IPNet) bool {
+	if network == nil {
+		return false
+	}
+	trustsEveryIPv4 := network.Contains(net.IPv4zero) && network.Contains(net.IPv4bcast)
+	lastIPv6 := net.IP{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	trustsEveryIPv6 := network.Contains(net.IPv6zero) && network.Contains(lastIPv6)
+	return trustsEveryIPv4 || trustsEveryIPv6
+}

--- a/internal/config/trusted_proxies_test.go
+++ b/internal/config/trusted_proxies_test.go
@@ -1,0 +1,24 @@
+package config
+
+import "testing"
+
+func TestNormalizeAndValidateTrustedProxies(t *testing.T) {
+	cfg := &Config{TrustedProxies: []string{" 127.0.0.1 ", "10.0.0.0/8", "::ffff:192.0.2.0/120", "127.0.0.1", ""}}
+	cfg.NormalizeTrustedProxies()
+	if len(cfg.TrustedProxies) != 3 || cfg.TrustedProxies[0] != "127.0.0.1" || cfg.TrustedProxies[1] != "10.0.0.0/8" || cfg.TrustedProxies[2] != "::ffff:192.0.2.0/120" {
+		t.Fatalf("normalized trusted proxies = %#v", cfg.TrustedProxies)
+	}
+	if errValidate := ValidateTrustedProxies(cfg.TrustedProxies); errValidate != nil {
+		t.Fatalf("ValidateTrustedProxies() error = %v", errValidate)
+	}
+}
+
+func TestValidateTrustedProxiesRejectsInvalidAndTrustAllEntries(t *testing.T) {
+	for _, value := range []string{"proxy.example.com", "10.0.0.0/99", "0.0.0.0/0", "::/0", "::ffff:0:0/96"} {
+		t.Run(value, func(t *testing.T) {
+			if errValidate := ValidateTrustedProxies([]string{value}); errValidate == nil {
+				t.Fatalf("ValidateTrustedProxies(%q) succeeded", value)
+			}
+		})
+	}
+}

--- a/internal/config/user_email.go
+++ b/internal/config/user_email.go
@@ -1,0 +1,34 @@
+package config
+
+import "strings"
+
+const (
+	DefaultUserEmailVerificationTokenTTL = "24h"
+	DefaultUserEmailResetTokenTTL        = "30m"
+	DefaultUserEmailSMTPPort             = 587
+)
+
+// NormalizeUserEmailConfig applies stable defaults without deciding whether the feature is usable.
+func (cfg *Config) NormalizeUserEmailConfig() {
+	if cfg == nil {
+		return
+	}
+	cfg.UserEmail.PublicUserURL = strings.TrimSpace(cfg.UserEmail.PublicUserURL)
+	cfg.UserEmail.FromAddress = strings.TrimSpace(cfg.UserEmail.FromAddress)
+	cfg.UserEmail.FromName = strings.TrimSpace(cfg.UserEmail.FromName)
+	cfg.UserEmail.Sender.Type = strings.ToLower(strings.TrimSpace(cfg.UserEmail.Sender.Type))
+	cfg.UserEmail.Sender.SMTP.Host = strings.TrimSpace(cfg.UserEmail.Sender.SMTP.Host)
+	cfg.UserEmail.Sender.SMTP.Username = strings.TrimSpace(cfg.UserEmail.Sender.SMTP.Username)
+	cfg.UserEmail.Sender.SMTP.PasswordEnv = strings.TrimSpace(cfg.UserEmail.Sender.SMTP.PasswordEnv)
+	if cfg.UserEmail.Sender.SMTP.Port <= 0 {
+		cfg.UserEmail.Sender.SMTP.Port = DefaultUserEmailSMTPPort
+	}
+	cfg.UserEmail.VerificationTokenTTL = strings.TrimSpace(cfg.UserEmail.VerificationTokenTTL)
+	if cfg.UserEmail.VerificationTokenTTL == "" {
+		cfg.UserEmail.VerificationTokenTTL = DefaultUserEmailVerificationTokenTTL
+	}
+	cfg.UserEmail.ResetTokenTTL = strings.TrimSpace(cfg.UserEmail.ResetTokenTTL)
+	if cfg.UserEmail.ResetTokenTTL == "" {
+		cfg.UserEmail.ResetTokenTTL = DefaultUserEmailResetTokenTTL
+	}
+}

--- a/internal/home/config_yaml.go
+++ b/internal/home/config_yaml.go
@@ -136,6 +136,8 @@ func sanitizeConfigYAMLForDownstream(payload []byte) ([]byte, error) {
 	doc := yamlRoot.Content[0]
 	removeConfigKeysForDownstream(doc, []string{
 		"remote-management",
+		"trusted-proxies",
+		"user-email",
 		"api-keys",
 		"auth-dir",
 		"tls",

--- a/internal/home/config_yaml_test.go
+++ b/internal/home/config_yaml_test.go
@@ -16,6 +16,17 @@ tls:
   enable: false
 remote-management:
   allow-remote: false
+trusted-proxies:
+  - "127.0.0.1"
+user-email:
+  enabled: true
+  public-user-url: "https://home.example.com/user.html"
+  from-address: "no-reply@example.com"
+  sender:
+    type: smtp
+    smtp:
+      host: "smtp.example.com"
+      password-env: "HOME_USER_EMAIL_SMTP_PASSWORD"
 auth-dir: "~/.cli-proxy-api-home"
 api-keys:
   - "k1"
@@ -81,6 +92,9 @@ plugins:
 
 	assertNotContains("tls:")
 	assertNotContains("remote-management:")
+	assertNotContains("trusted-proxies:")
+	assertNotContains("user-email:")
+	assertNotContains("HOME_USER_EMAIL_SMTP_PASSWORD")
 	assertNotContains("auth-dir:")
 	assertNotContains("api-keys:")
 	assertNotContains("gemini-api-key:")

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -540,7 +540,20 @@ func Build(configFilePath string, opts ...RouteOption) (*BuildResult, error) {
 	handler.SetLogDirectory("logs")
 
 	engine := gin.New()
-	_ = engine.SetTrustedProxies(nil)
+	var trustedProxies []string
+	if clusterEnabled {
+		if current := clusterOpt.Runtime.Config(); current != nil {
+			proxyConfig := &appconfig.Config{TrustedProxies: append([]string(nil), current.TrustedProxies...)}
+			proxyConfig.NormalizeTrustedProxies()
+			if errValidate := appconfig.ValidateTrustedProxies(proxyConfig.TrustedProxies); errValidate != nil {
+				return nil, fmt.Errorf("management http: configure trusted proxies: %w", errValidate)
+			}
+			trustedProxies = proxyConfig.TrustedProxies
+		}
+	}
+	if errTrustedProxies := engine.SetTrustedProxies(trustedProxies); errTrustedProxies != nil {
+		return nil, fmt.Errorf("management http: configure trusted proxies: %w", errTrustedProxies)
+	}
 	engine.Use(gin.Recovery())
 	engine.Use(corsMiddleware())
 

--- a/internal/userapi/billing_test.go
+++ b/internal/userapi/billing_test.go
@@ -523,7 +523,7 @@ func createUserBillingBearerToken(t *testing.T, handler *Handler, userID uint) s
 	if _, _, errKey := handler.repo.ClusterCAKeyPair(ctx); errKey != nil {
 		t.Fatalf("ClusterCAKeyPair() error = %v", errKey)
 	}
-	token, _, errToken := handler.createBearerToken(ctx, userID, time.Hour)
+	token, _, errToken := handler.createBearerToken(ctx, userID, 0, time.Hour)
 	if errToken != nil {
 		t.Fatalf("createBearerToken() error = %v", errToken)
 	}

--- a/internal/userapi/email_recovery.go
+++ b/internal/userapi/email_recovery.go
@@ -1,0 +1,496 @@
+package userapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/mail"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/buildinfo"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/usermail"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/idna"
+	"gorm.io/gorm"
+)
+
+const forgotPasswordAcceptedMessage = "If an eligible account matches, password reset instructions will be sent."
+
+const maxUserSecurityTokenBytes = 512
+
+const (
+	verificationResendCooldown   = time.Minute
+	verificationUserHourlyLimit  = 5
+	verificationEmailHourlyLimit = 5
+	verificationIPLimit          = 20
+	verificationIPWindow         = 15 * time.Minute
+	verificationGlobalLimit      = 100
+	verificationGlobalWindow     = time.Minute
+	emailMutationIPLimit         = 20
+	emailMutationIPWindow        = 15 * time.Minute
+	emailMutationUserLimit       = 10
+	emailMutationUserWindow      = time.Hour
+	emailMutationGlobalLimit     = 100
+	emailMutationGlobalWindow    = time.Minute
+	registrationIPLimit          = 10
+	registrationIPWindow         = 15 * time.Minute
+	registrationGlobalLimit      = 100
+	registrationGlobalWindow     = time.Minute
+
+	forgotPasswordIPLimit       = 5
+	forgotPasswordIPWindow      = 15 * time.Minute
+	forgotPasswordEmailCooldown = 5 * time.Minute
+	forgotPasswordEmailLimit    = 3
+	forgotPasswordEmailWindow   = time.Hour
+	forgotPasswordGlobalLimit   = 100
+	forgotPasswordGlobalWindow  = time.Minute
+
+	publicTokenIPLimit      = 30
+	publicTokenIPWindow     = 15 * time.Minute
+	publicTokenGlobalLimit  = 300
+	publicTokenGlobalWindow = time.Minute
+)
+
+type emailRequest struct {
+	Email string `json:"email"`
+}
+
+type securityTokenRequest struct {
+	Token string `json:"token"`
+}
+
+type passwordResetRequest struct {
+	Token           string `json:"token"`
+	NewPassword     string `json:"new_password"`
+	NewPasswordDash string `json:"new-password"`
+}
+
+// GetCapabilities reports optional User API features without exposing mail configuration.
+func (h *Handler) GetCapabilities(c *gin.Context) {
+	enabled := h.userEmailEnabled()
+	c.JSON(http.StatusOK, gin.H{
+		"capabilities": gin.H{
+			"email_registration": enabled,
+			"email_verification": enabled,
+			"password_recovery":  enabled,
+		},
+		"server_info": gin.H{
+			"home_version":    buildinfo.Version,
+			"home_commit":     buildinfo.Commit,
+			"home_build_date": buildinfo.BuildDate,
+		},
+	})
+}
+
+// UpdateEmail adds or replaces the authenticated user's optional email.
+func (h *Handler) UpdateEmail(c *gin.Context) {
+	if !h.requireUserEmailEnabled(c) {
+		return
+	}
+	var body emailRequest
+	if !decodeJSONBody(c, &body) {
+		return
+	}
+	email, errEmail := normalizeUserEmail(body.Email)
+	if errEmail != nil {
+		respondError(c, http.StatusBadRequest, "invalid_email", fmt.Errorf("email is invalid"))
+		return
+	}
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	record, ok := h.authenticatedUser(c, ctx, authFields{})
+	if !ok {
+		return
+	}
+	if record.Email != nil && strings.TrimSpace(*record.Email) == email {
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "user": h.userResponse(record)})
+		return
+	}
+	allowed, retryAfter, errAllowed := h.allowUserSecurityActions(ctx, time.Now().UTC(), []userSecurityActionLimit{
+		{action: "email_update_user", scope: "user:" + strconv.FormatUint(uint64(record.ID), 10), limit: emailMutationUserLimit, window: emailMutationUserWindow},
+		{action: "email_update_ip", scope: "ip:" + c.ClientIP(), limit: emailMutationIPLimit, window: emailMutationIPWindow},
+		{action: "email_update_global", scope: "global", limit: emailMutationGlobalLimit, window: emailMutationGlobalWindow},
+	})
+	if errAllowed != nil {
+		respondError(c, http.StatusInternalServerError, "email_update_failed", errAllowed)
+		return
+	}
+	if !allowed {
+		c.Header("Retry-After", retryAfterHeaderValue(retryAfter))
+		respondError(c, http.StatusTooManyRequests, "email_update_rate_limited", fmt.Errorf("email update rate limit exceeded"))
+		return
+	}
+	updated, errUpdate := h.repo.UpdateUser(ctx, record.ID, cluster.UserUpdate{Email: &email})
+	if errUpdate != nil {
+		respondError(c, http.StatusInternalServerError, "email_update_failed", errUpdate)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "user": h.userResponse(updated)})
+}
+
+// ClearEmail removes the authenticated user's email and invalidates email-bound security state.
+func (h *Handler) ClearEmail(c *gin.Context) {
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	record, ok := h.authenticatedUser(c, ctx, authFields{})
+	if !ok {
+		return
+	}
+	if record.Email == nil || strings.TrimSpace(*record.Email) == "" {
+		c.JSON(http.StatusOK, gin.H{"status": "ok", "user": h.userResponse(record)})
+		return
+	}
+	allowed, retryAfter, errAllowed := h.allowUserSecurityActions(ctx, time.Now().UTC(), []userSecurityActionLimit{
+		{action: "email_update_user", scope: "user:" + strconv.FormatUint(uint64(record.ID), 10), limit: emailMutationUserLimit, window: emailMutationUserWindow},
+		{action: "email_update_ip", scope: "ip:" + c.ClientIP(), limit: emailMutationIPLimit, window: emailMutationIPWindow},
+		{action: "email_update_global", scope: "global", limit: emailMutationGlobalLimit, window: emailMutationGlobalWindow},
+	})
+	if errAllowed != nil {
+		respondError(c, http.StatusInternalServerError, "email_update_failed", errAllowed)
+		return
+	}
+	if !allowed {
+		c.Header("Retry-After", retryAfterHeaderValue(retryAfter))
+		respondError(c, http.StatusTooManyRequests, "email_update_rate_limited", fmt.Errorf("email update rate limit exceeded"))
+		return
+	}
+	emptyEmail := ""
+	updated, errUpdate := h.repo.UpdateUser(ctx, record.ID, cluster.UserUpdate{Email: &emptyEmail})
+	if errUpdate != nil {
+		respondError(c, http.StatusInternalServerError, "email_update_failed", errUpdate)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok", "user": h.userResponse(updated)})
+}
+
+// RequestEmailVerification queues a verification message for the current unverified email.
+func (h *Handler) RequestEmailVerification(c *gin.Context) {
+	if !h.requireUserEmailEnabled(c) {
+		return
+	}
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	record, ok := h.authenticatedUser(c, ctx, authFields{})
+	if !ok {
+		return
+	}
+	if record.Email == nil || strings.TrimSpace(*record.Email) == "" {
+		respondError(c, http.StatusConflict, "email_not_configured", fmt.Errorf("email is not configured"))
+		return
+	}
+	if record.EmailVerifiedAt != nil {
+		respondOK(c)
+		return
+	}
+	queued, retryAfter, errQueue := h.enqueueEmailVerification(ctx, record, c.ClientIP(), time.Now().UTC())
+	if errQueue != nil {
+		respondError(c, http.StatusInternalServerError, "verification_request_failed", errQueue)
+		return
+	}
+	if !queued {
+		c.Header("Retry-After", retryAfterHeaderValue(retryAfter))
+		respondError(c, http.StatusTooManyRequests, "verification_rate_limited", fmt.Errorf("verification request rate limit exceeded"))
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"status": "accepted"})
+}
+
+// VerifyEmail consumes a single-use email-verification token.
+func (h *Handler) VerifyEmail(c *gin.Context) {
+	var body securityTokenRequest
+	if !decodeJSONBody(c, &body) {
+		return
+	}
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	allowed, _, errAllowed := h.allowUserSecurityActions(ctx, time.Now().UTC(), []userSecurityActionLimit{
+		{action: "verify_email_token_ip", scope: "ip:" + c.ClientIP(), limit: publicTokenIPLimit, window: publicTokenIPWindow},
+		{action: "verify_email_token_global", scope: "global", limit: publicTokenGlobalLimit, window: publicTokenGlobalWindow},
+	})
+	if errAllowed != nil || !allowed {
+		respondInvalidOrExpiredToken(c, "verification link is invalid or expired")
+		return
+	}
+	token := strings.TrimSpace(body.Token)
+	if token == "" || len(token) > maxUserSecurityTokenBytes {
+		respondInvalidOrExpiredToken(c, "verification link is invalid or expired")
+		return
+	}
+	tokenHash := cluster.HashUserSecurityValue(token)
+	if _, errVerify := h.repo.ConsumeUserEmailVerificationToken(ctx, tokenHash, time.Now().UTC()); errVerify != nil {
+		if errors.Is(errVerify, cluster.ErrUserSecurityTokenInvalid) || errors.Is(errVerify, gorm.ErrRecordNotFound) || cluster.IsUserEmailConflictError(errVerify) {
+			respondInvalidOrExpiredToken(c, "verification link is invalid or expired")
+			return
+		}
+		respondError(c, http.StatusInternalServerError, "email_verification_failed", errVerify)
+		return
+	}
+	respondOK(c)
+}
+
+// ForgotPassword accepts recovery requests without revealing account state.
+func (h *Handler) ForgotPassword(c *gin.Context) {
+	if !h.requireUserEmailEnabled(c) {
+		return
+	}
+	startedAt := time.Now()
+	var body emailRequest
+	if !decodeJSONBody(c, &body) {
+		return
+	}
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	now := time.Now().UTC()
+	allowed, _, errAllowed := h.allowUserSecurityActions(ctx, now, []userSecurityActionLimit{
+		{action: "forgot_password_ip", scope: "ip:" + c.ClientIP(), limit: forgotPasswordIPLimit, window: forgotPasswordIPWindow},
+		{action: "forgot_password_global", scope: "global", limit: forgotPasswordGlobalLimit, window: forgotPasswordGlobalWindow},
+	})
+	if errAllowed != nil || !allowed {
+		if errAllowed != nil {
+			log.WithField("error_type", fmt.Sprintf("%T", errAllowed)).Warn("user recovery throttle failed")
+		}
+		h.respondForgotPasswordAccepted(c, startedAt)
+		return
+	}
+	email, errEmail := normalizeUserEmail(body.Email)
+	if errEmail != nil {
+		h.respondForgotPasswordAccepted(c, startedAt)
+		return
+	}
+	allowed, _, errAllowed = h.allowUserSecurityActions(ctx, now, []userSecurityActionLimit{
+		{action: "forgot_password_email_cooldown", scope: "email:" + email, limit: 1, window: forgotPasswordEmailCooldown},
+		{action: "forgot_password_email_hourly", scope: "email:" + email, limit: forgotPasswordEmailLimit, window: forgotPasswordEmailWindow},
+	})
+	if errAllowed != nil || !allowed {
+		if errAllowed != nil {
+			log.WithField("error_type", fmt.Sprintf("%T", errAllowed)).Warn("user recovery email throttle failed")
+		}
+		h.respondForgotPasswordAccepted(c, startedAt)
+		return
+	}
+	record, errUser := h.repo.GetUserByEmail(ctx, email)
+	if errUser != nil {
+		if !errors.Is(errUser, gorm.ErrRecordNotFound) {
+			log.WithField("error_type", fmt.Sprintf("%T", errUser)).Warn("user recovery account lookup failed")
+		}
+		h.respondForgotPasswordAccepted(c, startedAt)
+		return
+	}
+	if record == nil || record.EmailVerifiedAt == nil {
+		h.respondForgotPasswordAccepted(c, startedAt)
+		return
+	}
+	if _, errEnqueue := h.repo.EnqueueUserMailJob(ctx, record.ID, cluster.UserSecurityTokenPurposePasswordReset, record.EmailVersion, now); errEnqueue != nil {
+		log.WithFields(log.Fields{
+			"user_id":    record.ID,
+			"purpose":    cluster.UserSecurityTokenPurposePasswordReset,
+			"error_type": fmt.Sprintf("%T", errEnqueue),
+		}).Warn("user recovery mail enqueue failed")
+	}
+	h.respondForgotPasswordAccepted(c, startedAt)
+}
+
+// ResetPassword consumes a reset token and sets a new password without bypassing MFA or Passkeys.
+func (h *Handler) ResetPassword(c *gin.Context) {
+	var body passwordResetRequest
+	if !decodeJSONBody(c, &body) {
+		return
+	}
+	ctx, cancel := requestContext(c)
+	defer cancel()
+	allowed, _, errAllowed := h.allowUserSecurityActions(ctx, time.Now().UTC(), []userSecurityActionLimit{
+		{action: "reset_password_ip", scope: "ip:" + c.ClientIP(), limit: 10, window: 15 * time.Minute},
+		{action: "reset_password_global", scope: "global", limit: publicTokenGlobalLimit, window: publicTokenGlobalWindow},
+	})
+	if errAllowed != nil || !allowed {
+		respondInvalidOrExpiredToken(c, "password reset link is invalid or expired")
+		return
+	}
+	newPassword := firstRawNonEmpty(body.NewPassword, body.NewPasswordDash)
+	token := strings.TrimSpace(body.Token)
+	if token == "" || len(token) > maxUserSecurityTokenBytes || newPassword == "" {
+		respondInvalidOrExpiredToken(c, "password reset link is invalid or expired")
+		return
+	}
+	hashed, errHash := hashPassword(newPassword)
+	if errHash != nil {
+		respondPasswordHashError(c, errHash)
+		return
+	}
+	if _, errReset := h.repo.ConsumeUserPasswordResetToken(ctx, cluster.HashUserSecurityValue(token), hashed, time.Now().UTC()); errReset != nil {
+		if errors.Is(errReset, cluster.ErrUserSecurityTokenInvalid) || errors.Is(errReset, gorm.ErrRecordNotFound) {
+			respondInvalidOrExpiredToken(c, "password reset link is invalid or expired")
+			return
+		}
+		respondError(c, http.StatusInternalServerError, "password_reset_failed", errReset)
+		return
+	}
+	respondOK(c)
+}
+
+func (h *Handler) userEmailEnabled() bool {
+	return h != nil && h.runtime != nil && usermail.Enabled(h.runtime.Config())
+}
+
+func (h *Handler) requireUserEmailEnabled(c *gin.Context) bool {
+	if h.userEmailEnabled() {
+		return true
+	}
+	respondError(c, http.StatusNotFound, "email_feature_unavailable", fmt.Errorf("email feature is unavailable"))
+	return false
+}
+
+func (h *Handler) enqueueEmailVerification(ctx context.Context, record *cluster.UserRecord, clientIP string, now time.Time) (bool, time.Duration, error) {
+	if h == nil || h.repo == nil || record == nil || record.Email == nil || strings.TrimSpace(*record.Email) == "" {
+		return false, 0, fmt.Errorf("user email is required")
+	}
+	userScope := "user:" + strconv.FormatUint(uint64(record.ID), 10)
+	emailScope := "email:" + strings.TrimSpace(*record.Email)
+	allowed, retryAfter, errAllowed := h.allowUserSecurityActions(ctx, now, []userSecurityActionLimit{
+		{action: "verify_email_user_cooldown", scope: userScope, limit: 1, window: verificationResendCooldown},
+		{action: "verify_email_email_cooldown", scope: emailScope, limit: 1, window: verificationResendCooldown},
+		{action: "verify_email_user_hourly", scope: userScope, limit: verificationUserHourlyLimit, window: time.Hour},
+		{action: "verify_email_email_hourly", scope: emailScope, limit: verificationEmailHourlyLimit, window: time.Hour},
+		{action: "verify_email_ip", scope: "ip:" + strings.TrimSpace(clientIP), limit: verificationIPLimit, window: verificationIPWindow},
+		{action: "verify_email_global", scope: "global", limit: verificationGlobalLimit, window: verificationGlobalWindow},
+	})
+	if errAllowed != nil || !allowed {
+		return false, retryAfter, errAllowed
+	}
+	owner, errOwner := h.repo.GetUserByEmail(ctx, strings.TrimSpace(*record.Email))
+	if errOwner == nil && owner != nil && owner.ID != record.ID {
+		// Preserve a non-enumerating accepted response without sending mail to
+		// an address that is already verified by another active account.
+		return true, 0, nil
+	}
+	if errOwner != nil && !errors.Is(errOwner, gorm.ErrRecordNotFound) {
+		return false, 0, errOwner
+	}
+	if _, errEnqueue := h.repo.EnqueueUserMailJob(ctx, record.ID, cluster.UserSecurityTokenPurposeEmailVerification, record.EmailVersion, now); errEnqueue != nil {
+		return false, 0, errEnqueue
+	}
+	return true, 0, nil
+}
+
+type userSecurityActionLimit struct {
+	action string
+	scope  string
+	limit  int
+	window time.Duration
+}
+
+func (h *Handler) allowUserSecurityActions(ctx context.Context, now time.Time, limits []userSecurityActionLimit) (bool, time.Duration, error) {
+	if h == nil || h.repo == nil {
+		return false, 0, fmt.Errorf("user security repository is unavailable")
+	}
+	for _, current := range limits {
+		allowed, retryAfter, errAllow := h.repo.AllowUserSecurityActionWithRetry(
+			ctx,
+			current.action,
+			cluster.HashUserSecurityValue(current.scope),
+			current.limit,
+			current.window,
+			now,
+		)
+		if errAllow != nil || !allowed {
+			return false, retryAfter, errAllow
+		}
+	}
+	return true, 0, nil
+}
+
+func retryAfterHeaderValue(retryAfter time.Duration) string {
+	seconds := int64((retryAfter + time.Second - 1) / time.Second)
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.FormatInt(seconds, 10)
+}
+
+func userEmailStatusResponse(record *cluster.UserRecord, recoveryEnabled bool) gin.H {
+	configured := record != nil && record.Email != nil && strings.TrimSpace(*record.Email) != ""
+	verified := configured && record.EmailVerifiedAt != nil
+	masked := ""
+	if configured {
+		masked = maskUserEmail(*record.Email)
+	}
+	return gin.H{
+		"configured":     configured,
+		"verified":       verified,
+		"masked":         masked,
+		"recovery_ready": verified && recoveryEnabled,
+	}
+}
+
+func normalizeUserEmail(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" || len(value) > 320 {
+		return "", fmt.Errorf("email is invalid")
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("email is invalid")
+		}
+	}
+	parsed, errParse := mail.ParseAddress(value)
+	if errParse != nil || parsed == nil || parsed.Name != "" {
+		return "", fmt.Errorf("email is invalid")
+	}
+	address := strings.TrimSpace(parsed.Address)
+	at := strings.LastIndex(address, "@")
+	if at <= 0 || at == len(address)-1 {
+		return "", fmt.Errorf("email is invalid")
+	}
+	local := strings.ToLower(address[:at])
+	domain, errDomain := idna.Lookup.ToASCII(strings.ToLower(address[at+1:]))
+	if errDomain != nil || strings.TrimSpace(domain) == "" {
+		return "", fmt.Errorf("email is invalid")
+	}
+	normalized := local + "@" + strings.ToLower(domain)
+	if len(normalized) > 320 {
+		return "", fmt.Errorf("email is invalid")
+	}
+	return normalized, nil
+}
+
+func maskUserEmail(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at <= 0 || at == len(email)-1 {
+		return "***"
+	}
+	localRunes := []rune(email[:at])
+	maskedLocal := "*"
+	if len(localRunes) > 0 {
+		maskedLocal = string(localRunes[0]) + "***"
+	}
+	return maskedLocal + email[at:]
+}
+
+func (h *Handler) respondForgotPasswordAccepted(c *gin.Context, startedAt time.Time) {
+	if h != nil && h.forgotPasswordResponseFloor > 0 {
+		remaining := h.forgotPasswordResponseFloor - time.Since(startedAt)
+		if remaining > 0 {
+			timer := time.NewTimer(remaining)
+			defer timer.Stop()
+			var requestDone <-chan struct{}
+			if c != nil && c.Request != nil {
+				requestDone = c.Request.Context().Done()
+			}
+			select {
+			case <-requestDone:
+			case <-timer.C:
+			}
+		}
+	}
+	c.JSON(http.StatusAccepted, gin.H{"status": "accepted", "message": forgotPasswordAcceptedMessage})
+}
+
+func respondInvalidOrExpiredToken(c *gin.Context, message string) {
+	respondError(c, http.StatusBadRequest, "invalid_or_expired_token", fmt.Errorf("%s", message))
+}

--- a/internal/userapi/email_recovery_test.go
+++ b/internal/userapi/email_recovery_test.go
@@ -1,0 +1,537 @@
+package userapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
+	"gorm.io/gorm"
+)
+
+func TestNormalizeUserEmailAndMask(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "trim and lowercase", raw: "  Alice@EXAMPLE.com  ", want: "alice@example.com"},
+		{name: "idna domain", raw: "User@例子.测试", want: "user@xn--fsqu00a.xn--0zwm56d"},
+		{name: "display name", raw: "Alice <alice@example.com>", wantErr: true},
+		{name: "multiple", raw: "alice@example.com,bob@example.com", wantErr: true},
+		{name: "header break", raw: "alice@example.com\r\nBcc: bob@example.com", wantErr: true},
+		{name: "empty", raw: " ", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, errNormalize := normalizeUserEmail(test.raw)
+			if test.wantErr {
+				if errNormalize == nil {
+					t.Fatalf("normalizeUserEmail(%q) = %q, want error", test.raw, got)
+				}
+				return
+			}
+			if errNormalize != nil || got != test.want {
+				t.Fatalf("normalizeUserEmail(%q) = %q, %v; want %q", test.raw, got, errNormalize, test.want)
+			}
+		})
+	}
+	if got := maskUserEmail("alice@example.com"); got != "a***@example.com" {
+		t.Fatalf("maskUserEmail() = %q", got)
+	}
+}
+
+func TestRespondErrorDoesNotExposeInternalFailureDetails(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	respondError(ginContext, http.StatusInternalServerError, "user_load_failed", errors.New("database password=secret failed"))
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if strings.Contains(recorder.Body.String(), "password=secret") || !strings.Contains(recorder.Body.String(), "internal server error") {
+		t.Fatalf("internal error response = %s", recorder.Body.String())
+	}
+}
+
+func TestUserCapabilitiesReflectUsableConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*appconfig.Config)
+		enabled bool
+	}{
+		{name: "disabled", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.Enabled = false }, enabled: false},
+		{name: "invalid", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.FromAddress = "" }, enabled: false},
+		{name: "enabled", mutate: func(*appconfig.Config) {}, enabled: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler, router, _ := newUserEmailTestHandler(t, test.mutate)
+			_ = handler
+			response := performUserJSONRequest(t, router, http.MethodGet, "/user/capabilities", nil, "")
+			if response.Code != http.StatusOK {
+				t.Fatalf("capabilities status = %d body=%s", response.Code, response.Body.String())
+			}
+			var body struct {
+				Capabilities struct {
+					EmailRegistration bool `json:"email_registration"`
+					EmailVerification bool `json:"email_verification"`
+					PasswordRecovery  bool `json:"password_recovery"`
+				} `json:"capabilities"`
+			}
+			if errDecode := json.Unmarshal(response.Body.Bytes(), &body); errDecode != nil {
+				t.Fatalf("decode capabilities: %v", errDecode)
+			}
+			if body.Capabilities.EmailRegistration != test.enabled || body.Capabilities.EmailVerification != test.enabled || body.Capabilities.PasswordRecovery != test.enabled {
+				t.Fatalf("capabilities = %#v, want enabled=%v", body.Capabilities, test.enabled)
+			}
+		})
+	}
+}
+
+func TestForgotPasswordResponsesDoNotEnumerateAccounts(t *testing.T) {
+	handler, router, db := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	unverifiedEmail := "unverified@example.com"
+	unverifiedName := "unverified"
+	if _, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &unverifiedName, Email: &unverifiedEmail}); errCreate != nil {
+		t.Fatalf("CreateUser(unverified) error = %v", errCreate)
+	}
+	verifiedEmail := "verified@example.com"
+	verifiedName := "verified"
+	verified, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &verifiedName, Email: &verifiedEmail})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(verified) error = %v", errCreate)
+	}
+	verifiedAt := time.Now().UTC()
+	if errVerify := db.Model(&cluster.UserRecord{}).Where("id = ?", verified.ID).Update("email_verified_at", verifiedAt).Error; errVerify != nil {
+		t.Fatalf("mark email verified: %v", errVerify)
+	}
+
+	requests := []map[string]any{
+		{"email": "not-an-email"},
+		{"email": "missing@example.com"},
+		{"email": unverifiedEmail},
+		{"email": verifiedEmail},
+	}
+	var wantBody string
+	for _, request := range requests {
+		response := performUserJSONRequest(t, router, http.MethodPost, "/user/password/forgot", request, "")
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("forgot status = %d body=%s", response.Code, response.Body.String())
+		}
+		if wantBody == "" {
+			wantBody = response.Body.String()
+		} else if response.Body.String() != wantBody {
+			t.Fatalf("forgot response differs: got %q want %q", response.Body.String(), wantBody)
+		}
+		if strings.Contains(response.Body.String(), verifiedEmail) || strings.Contains(response.Body.String(), unverifiedEmail) {
+			t.Fatalf("forgot response leaked email: %s", response.Body.String())
+		}
+	}
+	for attempt := 0; attempt < 4; attempt++ {
+		response := performUserJSONRequest(t, router, http.MethodPost, "/user/password/forgot", map[string]any{"email": verifiedEmail}, "")
+		if response.Code != http.StatusAccepted || response.Body.String() != wantBody {
+			t.Fatalf("rate-limited forgot response = %d %q, want generic accepted", response.Code, response.Body.String())
+		}
+	}
+	var jobs int64
+	if errCount := db.Model(&cluster.UserMailJobRecord{}).Where("user_id = ? AND purpose = ?", verified.ID, cluster.UserSecurityTokenPurposePasswordReset).Count(&jobs).Error; errCount != nil {
+		t.Fatalf("count recovery jobs: %v", errCount)
+	}
+	if jobs == 0 {
+		t.Fatal("eligible recovery request did not enqueue a mail job")
+	}
+}
+
+func TestEmailVerificationResendCooldown(t *testing.T) {
+	handler, router, _ := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	bearer := createUserTestBearerToken(t, handler, user.ID, user.SessionVersion)
+	first := performUserJSONRequest(t, router, http.MethodPost, "/user/email/verification", map[string]any{}, bearer)
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first verification request = %d %s", first.Code, first.Body.String())
+	}
+	second := performUserJSONRequest(t, router, http.MethodPost, "/user/email/verification", map[string]any{}, bearer)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second verification request = %d %s", second.Code, second.Body.String())
+	}
+	if got := second.Header().Get("Retry-After"); got != "60" {
+		t.Fatalf("Retry-After = %q, want 60", got)
+	}
+}
+
+func TestRegistrationVerificationUsesSharedRateLimits(t *testing.T) {
+	_, router, db := newUserEmailTestHandler(t, nil)
+	register := performUserJSONRequest(t, router, http.MethodPost, "/user/register", map[string]any{
+		"username": "alice",
+		"password": "password",
+		"email":    "alice@example.com",
+	}, "")
+	if register.Code != http.StatusOK {
+		t.Fatalf("register status = %d body=%s", register.Code, register.Body.String())
+	}
+	var login struct {
+		Token string `json:"token"`
+	}
+	if errDecode := json.Unmarshal(register.Body.Bytes(), &login); errDecode != nil || login.Token == "" {
+		t.Fatalf("decode registration token: token=%q error=%v", login.Token, errDecode)
+	}
+	resend := performUserJSONRequest(t, router, http.MethodPost, "/user/email/verification", map[string]any{}, login.Token)
+	if resend.Code != http.StatusTooManyRequests {
+		t.Fatalf("immediate resend status = %d body=%s", resend.Code, resend.Body.String())
+	}
+	if got := resend.Header().Get("Retry-After"); got != "60" {
+		t.Fatalf("Retry-After = %q, want 60", got)
+	}
+	var jobs int64
+	if errCount := db.Model(&cluster.UserMailJobRecord{}).Where("purpose = ?", cluster.UserSecurityTokenPurposeEmailVerification).Count(&jobs).Error; errCount != nil {
+		t.Fatalf("count verification jobs: %v", errCount)
+	}
+	if jobs != 1 {
+		t.Fatalf("verification jobs = %d, want 1", jobs)
+	}
+}
+
+func TestRegistrationWithoutEmailIsRateLimited(t *testing.T) {
+	_, router, _ := newUserEmailTestHandler(t, nil)
+	for attempt := 0; attempt < registrationIPLimit; attempt++ {
+		response := performUserJSONRequest(t, router, http.MethodPost, "/user/register", map[string]any{
+			"username": "alice",
+			"password": "password",
+		}, "")
+		if attempt == 0 && response.Code != http.StatusOK {
+			t.Fatalf("initial registration status = %d body=%s", response.Code, response.Body.String())
+		}
+		if attempt > 0 && response.Code != http.StatusConflict {
+			t.Fatalf("duplicate registration %d status = %d body=%s", attempt, response.Code, response.Body.String())
+		}
+	}
+	limited := performUserJSONRequest(t, router, http.MethodPost, "/user/register", map[string]any{
+		"username": "bob",
+		"password": "password",
+	}, "")
+	if limited.Code != http.StatusTooManyRequests {
+		t.Fatalf("limited registration status = %d body=%s", limited.Code, limited.Body.String())
+	}
+	if limited.Header().Get("Retry-After") == "" {
+		t.Fatal("limited registration omitted Retry-After")
+	}
+}
+
+func TestRegistrationDoesNotRevealOrMailVerifiedEmailOwner(t *testing.T) {
+	handler, router, db := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	email := "shared@example.com"
+	ownerName := "owner"
+	owner, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &ownerName, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(owner) error = %v", errCreate)
+	}
+	verifiedAt := time.Now().UTC()
+	if errVerify := db.Model(&cluster.UserRecord{}).Where("id = ?", owner.ID).Update("email_verified_at", verifiedAt).Error; errVerify != nil {
+		t.Fatalf("mark owner email verified: %v", errVerify)
+	}
+	register := performUserJSONRequest(t, router, http.MethodPost, "/user/register", map[string]any{
+		"username": "claimant",
+		"password": "password",
+		"email":    email,
+	}, "")
+	if register.Code != http.StatusOK {
+		t.Fatalf("claimant registration status = %d body=%s", register.Code, register.Body.String())
+	}
+	var verificationJobs int64
+	if errCount := db.Model(&cluster.UserMailJobRecord{}).Where("purpose = ?", cluster.UserSecurityTokenPurposeEmailVerification).Count(&verificationJobs).Error; errCount != nil {
+		t.Fatalf("count verification jobs: %v", errCount)
+	}
+	if verificationJobs != 0 {
+		t.Fatalf("verification jobs for owned address = %d, want 0", verificationJobs)
+	}
+	forgot := performUserJSONRequest(t, router, http.MethodPost, "/user/password/forgot", map[string]any{"email": email}, "")
+	if forgot.Code != http.StatusAccepted {
+		t.Fatalf("forgot-password status = %d body=%s", forgot.Code, forgot.Body.String())
+	}
+	var resetJobs int64
+	if errCount := db.Model(&cluster.UserMailJobRecord{}).Where("user_id = ? AND purpose = ?", owner.ID, cluster.UserSecurityTokenPurposePasswordReset).Count(&resetJobs).Error; errCount != nil {
+		t.Fatalf("count owner reset jobs: %v", errCount)
+	}
+	if resetJobs != 1 {
+		t.Fatalf("verified owner reset jobs = %d, want 1", resetJobs)
+	}
+}
+
+func TestClearEmailWorksWhenMailCapabilityIsDisabled(t *testing.T) {
+	handler, router, _ := newUserEmailTestHandler(t, func(cfg *appconfig.Config) {
+		cfg.UserEmail.Enabled = false
+	})
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	bearer := createUserTestBearerToken(t, handler, user.ID, user.SessionVersion)
+	response := performUserJSONRequest(t, router, http.MethodDelete, "/user/email", nil, bearer)
+	if response.Code != http.StatusOK {
+		t.Fatalf("clear email status = %d body=%s", response.Code, response.Body.String())
+	}
+	updated, errLoad := handler.repo.GetUser(ctx, user.ID)
+	if errLoad != nil {
+		t.Fatalf("GetUser() error = %v", errLoad)
+	}
+	if updated.Email != nil || updated.EmailVerifiedAt != nil || updated.EmailVersion != user.EmailVersion+1 {
+		t.Fatalf("cleared email state = %#v", updated)
+	}
+}
+
+func TestClearEmailWithoutConfiguredAddressIsIdempotent(t *testing.T) {
+	handler, router, _ := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	username := "alice"
+	user, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	bearer := createUserTestBearerToken(t, handler, user.ID, user.SessionVersion)
+	for attempt := 0; attempt <= emailMutationUserLimit; attempt++ {
+		response := performUserJSONRequest(t, router, http.MethodDelete, "/user/email", nil, bearer)
+		if response.Code != http.StatusOK {
+			t.Fatalf("idempotent clear %d status = %d body=%s", attempt, response.Code, response.Body.String())
+		}
+	}
+}
+
+func TestUpdateEmailWithSameAddressIsIdempotent(t *testing.T) {
+	handler, router, _ := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	bearer := createUserTestBearerToken(t, handler, user.ID, user.SessionVersion)
+	for attempt := 0; attempt <= emailMutationUserLimit; attempt++ {
+		response := performUserJSONRequest(t, router, http.MethodPut, "/user/email", map[string]any{"email": " Alice@EXAMPLE.com "}, bearer)
+		if response.Code != http.StatusOK {
+			t.Fatalf("idempotent update %d status = %d body=%s", attempt, response.Code, response.Body.String())
+		}
+	}
+	stored, errLoad := handler.repo.GetUser(ctx, user.ID)
+	if errLoad != nil {
+		t.Fatalf("GetUser() error = %v", errLoad)
+	}
+	if stored.EmailVersion != user.EmailVersion {
+		t.Fatalf("email version = %d, want %d", stored.EmailVersion, user.EmailVersion)
+	}
+}
+
+func TestVerifyEmailHidesVerifiedOwnershipConflict(t *testing.T) {
+	handler, router, db := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	email := "shared@example.com"
+	ownerName := "owner"
+	owner, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &ownerName, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(owner) error = %v", errCreate)
+	}
+	claimantName := "claimant"
+	claimant, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &claimantName, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(claimant) error = %v", errCreate)
+	}
+	verifiedAt := time.Now().UTC()
+	if errVerify := db.Model(&cluster.UserRecord{}).Where("id = ?", owner.ID).Update("email_verified_at", verifiedAt).Error; errVerify != nil {
+		t.Fatalf("mark owner email verified: %v", errVerify)
+	}
+	rawToken := "claimant-verification-token"
+	if errStore := handler.repo.ReplaceUserSecurityToken(ctx, cluster.UserSecurityTokenRecord{
+		UserID:       claimant.ID,
+		Purpose:      cluster.UserSecurityTokenPurposeEmailVerification,
+		TokenHash:    cluster.HashUserSecurityValue(rawToken),
+		EmailVersion: claimant.EmailVersion,
+		ExpiresAt:    verifiedAt.Add(time.Hour),
+		CreatedAt:    verifiedAt,
+	}); errStore != nil {
+		t.Fatalf("store claimant verification token: %v", errStore)
+	}
+	response := performUserJSONRequest(t, router, http.MethodPost, "/user/email/verify", map[string]any{"token": rawToken}, "")
+	if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "invalid_or_expired_token") {
+		t.Fatalf("ownership-conflict response = %d %s", response.Code, response.Body.String())
+	}
+	stored, errLoad := handler.repo.GetUser(ctx, claimant.ID)
+	if errLoad != nil {
+		t.Fatalf("GetUser(claimant) error = %v", errLoad)
+	}
+	if stored.EmailVerifiedAt != nil {
+		t.Fatal("ownership-conflict verification unexpectedly succeeded")
+	}
+}
+
+func TestUserAPIRejectsOversizedJSONBody(t *testing.T) {
+	_, router, _ := newUserEmailTestHandler(t, nil)
+	payload := []byte(`{"email":"` + strings.Repeat("a", int(maxUserJSONBodyBytes)) + `"}`)
+	request := httptest.NewRequest(http.MethodPost, "/user/password/forgot", bytes.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized request status = %d body=%s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "request_too_large") {
+		t.Fatalf("oversized request body = %s", response.Body.String())
+	}
+}
+
+func TestRegistrationRejectsPasswordBeyondBcryptLimit(t *testing.T) {
+	_, router, _ := newUserEmailTestHandler(t, nil)
+	response := performUserJSONRequest(t, router, http.MethodPost, "/user/register", map[string]any{
+		"username": "alice",
+		"password": strings.Repeat("p", maxPasswordBytes+1),
+	}, "")
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("long password status = %d body=%s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "invalid_password") {
+		t.Fatalf("long password body = %s", response.Body.String())
+	}
+}
+
+func TestChangePasswordRotatesSessionAndReturnsReplacement(t *testing.T) {
+	handler, router, _ := newUserEmailTestHandler(t, nil)
+	ctx := context.Background()
+	username := "alice"
+	oldPassword := "old-password"
+	hashed, errHash := hashPassword(oldPassword)
+	if errHash != nil {
+		t.Fatalf("hashPassword() error = %v", errHash)
+	}
+	user, errCreate := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Password: &hashed})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	oldBearer := createUserTestBearerToken(t, handler, user.ID, user.SessionVersion)
+	change := performUserJSONRequest(t, router, http.MethodPost, "/user/password", map[string]any{"new_password": "new-password"}, oldBearer)
+	if change.Code != http.StatusOK {
+		t.Fatalf("change password = %d %s", change.Code, change.Body.String())
+	}
+	var replacement struct {
+		Token string `json:"token"`
+	}
+	if errDecode := json.Unmarshal(change.Body.Bytes(), &replacement); errDecode != nil || replacement.Token == "" {
+		t.Fatalf("decode replacement session: token=%q error=%v", replacement.Token, errDecode)
+	}
+	oldSession := performUserJSONRequest(t, router, http.MethodGet, "/user/me", nil, oldBearer)
+	if oldSession.Code != http.StatusUnauthorized {
+		t.Fatalf("old session status = %d body=%s", oldSession.Code, oldSession.Body.String())
+	}
+	newSession := performUserJSONRequest(t, router, http.MethodGet, "/user/me", nil, replacement.Token)
+	if newSession.Code != http.StatusOK {
+		t.Fatalf("replacement session status = %d body=%s", newSession.Code, newSession.Body.String())
+	}
+	updated, errLoad := handler.repo.GetUser(ctx, user.ID)
+	if errLoad != nil {
+		t.Fatalf("GetUser() error = %v", errLoad)
+	}
+	if updated.SessionVersion != user.SessionVersion+1 || !passwordMatches(updated.Password, "new-password") {
+		t.Fatalf("updated session/password state = version %d", updated.SessionVersion)
+	}
+}
+
+func newUserEmailTestHandler(t *testing.T, mutate func(*appconfig.Config)) (*Handler, *gin.Engine, *gorm.DB) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	cfg := &appconfig.Config{
+		AuthDir: t.TempDir(),
+		UserEmail: appconfig.UserEmailConfig{
+			Enabled:              true,
+			PublicUserURL:        "http://127.0.0.1/user.html",
+			FromAddress:          "no-reply@example.com",
+			FromName:             "CLIProxyAPIHome",
+			VerificationTokenTTL: "24h",
+			ResetTokenTTL:        "30m",
+			Sender: appconfig.UserEmailSenderConfig{
+				Type: "smtp",
+				SMTP: appconfig.UserEmailSMTPConfig{Host: "127.0.0.1", Port: 2525},
+			},
+		},
+	}
+	if mutate != nil {
+		mutate(cfg)
+	}
+	cfg.NormalizeUserEmailConfig()
+	runtime, errRuntime := home.NewRuntime(cfg)
+	if errRuntime != nil {
+		t.Fatalf("home.NewRuntime() error = %v", errRuntime)
+	}
+	t.Cleanup(runtime.Stop)
+	db, errOpen := cluster.OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if errMigrate := cluster.AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	handler := NewHandler(cluster.NewRepository(db), runtime)
+	handler.forgotPasswordResponseFloor = 0
+	router := gin.New()
+	Register(router.Group("/user"), handler)
+	return handler, router, db
+}
+
+func createUserTestBearerToken(t *testing.T, handler *Handler, userID uint, sessionVersion uint64) string {
+	t.Helper()
+	ctx := context.Background()
+	if _, _, errKey := handler.repo.ClusterCAKeyPair(ctx); errKey != nil {
+		t.Fatalf("ClusterCAKeyPair() error = %v", errKey)
+	}
+	token, _, errToken := handler.createBearerToken(ctx, userID, sessionVersion, time.Hour)
+	if errToken != nil {
+		t.Fatalf("createBearerToken() error = %v", errToken)
+	}
+	return token
+}
+
+func performUserJSONRequest(t *testing.T, router http.Handler, method string, path string, body any, bearer string) *httptest.ResponseRecorder {
+	t.Helper()
+	var payload []byte
+	if body != nil {
+		var errMarshal error
+		payload, errMarshal = json.Marshal(body)
+		if errMarshal != nil {
+			t.Fatalf("marshal request body: %v", errMarshal)
+		}
+	}
+	request := httptest.NewRequest(method, path, bytes.NewReader(payload))
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if bearer != "" {
+		request.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}

--- a/internal/userapi/handler.go
+++ b/internal/userapi/handler.go
@@ -14,12 +14,16 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
+	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
+const maxUserJSONBodyBytes int64 = 1 << 20
+
 type Handler struct {
-	repo    *cluster.Repository
-	runtime *home.Runtime
+	repo                        *cluster.Repository
+	runtime                     *home.Runtime
+	forgotPasswordResponseFloor time.Duration
 }
 
 type authFields struct {
@@ -35,6 +39,7 @@ type authFields struct {
 
 type loginRequest struct {
 	authFields
+	Email string `json:"email"`
 }
 
 type passwordRequest struct {
@@ -83,8 +88,9 @@ type passkeyRequest struct {
 // NewHandler creates a user API handler.
 func NewHandler(repo *cluster.Repository, runtime *home.Runtime) *Handler {
 	return &Handler{
-		repo:    repo,
-		runtime: runtime,
+		repo:                        repo,
+		runtime:                     runtime,
+		forgotPasswordResponseFloor: 150 * time.Millisecond,
 	}
 }
 
@@ -93,6 +99,7 @@ func Register(group *gin.RouterGroup, handler *Handler) {
 	if group == nil || handler == nil {
 		return
 	}
+	group.GET("/capabilities", handler.GetCapabilities)
 	group.POST("/register", handler.RegisterUser)
 	group.POST("/login", handler.Login)
 	group.POST("/login/passkey/begin", handler.BeginPasskeyLogin)
@@ -106,6 +113,13 @@ func Register(group *gin.RouterGroup, handler *Handler) {
 
 	group.POST("/password", handler.ChangePassword)
 	group.PATCH("/password", handler.ChangePassword)
+	group.POST("/password/forgot", handler.ForgotPassword)
+	group.POST("/password/reset", handler.ResetPassword)
+
+	group.PUT("/email", handler.UpdateEmail)
+	group.DELETE("/email", handler.ClearEmail)
+	group.POST("/email/verification", handler.RequestEmailVerification)
+	group.POST("/email/verify", handler.VerifyEmail)
 
 	group.GET("/totp", handler.ShowTOTP)
 	group.POST("/totp/show", handler.ShowTOTP)
@@ -145,6 +159,7 @@ func (h *Handler) RegisterUser(c *gin.Context) {
 	}
 	username := body.username()
 	password := body.Password
+	email := ""
 	if username == "" {
 		respondError(c, http.StatusBadRequest, "invalid_body", fmt.Errorf("username is required"))
 		return
@@ -153,9 +168,35 @@ func (h *Handler) RegisterUser(c *gin.Context) {
 		respondError(c, http.StatusBadRequest, "invalid_body", fmt.Errorf("password is required"))
 		return
 	}
+	if strings.TrimSpace(body.Email) != "" {
+		if !h.userEmailEnabled() {
+			respondError(c, http.StatusConflict, "email_feature_unavailable", fmt.Errorf("email feature is unavailable"))
+			return
+		}
+		var errEmail error
+		email, errEmail = normalizeUserEmail(body.Email)
+		if errEmail != nil {
+			respondError(c, http.StatusBadRequest, "invalid_email", fmt.Errorf("email is invalid"))
+			return
+		}
+	}
 
 	ctx, cancel := requestContext(c)
 	defer cancel()
+	registrationLimits := []userSecurityActionLimit{
+		{action: "user_registration_ip", scope: "ip:" + c.ClientIP(), limit: registrationIPLimit, window: registrationIPWindow},
+		{action: "user_registration_global", scope: "global", limit: registrationGlobalLimit, window: registrationGlobalWindow},
+	}
+	allowed, retryAfter, errAllowed := h.allowUserSecurityActions(ctx, time.Now().UTC(), registrationLimits)
+	if errAllowed != nil {
+		respondError(c, http.StatusInternalServerError, "user_create_failed", errAllowed)
+		return
+	}
+	if !allowed {
+		c.Header("Retry-After", retryAfterHeaderValue(retryAfter))
+		respondError(c, http.StatusTooManyRequests, "registration_rate_limited", fmt.Errorf("registration rate limit exceeded"))
+		return
+	}
 	if _, errExisting := h.repo.GetUserByUsername(ctx, username); errExisting == nil {
 		respondError(c, http.StatusConflict, "user_exists", fmt.Errorf("user already exists"))
 		return
@@ -165,13 +206,17 @@ func (h *Handler) RegisterUser(c *gin.Context) {
 	}
 	hashed, errHash := hashPassword(password)
 	if errHash != nil {
-		respondError(c, http.StatusInternalServerError, "password_hash_failed", errHash)
+		respondPasswordHashError(c, errHash)
 		return
 	}
-	record, errCreate := h.repo.CreateUser(ctx, cluster.UserUpdate{
+	update := cluster.UserUpdate{
 		Username: &username,
 		Password: &hashed,
-	})
+	}
+	if email != "" {
+		update.Email = &email
+	}
+	record, errCreate := h.repo.CreateUser(ctx, update)
 	if errCreate != nil {
 		if cluster.IsUserConflictError(errCreate) {
 			respondError(c, http.StatusConflict, "user_exists", fmt.Errorf("user already exists"))
@@ -179,6 +224,15 @@ func (h *Handler) RegisterUser(c *gin.Context) {
 		}
 		respondError(c, http.StatusInternalServerError, "user_create_failed", errCreate)
 		return
+	}
+	if email != "" {
+		if _, _, errEnqueue := h.enqueueEmailVerification(ctx, record, c.ClientIP(), time.Now().UTC()); errEnqueue != nil {
+			log.WithFields(log.Fields{
+				"user_id":    record.ID,
+				"purpose":    cluster.UserSecurityTokenPurposeEmailVerification,
+				"error_type": fmt.Sprintf("%T", errEnqueue),
+			}).Warn("user mail enqueue failed")
+		}
 	}
 	h.respondLogin(c, ctx, record)
 }
@@ -269,7 +323,7 @@ func (h *Handler) CurrentUser(c *gin.Context) {
 	if !ok {
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": userResponseWithPasskeys(record), "status": "ok"})
+	c.JSON(http.StatusOK, gin.H{"user": h.userResponseWithPasskeys(record), "status": "ok"})
 }
 
 // ChangePassword updates the authenticated user's password.
@@ -291,7 +345,7 @@ func (h *Handler) ChangePassword(c *gin.Context) {
 	}
 	hashed, errHash := hashPassword(newPassword)
 	if errHash != nil {
-		respondError(c, http.StatusInternalServerError, "password_hash_failed", errHash)
+		respondPasswordHashError(c, errHash)
 		return
 	}
 	update := cluster.UserUpdate{Password: &hashed}
@@ -300,7 +354,7 @@ func (h *Handler) ChangePassword(c *gin.Context) {
 		respondUserError(c, "password_update_failed", errUpdate)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": userResponse(updated), "status": "ok"})
+	h.respondLogin(c, ctx, updated)
 }
 
 // ShowTOTP returns a TOTP setup secret and otpauth URL.
@@ -378,7 +432,7 @@ func (h *Handler) BindTOTP(c *gin.Context) {
 		respondUserError(c, "totp_bind_failed", errUpdate)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": userResponse(updated), "status": "ok"})
+	c.JSON(http.StatusOK, gin.H{"user": h.userResponse(updated), "status": "ok"})
 }
 
 // DeleteTOTP removes the authenticated user's TOTP configuration.
@@ -395,7 +449,7 @@ func (h *Handler) DeleteTOTP(c *gin.Context) {
 		respondUserError(c, "totp_delete_failed", errUpdate)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"user": userResponse(updated), "status": "ok"})
+	c.JSON(http.StatusOK, gin.H{"user": h.userResponse(updated), "status": "ok"})
 }
 
 // ListAPIKeys lists API keys owned by the authenticated user.
@@ -662,14 +716,18 @@ func (h *Handler) authenticatedUser(c *gin.Context, ctx context.Context, fields 
 		respondError(c, http.StatusUnauthorized, "bearer_token_required", fmt.Errorf("bearer token is required"))
 		return nil, false
 	}
-	userID, errToken := h.bearerTokenUserID(ctx, token)
+	claims, errToken := h.bearerTokenClaims(ctx, token)
 	if errToken != nil {
 		respondError(c, http.StatusUnauthorized, "invalid_token", fmt.Errorf("invalid token"))
 		return nil, false
 	}
-	record, errUser := h.repo.GetUser(ctx, userID)
+	record, errUser := h.repo.GetUser(ctx, claims.UserID)
 	if errUser != nil {
 		respondAuthError(c, errUser)
+		return nil, false
+	}
+	if claims.SessionVersion != record.SessionVersion {
+		respondError(c, http.StatusUnauthorized, "invalid_token", fmt.Errorf("invalid token"))
 		return nil, false
 	}
 	return record, true
@@ -708,7 +766,7 @@ func (h *Handler) requirePasskeyLogin(c *gin.Context, record *cluster.UserRecord
 }
 
 func (h *Handler) respondLogin(c *gin.Context, ctx context.Context, record *cluster.UserRecord) {
-	token, expiresAt, errToken := h.createBearerToken(ctx, record.ID, defaultSessionTTL)
+	token, expiresAt, errToken := h.createBearerToken(ctx, record.ID, record.SessionVersion, defaultSessionTTL)
 	if errToken != nil {
 		respondError(c, http.StatusInternalServerError, "token_create_failed", errToken)
 		return
@@ -716,7 +774,7 @@ func (h *Handler) respondLogin(c *gin.Context, ctx context.Context, record *clus
 	c.JSON(http.StatusOK, gin.H{
 		"token":      token,
 		"expires_at": expiresAt,
-		"user":       userResponse(record),
+		"user":       h.userResponse(record),
 	})
 }
 
@@ -735,7 +793,7 @@ func (h *Handler) refreshConfig(ctx context.Context) error {
 	return nil
 }
 
-func userResponse(record *cluster.UserRecord) gin.H {
+func (h *Handler) userResponse(record *cluster.UserRecord) gin.H {
 	if record == nil {
 		return gin.H{}
 	}
@@ -747,13 +805,14 @@ func userResponse(record *cluster.UserRecord) gin.H {
 		"credits":       record.Credits,
 		"totp_enabled":  totpEnabled,
 		"passkey_count": len(passkeys),
+		"email_status":  userEmailStatusResponse(record, h.userEmailEnabled()),
 		"created_at":    record.CreatedAt,
 		"updated_at":    record.UpdatedAt,
 	}
 }
 
-func userResponseWithPasskeys(record *cluster.UserRecord) gin.H {
-	out := userResponse(record)
+func (h *Handler) userResponseWithPasskeys(record *cluster.UserRecord) gin.H {
+	out := h.userResponse(record)
 	if record == nil {
 		return out
 	}
@@ -812,8 +871,13 @@ func decodeJSONBodyWithRaw(c *gin.Context, out any) ([]byte, bool) {
 	if c == nil || c.Request == nil || c.Request.Body == nil {
 		return nil, true
 	}
-	data, errRead := io.ReadAll(c.Request.Body)
+	data, errRead := io.ReadAll(http.MaxBytesReader(c.Writer, c.Request.Body, maxUserJSONBodyBytes))
 	if errRead != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(errRead, &maxBytesError) {
+			respondError(c, http.StatusRequestEntityTooLarge, "request_too_large", fmt.Errorf("request body exceeds %d bytes", maxUserJSONBodyBytes))
+			return nil, false
+		}
 		respondError(c, http.StatusBadRequest, "invalid_body", errRead)
 		return nil, false
 	}
@@ -837,10 +901,29 @@ func requestContext(c *gin.Context) (context.Context, context.CancelFunc) {
 
 func respondError(c *gin.Context, status int, code string, err error) {
 	message := strings.TrimSpace(code)
-	if err != nil && strings.TrimSpace(err.Error()) != "" {
+	if status >= http.StatusInternalServerError {
+		message = strings.ToLower(http.StatusText(http.StatusInternalServerError))
+		fields := log.Fields{"error_code": code}
+		if err != nil {
+			fields["error_type"] = fmt.Sprintf("%T", err)
+		}
+		if c != nil && c.Request != nil {
+			fields["method"] = c.Request.Method
+			fields["path"] = c.FullPath()
+		}
+		log.WithFields(fields).Error("user API request failed")
+	} else if err != nil && strings.TrimSpace(err.Error()) != "" {
 		message = err.Error()
 	}
 	c.JSON(status, gin.H{"error": code, "message": message})
+}
+
+func respondPasswordHashError(c *gin.Context, err error) {
+	if errors.Is(err, errPasswordTooLong) {
+		respondError(c, http.StatusBadRequest, "invalid_password", err)
+		return
+	}
+	respondError(c, http.StatusInternalServerError, "password_hash_failed", err)
 }
 
 func respondOK(c *gin.Context) {

--- a/internal/userapi/session.go
+++ b/internal/userapi/session.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -20,10 +21,13 @@ import (
 const (
 	defaultSessionTTL = 24 * time.Hour
 	randomTokenBytes  = 32
+	maxPasswordBytes  = 72
 	userJWTAlgorithm  = "RS256"
 	userJWTType       = "JWT"
 	userJWTClaimType  = "user"
 )
+
+var errPasswordTooLong = errors.New("password exceeds the 72-byte bcrypt limit")
 
 type userJWTHeader struct {
 	Algorithm string `json:"alg"`
@@ -31,14 +35,15 @@ type userJWTHeader struct {
 }
 
 type userJWTClaims struct {
-	Subject   string `json:"sub,omitempty"`
-	UserID    uint   `json:"user_id"`
-	IssuedAt  int64  `json:"iat"`
-	ExpiresAt int64  `json:"exp"`
-	TokenType string `json:"typ"`
+	Subject        string `json:"sub,omitempty"`
+	UserID         uint   `json:"user_id"`
+	SessionVersion uint64 `json:"session_version,omitempty"`
+	IssuedAt       int64  `json:"iat"`
+	ExpiresAt      int64  `json:"exp"`
+	TokenType      string `json:"typ"`
 }
 
-func (h *Handler) createBearerToken(ctx context.Context, userID uint, ttl time.Duration) (string, time.Time, error) {
+func (h *Handler) createBearerToken(ctx context.Context, userID uint, sessionVersion uint64, ttl time.Duration) (string, time.Time, error) {
 	if userID == 0 {
 		return "", time.Time{}, fmt.Errorf("user id is required")
 	}
@@ -52,11 +57,12 @@ func (h *Handler) createBearerToken(ctx context.Context, userID uint, ttl time.D
 	now := time.Now().UTC()
 	expiresAt := now.Add(ttl)
 	claims := userJWTClaims{
-		Subject:   strconv.FormatUint(uint64(userID), 10),
-		UserID:    userID,
-		IssuedAt:  now.Unix(),
-		ExpiresAt: expiresAt.Unix(),
-		TokenType: userJWTClaimType,
+		Subject:        strconv.FormatUint(uint64(userID), 10),
+		UserID:         userID,
+		SessionVersion: sessionVersion,
+		IssuedAt:       now.Unix(),
+		ExpiresAt:      expiresAt.Unix(),
+		TokenType:      userJWTClaimType,
 	}
 	token, errToken := signUserJWT(key, claims)
 	if errToken != nil {
@@ -65,10 +71,10 @@ func (h *Handler) createBearerToken(ctx context.Context, userID uint, ttl time.D
 	return token, expiresAt, nil
 }
 
-func (h *Handler) bearerTokenUserID(ctx context.Context, token string) (uint, error) {
+func (h *Handler) bearerTokenClaims(ctx context.Context, token string) (userJWTClaims, error) {
 	key, errKey := h.userJWTPublicKey(ctx)
 	if errKey != nil {
-		return 0, errKey
+		return userJWTClaims{}, errKey
 	}
 	return verifyUserJWT(key, token)
 }
@@ -127,67 +133,68 @@ func signUserJWT(key *rsa.PrivateKey, claims userJWTClaims) (string, error) {
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
 }
 
-func verifyUserJWT(key *rsa.PublicKey, token string) (uint, error) {
+func verifyUserJWT(key *rsa.PublicKey, token string) (userJWTClaims, error) {
 	if key == nil {
-		return 0, fmt.Errorf("jwt public key is required")
+		return userJWTClaims{}, fmt.Errorf("jwt public key is required")
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return 0, fmt.Errorf("jwt token is required")
+		return userJWTClaims{}, fmt.Errorf("jwt token is required")
 	}
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return 0, fmt.Errorf("invalid jwt token")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt token")
 	}
 	headerData, errHeader := base64.RawURLEncoding.DecodeString(parts[0])
 	if errHeader != nil {
-		return 0, fmt.Errorf("invalid jwt header")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt header")
 	}
 	var header userJWTHeader
 	if errUnmarshalHeader := json.Unmarshal(headerData, &header); errUnmarshalHeader != nil {
-		return 0, fmt.Errorf("invalid jwt header")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt header")
 	}
 	if header.Algorithm != userJWTAlgorithm || header.Type != userJWTType {
-		return 0, fmt.Errorf("invalid jwt header")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt header")
 	}
 	signature, errDecodeSignature := base64.RawURLEncoding.DecodeString(parts[2])
 	if errDecodeSignature != nil {
-		return 0, fmt.Errorf("invalid jwt signature")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt signature")
 	}
 	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
 	if errVerifySignature := rsa.VerifyPKCS1v15(key, crypto.SHA256, sum[:], signature); errVerifySignature != nil {
-		return 0, fmt.Errorf("invalid jwt signature")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt signature")
 	}
 	claimsData, errClaims := base64.RawURLEncoding.DecodeString(parts[1])
 	if errClaims != nil {
-		return 0, fmt.Errorf("invalid jwt claims")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt claims")
 	}
 	var claims userJWTClaims
 	if errUnmarshalClaims := json.Unmarshal(claimsData, &claims); errUnmarshalClaims != nil {
-		return 0, fmt.Errorf("invalid jwt claims")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt claims")
 	}
 	if claims.TokenType != userJWTClaimType {
-		return 0, fmt.Errorf("invalid jwt claims")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt claims")
 	}
 	now := time.Now().UTC()
 	if claims.ExpiresAt <= 0 || !time.Unix(claims.ExpiresAt, 0).After(now) {
-		return 0, fmt.Errorf("jwt token is expired")
+		return userJWTClaims{}, fmt.Errorf("jwt token is expired")
 	}
 	if claims.IssuedAt > now.Add(time.Minute).Unix() {
-		return 0, fmt.Errorf("invalid jwt claims")
+		return userJWTClaims{}, fmt.Errorf("invalid jwt claims")
 	}
 	userID := claims.UserID
 	if userID == 0 && strings.TrimSpace(claims.Subject) != "" {
 		parsed, errParse := strconv.ParseUint(strings.TrimSpace(claims.Subject), 10, 64)
 		if errParse != nil {
-			return 0, fmt.Errorf("invalid jwt subject")
+			return userJWTClaims{}, fmt.Errorf("invalid jwt subject")
 		}
 		userID = uint(parsed)
 	}
 	if userID == 0 {
-		return 0, fmt.Errorf("user id is required")
+		return userJWTClaims{}, fmt.Errorf("user id is required")
 	}
-	return userID, nil
+	claims.UserID = userID
+	return claims, nil
 }
 
 func randomToken(size int) (string, error) {
@@ -204,6 +211,9 @@ func randomToken(size int) (string, error) {
 func hashPassword(password string) (string, error) {
 	if password == "" {
 		return "", fmt.Errorf("password is required")
+	}
+	if len([]byte(password)) > maxPasswordBytes {
+		return "", errPasswordTooLong
 	}
 	hashed, errHash := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if errHash != nil {

--- a/internal/usermail/config.go
+++ b/internal/usermail/config.go
@@ -1,0 +1,147 @@
+package usermail
+
+import (
+	"fmt"
+	"net"
+	"net/mail"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+)
+
+type ResolvedConfig struct {
+	PublicUserURL   *url.URL
+	FromAddress     string
+	FromName        string
+	SMTP            SMTPConfig
+	VerificationTTL time.Duration
+	ResetTTL        time.Duration
+}
+
+type SMTPConfig struct {
+	Host     string
+	Port     int
+	Username string
+	Password string
+	StartTLS bool
+	Timeout  time.Duration
+}
+
+// ResolveConfig validates the current runtime mail configuration.
+func ResolveConfig(cfg *appconfig.Config) (ResolvedConfig, error) {
+	if cfg == nil || !cfg.UserEmail.Enabled {
+		return ResolvedConfig{}, fmt.Errorf("user email is disabled")
+	}
+	current := cfg.UserEmail
+	publicURL, errURL := url.Parse(strings.TrimSpace(current.PublicUserURL))
+	if errURL != nil || publicURL == nil || publicURL.IsAbs() == false || publicURL.Host == "" {
+		return ResolvedConfig{}, fmt.Errorf("public user url must be absolute")
+	}
+	if publicURL.Scheme != "https" && !(publicURL.Scheme == "http" && isLoopbackHost(publicURL.Hostname())) {
+		return ResolvedConfig{}, fmt.Errorf("public user url must use https")
+	}
+	if publicURL.User != nil {
+		return ResolvedConfig{}, fmt.Errorf("public user url must not contain user information")
+	}
+	publicURL.RawQuery = ""
+	publicURL.Fragment = ""
+
+	fromAddress := strings.TrimSpace(current.FromAddress)
+	parsedFrom, errFrom := mail.ParseAddress(fromAddress)
+	if errFrom != nil || parsedFrom == nil || parsedFrom.Name != "" || !strings.EqualFold(parsedFrom.Address, fromAddress) {
+		return ResolvedConfig{}, fmt.Errorf("from address is invalid")
+	}
+	fromName := strings.TrimSpace(current.FromName)
+	if !validMailDisplayName(fromName) {
+		return ResolvedConfig{}, fmt.Errorf("from name is invalid")
+	}
+	if strings.ToLower(strings.TrimSpace(current.Sender.Type)) != "smtp" {
+		return ResolvedConfig{}, fmt.Errorf("smtp sender is required")
+	}
+	host := strings.TrimSpace(current.Sender.SMTP.Host)
+	if host == "" {
+		return ResolvedConfig{}, fmt.Errorf("smtp host is required")
+	}
+	port := current.Sender.SMTP.Port
+	if port <= 0 || port > 65535 {
+		return ResolvedConfig{}, fmt.Errorf("smtp port is invalid")
+	}
+	if port == 465 {
+		return ResolvedConfig{}, fmt.Errorf("smtp implicit tls on port 465 is not supported")
+	}
+	if !current.Sender.SMTP.StartTLS && !isLoopbackHost(host) {
+		return ResolvedConfig{}, fmt.Errorf("smtp starttls is required for non-loopback hosts")
+	}
+	password := ""
+	passwordEnv := strings.TrimSpace(current.Sender.SMTP.PasswordEnv)
+	if passwordEnv != "" {
+		password = os.Getenv(passwordEnv)
+	}
+	username := strings.TrimSpace(current.Sender.SMTP.Username)
+	if username != "" && passwordEnv == "" {
+		return ResolvedConfig{}, fmt.Errorf("smtp password environment variable is required")
+	}
+	if username != "" && password == "" {
+		return ResolvedConfig{}, fmt.Errorf("smtp password environment variable is empty")
+	}
+	verificationTTL, errVerificationTTL := time.ParseDuration(strings.TrimSpace(current.VerificationTokenTTL))
+	if errVerificationTTL != nil || verificationTTL <= 0 {
+		return ResolvedConfig{}, fmt.Errorf("verification token ttl is invalid")
+	}
+	resetTTL, errResetTTL := time.ParseDuration(strings.TrimSpace(current.ResetTokenTTL))
+	if errResetTTL != nil || resetTTL <= 0 {
+		return ResolvedConfig{}, fmt.Errorf("reset token ttl is invalid")
+	}
+
+	return ResolvedConfig{
+		PublicUserURL:   publicURL,
+		FromAddress:     fromAddress,
+		FromName:        fromName,
+		VerificationTTL: verificationTTL,
+		ResetTTL:        resetTTL,
+		SMTP: SMTPConfig{
+			Host:     host,
+			Port:     port,
+			Username: username,
+			Password: password,
+			StartTLS: current.Sender.SMTP.StartTLS,
+			Timeout:  20 * time.Second,
+		},
+	}, nil
+}
+
+func validMailDisplayName(value string) bool {
+	if len([]rune(value)) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return false
+		}
+	}
+	return true
+}
+
+// Enabled reports whether all required mail settings are currently usable.
+func Enabled(cfg *appconfig.Config) bool {
+	_, errResolve := ResolveConfig(cfg)
+	return errResolve == nil
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func smtpAddress(cfg SMTPConfig) string {
+	return net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+}

--- a/internal/usermail/sender.go
+++ b/internal/usermail/sender.go
@@ -1,0 +1,169 @@
+package usermail
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/mail"
+	"net/smtp"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	errSMTPStartTLSUnsupported = errors.New("smtp server does not support STARTTLS")
+	errSMTPAuthUnsupported     = errors.New("smtp server does not support authentication")
+)
+
+type Message struct {
+	To      string
+	Subject string
+	Text    string
+}
+
+type Sender interface {
+	Send(context.Context, Message) error
+}
+
+type SMTPSender struct {
+	config      SMTPConfig
+	fromAddress string
+	fromName    string
+	tlsConfig   *tls.Config
+}
+
+func NewSMTPSender(cfg ResolvedConfig) *SMTPSender {
+	return &SMTPSender{
+		config:      cfg.SMTP,
+		fromAddress: cfg.FromAddress,
+		fromName:    cfg.FromName,
+	}
+}
+
+func (s *SMTPSender) Send(ctx context.Context, message Message) error {
+	if s == nil {
+		return fmt.Errorf("smtp sender is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	to, errTo := mail.ParseAddress(strings.TrimSpace(message.To))
+	if errTo != nil || to == nil || to.Name != "" {
+		return fmt.Errorf("recipient address is invalid")
+	}
+	if containsHeaderBreak(message.Subject) {
+		return fmt.Errorf("subject is invalid")
+	}
+	timeout := s.config.Timeout
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	dialer := net.Dialer{Timeout: timeout}
+	conn, errDial := dialer.DialContext(ctx, "tcp", smtpAddress(s.config))
+	if errDial != nil {
+		return errDial
+	}
+	defer func() { _ = conn.Close() }()
+	stopCancellation := context.AfterFunc(ctx, func() {
+		_ = conn.SetDeadline(time.Now())
+	})
+	defer stopCancellation()
+	deadline := time.Now().Add(timeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	_ = conn.SetDeadline(deadline)
+
+	client, errClient := smtp.NewClient(conn, s.config.Host)
+	if errClient != nil {
+		return errClient
+	}
+	defer func() { _ = client.Close() }()
+	if s.config.StartTLS {
+		if ok, _ := client.Extension("STARTTLS"); !ok {
+			return errSMTPStartTLSUnsupported
+		}
+		tlsConfig := &tls.Config{ServerName: s.config.Host, MinVersion: tls.VersionTLS12}
+		if s.tlsConfig != nil {
+			tlsConfig = s.tlsConfig.Clone()
+			if tlsConfig.ServerName == "" {
+				tlsConfig.ServerName = s.config.Host
+			}
+			if tlsConfig.MinVersion < tls.VersionTLS12 {
+				tlsConfig.MinVersion = tls.VersionTLS12
+			}
+		}
+		if errTLS := client.StartTLS(tlsConfig); errTLS != nil {
+			return errTLS
+		}
+	}
+	if s.config.Username != "" {
+		if ok, _ := client.Extension("AUTH"); !ok {
+			return errSMTPAuthUnsupported
+		}
+		auth := smtp.PlainAuth("", s.config.Username, s.config.Password, s.config.Host)
+		if errAuth := client.Auth(auth); errAuth != nil {
+			return errAuth
+		}
+	}
+	if errMail := client.Mail(s.fromAddress); errMail != nil {
+		return errMail
+	}
+	if errRecipient := client.Rcpt(to.Address); errRecipient != nil {
+		return errRecipient
+	}
+	writer, errData := client.Data()
+	if errData != nil {
+		return errData
+	}
+	if _, errWrite := io.WriteString(writer, s.renderMessage(to.Address, message)); errWrite != nil {
+		_ = writer.Close()
+		return errWrite
+	}
+	if errClose := writer.Close(); errClose != nil {
+		return errClose
+	}
+	if errQuit := client.Quit(); errQuit != nil {
+		log.WithFields(log.Fields{
+			"smtp_host":  s.config.Host,
+			"smtp_port":  s.config.Port,
+			"error_type": fmt.Sprintf("%T", errQuit),
+		}).Debug("smtp message accepted but connection cleanup failed")
+	}
+	return nil
+}
+
+func (s *SMTPSender) renderMessage(to string, message Message) string {
+	from := (&mail.Address{Name: s.fromName, Address: s.fromAddress}).String()
+	subject := mime.QEncoding.Encode("utf-8", strings.TrimSpace(message.Subject))
+	return strings.Join([]string{
+		"From: " + from,
+		"To: " + (&mail.Address{Address: to}).String(),
+		"Subject: " + subject,
+		"Date: " + time.Now().UTC().Format(time.RFC1123Z),
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"Content-Transfer-Encoding: 8bit",
+		"",
+		normalizeSMTPLineEndings(message.Text),
+		"",
+	}, "\r\n")
+}
+
+// normalizeSMTPLineEndings makes the rendered message RFC-compliant before
+// net/smtp applies dot-stuffing and writes the DATA payload.
+func normalizeSMTPLineEndings(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	return strings.ReplaceAll(value, "\n", "\r\n")
+}
+
+func containsHeaderBreak(value string) bool {
+	return strings.ContainsAny(value, "\r\n")
+}

--- a/internal/usermail/sender_test.go
+++ b/internal/usermail/sender_test.go
@@ -1,0 +1,314 @@
+package usermail
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSMTPSenderRenderMessageNormalizesBodyLineEndings(t *testing.T) {
+	sender := &SMTPSender{
+		fromAddress: "no-reply@example.com",
+		fromName:    "CLIProxyAPIHome",
+	}
+	rendered := sender.renderMessage("alice@example.com", Message{
+		Subject: "Line endings",
+		Text:    "first\nsecond\r\nthird\rfourth",
+	})
+	_, body, found := strings.Cut(rendered, "\r\n\r\n")
+	if !found {
+		t.Fatalf("rendered message has no header/body separator: %q", rendered)
+	}
+	if want := "first\r\nsecond\r\nthird\r\nfourth\r\n"; body != want {
+		t.Fatalf("rendered body = %q, want %q", body, want)
+	}
+	for index, current := range []byte(rendered) {
+		switch current {
+		case '\n':
+			if index == 0 || rendered[index-1] != '\r' {
+				t.Fatalf("rendered message contains bare LF at byte %d: %q", index, rendered)
+			}
+		case '\r':
+			if index+1 >= len(rendered) || rendered[index+1] != '\n' {
+				t.Fatalf("rendered message contains bare CR at byte %d: %q", index, rendered)
+			}
+		}
+	}
+}
+
+func TestSMTPSenderTreatsQuitFailureAfterAcceptedDataAsSuccess(t *testing.T) {
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("listen SMTP test server: %v", errListen)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- serveSMTPAcceptThenDropQuit(listener)
+	}()
+
+	host, portRaw, errSplit := net.SplitHostPort(listener.Addr().String())
+	if errSplit != nil {
+		t.Fatalf("split SMTP test address: %v", errSplit)
+	}
+	port, errPort := strconv.Atoi(portRaw)
+	if errPort != nil {
+		t.Fatalf("parse SMTP test port: %v", errPort)
+	}
+	sender := &SMTPSender{
+		config: SMTPConfig{
+			Host:    host,
+			Port:    port,
+			Timeout: time.Second,
+		},
+		fromAddress: "no-reply@example.com",
+		fromName:    "CLIProxyAPIHome",
+	}
+	if errSend := sender.Send(nil, Message{
+		To:      "alice@example.com",
+		Subject: "Accepted message",
+		Text:    "hello",
+	}); errSend != nil {
+		t.Fatalf("Send() error after accepted DATA = %v", errSend)
+	}
+	select {
+	case errServer := <-serverDone:
+		if errServer != nil {
+			t.Fatalf("SMTP test server: %v", errServer)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SMTP test server did not finish")
+	}
+}
+
+func TestSMTPSenderDeliversThroughSTARTTLS(t *testing.T) {
+	certificate, roots := newSMTPTestCertificate(t)
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("listen SMTP test server: %v", errListen)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- serveSMTPSTARTTLS(listener, certificate)
+	}()
+
+	host, portRaw, errSplit := net.SplitHostPort(listener.Addr().String())
+	if errSplit != nil {
+		t.Fatalf("split SMTP test address: %v", errSplit)
+	}
+	port, errPort := strconv.Atoi(portRaw)
+	if errPort != nil {
+		t.Fatalf("parse SMTP test port: %v", errPort)
+	}
+	sender := &SMTPSender{
+		config: SMTPConfig{
+			Host:     host,
+			Port:     port,
+			StartTLS: true,
+			Timeout:  2 * time.Second,
+		},
+		fromAddress: "no-reply@example.com",
+		fromName:    "CLIProxyAPIHome",
+		tlsConfig: &tls.Config{
+			RootCAs:    roots,
+			ServerName: host,
+		},
+	}
+	if errSend := sender.Send(context.Background(), Message{
+		To:      "alice@example.com",
+		Subject: "STARTTLS message",
+		Text:    "hello over TLS",
+	}); errSend != nil {
+		t.Fatalf("Send(STARTTLS) error = %v", errSend)
+	}
+	select {
+	case errServer := <-serverDone:
+		if errServer != nil {
+			t.Fatalf("STARTTLS test server: %v", errServer)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("STARTTLS test server did not finish")
+	}
+}
+
+func serveSMTPAcceptThenDropQuit(listener net.Listener) error {
+	conn, errAccept := listener.Accept()
+	if errAccept != nil {
+		return errAccept
+	}
+	defer func() { _ = conn.Close() }()
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	writeResponse := func(response string) error {
+		if _, errWrite := writer.WriteString(response); errWrite != nil {
+			return errWrite
+		}
+		return writer.Flush()
+	}
+	if errWrite := writeResponse("220 localhost ESMTP ready\r\n"); errWrite != nil {
+		return errWrite
+	}
+	for {
+		line, errRead := reader.ReadString('\n')
+		if errRead != nil {
+			return errRead
+		}
+		command := strings.ToUpper(strings.TrimSpace(line))
+		switch {
+		case strings.HasPrefix(command, "EHLO"):
+			if errWrite := writeResponse("250-localhost\r\n250 OK\r\n"); errWrite != nil {
+				return errWrite
+			}
+		case strings.HasPrefix(command, "HELO"), strings.HasPrefix(command, "MAIL FROM:"), strings.HasPrefix(command, "RCPT TO:"):
+			if errWrite := writeResponse("250 OK\r\n"); errWrite != nil {
+				return errWrite
+			}
+		case command == "DATA":
+			if errWrite := writeResponse("354 End data with <CR><LF>.<CR><LF>\r\n"); errWrite != nil {
+				return errWrite
+			}
+			for {
+				dataLine, errData := reader.ReadString('\n')
+				if errData != nil {
+					return errData
+				}
+				if dataLine == ".\r\n" {
+					break
+				}
+			}
+			if errWrite := writeResponse("250 queued\r\n"); errWrite != nil {
+				return errWrite
+			}
+		case command == "QUIT":
+			return conn.Close()
+		default:
+			return fmt.Errorf("unexpected SMTP command %q", command)
+		}
+	}
+}
+
+func serveSMTPSTARTTLS(listener net.Listener, certificate tls.Certificate) error {
+	conn, errAccept := listener.Accept()
+	if errAccept != nil {
+		return errAccept
+	}
+	defer func() { _ = conn.Close() }()
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+	writeResponse := func(response string) error {
+		if _, errWrite := writer.WriteString(response); errWrite != nil {
+			return errWrite
+		}
+		return writer.Flush()
+	}
+	if errWrite := writeResponse("220 localhost ESMTP ready\r\n"); errWrite != nil {
+		return errWrite
+	}
+	line, errRead := reader.ReadString('\n')
+	if errRead != nil || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(line)), "EHLO") {
+		return fmt.Errorf("initial EHLO = %q, %v", strings.TrimSpace(line), errRead)
+	}
+	if errWrite := writeResponse("250-localhost\r\n250-STARTTLS\r\n250 OK\r\n"); errWrite != nil {
+		return errWrite
+	}
+	line, errRead = reader.ReadString('\n')
+	if errRead != nil || strings.ToUpper(strings.TrimSpace(line)) != "STARTTLS" {
+		return fmt.Errorf("STARTTLS command = %q, %v", strings.TrimSpace(line), errRead)
+	}
+	if errWrite := writeResponse("220 Ready to start TLS\r\n"); errWrite != nil {
+		return errWrite
+	}
+	tlsConn := tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if errHandshake := tlsConn.Handshake(); errHandshake != nil {
+		return errHandshake
+	}
+	conn = tlsConn
+	reader = bufio.NewReader(conn)
+	writer = bufio.NewWriter(conn)
+	line, errRead = reader.ReadString('\n')
+	if errRead != nil || !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(line)), "EHLO") {
+		return fmt.Errorf("TLS EHLO = %q, %v", strings.TrimSpace(line), errRead)
+	}
+	if errWrite := writeResponse("250 localhost\r\n"); errWrite != nil {
+		return errWrite
+	}
+	for {
+		line, errRead = reader.ReadString('\n')
+		if errRead != nil {
+			return errRead
+		}
+		command := strings.ToUpper(strings.TrimSpace(line))
+		switch {
+		case strings.HasPrefix(command, "MAIL FROM:"), strings.HasPrefix(command, "RCPT TO:"):
+			if errWrite := writeResponse("250 OK\r\n"); errWrite != nil {
+				return errWrite
+			}
+		case command == "DATA":
+			if errWrite := writeResponse("354 End data with <CR><LF>.<CR><LF>\r\n"); errWrite != nil {
+				return errWrite
+			}
+			for {
+				dataLine, errData := reader.ReadString('\n')
+				if errData != nil {
+					return errData
+				}
+				if dataLine == ".\r\n" {
+					break
+				}
+			}
+			if errWrite := writeResponse("250 queued\r\n"); errWrite != nil {
+				return errWrite
+			}
+		case command == "QUIT":
+			return writeResponse("221 bye\r\n")
+		default:
+			return fmt.Errorf("unexpected TLS SMTP command %q", command)
+		}
+	}
+}
+
+func newSMTPTestCertificate(t *testing.T) (tls.Certificate, *x509.CertPool) {
+	t.Helper()
+	privateKey, errKey := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if errKey != nil {
+		t.Fatalf("generate SMTP test key: %v", errKey)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IsCA:         true,
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, errCertificate := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	if errCertificate != nil {
+		t.Fatalf("create SMTP test certificate: %v", errCertificate)
+	}
+	certificate := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: privateKey}
+	roots := x509.NewCertPool()
+	parsed, errParse := x509.ParseCertificate(der)
+	if errParse != nil {
+		t.Fatalf("parse SMTP test certificate: %v", errParse)
+	}
+	roots.AddCert(parsed)
+	return certificate, roots
+}

--- a/internal/usermail/service.go
+++ b/internal/usermail/service.go
@@ -1,0 +1,405 @@
+package usermail
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/textproto"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+const (
+	mailWorkerPollInterval = time.Second
+	mailJobLease           = 45 * time.Second
+	mailJobMaxAttempts     = 3
+	mailSecurityRetention  = 7 * 24 * time.Hour
+)
+
+type Service struct {
+	repo           *cluster.Repository
+	configProvider func() *appconfig.Config
+	workerID       string
+	senderFactory  func(ResolvedConfig) Sender
+	configMu       sync.Mutex
+	configState    string
+}
+
+func NewService(repo *cluster.Repository, configProvider func() *appconfig.Config) *Service {
+	return &Service{
+		repo:           repo,
+		configProvider: configProvider,
+		workerID:       newWorkerID(),
+		senderFactory: func(cfg ResolvedConfig) Sender {
+			return NewSMTPSender(cfg)
+		},
+	}
+}
+
+func (s *Service) Start(ctx context.Context) {
+	if s == nil || s.repo == nil || s.configProvider == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go s.run(ctx)
+}
+
+func (s *Service) run(ctx context.Context) {
+	pollTicker := time.NewTicker(mailWorkerPollInterval)
+	cleanupTicker := time.NewTicker(time.Hour)
+	defer pollTicker.Stop()
+	defer cleanupTicker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-pollTicker.C:
+			s.processAvailable(ctx)
+		case now := <-cleanupTicker.C:
+			if errPurge := s.repo.PurgeExpiredUserSecurity(ctx, now.UTC(), mailSecurityRetention); errPurge != nil {
+				log.WithError(errPurge).Warn("user mail security cleanup failed")
+			}
+		}
+	}
+}
+
+func (s *Service) processAvailable(ctx context.Context) {
+	for processed := 0; processed < 4; processed++ {
+		worked, errProcess := s.ProcessOne(ctx)
+		if errProcess != nil {
+			log.WithError(errProcess).Warn("user mail job processing failed")
+			return
+		}
+		if !worked {
+			return
+		}
+	}
+}
+
+// ProcessOne processes at most one queued message and is exported for focused tests.
+func (s *Service) ProcessOne(ctx context.Context) (bool, error) {
+	if s == nil || s.repo == nil || s.configProvider == nil {
+		return false, fmt.Errorf("user mail service is not configured")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	resolved, configured := s.resolveRuntimeConfig()
+	if !configured {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	job, errClaim := s.repo.ClaimUserMailJob(ctx, s.workerID, now, mailJobLease)
+	if errClaim != nil || job == nil {
+		return false, errClaim
+	}
+	user, errUser := s.repo.GetUser(ctx, job.UserID)
+	if errors.Is(errUser, gorm.ErrRecordNotFound) {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	if errUser != nil {
+		return true, s.failJob(ctx, job, "user_load_failed", now)
+	}
+	if user.Email == nil || strings.TrimSpace(*user.Email) == "" || user.EmailVersion != job.EmailVersion {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposePasswordReset && user.EmailVerifiedAt == nil {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposePasswordReset && user.SessionVersion != job.SessionVersion {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposeEmailVerification && user.EmailVerifiedAt != nil {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+
+	ttl, route, message := messageForPurpose(job.Purpose, resolved, user.Username)
+	if ttl <= 0 || route == "" {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	if !job.CreatedAt.IsZero() && !job.CreatedAt.Add(ttl).After(now) {
+		return true, s.supersedeJob(ctx, job.ID, now)
+	}
+	token, errToken := randomMailToken()
+	if errToken != nil {
+		return true, s.failJob(ctx, job, "token_generate_failed", now)
+	}
+	tokenHash := cluster.HashUserSecurityValue(token)
+	message.To = *user.Email
+	if errStore := s.repo.ReplaceUserSecurityTokenForMailJob(ctx, job.ID, s.workerID, cluster.UserSecurityTokenRecord{
+		UserID:       user.ID,
+		Purpose:      job.Purpose,
+		TokenHash:    tokenHash,
+		EmailVersion: user.EmailVersion,
+		ExpiresAt:    now.Add(ttl),
+		CreatedAt:    now,
+	}); errStore != nil {
+		if errors.Is(errStore, cluster.ErrUserMailJobClaimLost) {
+			return true, nil
+		}
+		return true, s.failJob(ctx, job, "token_store_failed", now)
+	}
+	latestUser, errLatestUser := s.repo.GetUser(ctx, job.UserID)
+	if errors.Is(errLatestUser, gorm.ErrRecordNotFound) {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.supersedeJob(ctx, job.ID, time.Now().UTC())
+	}
+	if errLatestUser != nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.failJob(ctx, job, "user_reload_failed", time.Now().UTC())
+	}
+	if latestUser == nil || latestUser.Email == nil || strings.TrimSpace(*latestUser.Email) != message.To || latestUser.EmailVersion != job.EmailVersion {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.supersedeJob(ctx, job.ID, time.Now().UTC())
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposePasswordReset && latestUser.SessionVersion != job.SessionVersion {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.supersedeJob(ctx, job.ID, time.Now().UTC())
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposeEmailVerification && latestUser.EmailVerifiedAt != nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.supersedeJob(ctx, job.ID, time.Now().UTC())
+	}
+	if job.Purpose == cluster.UserSecurityTokenPurposeEmailVerification {
+		owner, errOwner := s.repo.GetUserByEmail(ctx, message.To)
+		if errOwner == nil && owner != nil && owner.ID != job.UserID {
+			_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+			return true, s.supersedeJob(ctx, job.ID, time.Now().UTC())
+		}
+		if errOwner != nil && !errors.Is(errOwner, gorm.ErrRecordNotFound) {
+			_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+			return true, s.failJob(ctx, job, "email_owner_check_failed", time.Now().UTC())
+		}
+	}
+	deliveryLease := resolved.SMTP.Timeout + 10*time.Second
+	if deliveryLease < mailJobLease {
+		deliveryLease = mailJobLease
+	}
+	if errRenew := s.repo.RenewUserMailJobClaim(ctx, job.ID, s.workerID, time.Now().UTC(), deliveryLease); errRenew != nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		if errors.Is(errRenew, cluster.ErrUserMailJobClaimLost) {
+			return true, nil
+		}
+		return true, s.failJob(ctx, job, "job_claim_renew_failed", time.Now().UTC())
+	}
+	message.Text = strings.ReplaceAll(message.Text, "{{LINK}}", buildUserLink(resolved.PublicUserURL, route, token))
+	if s.senderFactory == nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.failJobWithRetry(ctx, job, "sender_unavailable", time.Now().UTC(), false)
+	}
+	sender := s.senderFactory(resolved)
+	if sender == nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		return true, s.failJobWithRetry(ctx, job, "sender_unavailable", time.Now().UTC(), false)
+	}
+	deliveryCtx, cancel := context.WithTimeout(ctx, resolved.SMTP.Timeout)
+	errSend := sender.Send(deliveryCtx, message)
+	cancel()
+	if errSend != nil {
+		_ = s.repo.InvalidateUserSecurityTokenHash(ctx, tokenHash, time.Now().UTC())
+		failure := classifyDeliveryFailure(errSend)
+		fields := log.Fields{
+			"job_id":       job.ID,
+			"user_id":      job.UserID,
+			"purpose":      job.Purpose,
+			"error_code":   failure.code,
+			"retryable":    failure.retryable,
+			"smtp_host":    resolved.SMTP.Host,
+			"smtp_port":    resolved.SMTP.Port,
+			"attempt":      job.Attempts,
+			"max_attempts": mailJobMaxAttempts,
+		}
+		if failure.smtpStatus > 0 {
+			fields["smtp_status"] = failure.smtpStatus
+		}
+		log.WithFields(fields).Warn("user mail delivery failed")
+		return true, s.failJobWithRetry(ctx, job, failure.code, time.Now().UTC(), failure.retryable)
+	}
+	if errComplete := s.repo.CompleteUserMailJob(ctx, job.ID, s.workerID, time.Now().UTC()); errors.Is(errComplete, cluster.ErrUserMailJobClaimLost) {
+		log.WithFields(log.Fields{"job_id": job.ID, "user_id": job.UserID, "purpose": job.Purpose}).Warn("user mail delivered after worker claim was lost")
+		return true, nil
+	} else if errComplete != nil {
+		return true, errComplete
+	}
+	log.WithFields(log.Fields{"job_id": job.ID, "user_id": job.UserID, "purpose": job.Purpose}).Info("user mail job delivered")
+	return true, nil
+}
+
+func (s *Service) resolveRuntimeConfig() (ResolvedConfig, bool) {
+	current := s.configProvider()
+	if current == nil || !current.UserEmail.Enabled {
+		s.reportConfigState("disabled", nil)
+		return ResolvedConfig{}, false
+	}
+	resolved, errResolve := ResolveConfig(current)
+	if errResolve != nil {
+		s.reportConfigState("invalid:"+errResolve.Error(), errResolve)
+		return ResolvedConfig{}, false
+	}
+	s.reportConfigState("ready", nil)
+	return resolved, true
+}
+
+func (s *Service) reportConfigState(state string, err error) {
+	s.configMu.Lock()
+	previous := s.configState
+	if previous == state {
+		s.configMu.Unlock()
+		return
+	}
+	s.configState = state
+	s.configMu.Unlock()
+
+	switch {
+	case strings.HasPrefix(state, "invalid:"):
+		log.WithError(err).Warn("user email capability disabled because configuration is invalid")
+	case state == "ready" && previous != "" && previous != "ready":
+		log.Info("user email capability enabled with valid configuration")
+	case state == "disabled" && previous != "" && previous != "disabled":
+		log.Info("user email capability disabled")
+	}
+}
+
+func (s *Service) failJob(ctx context.Context, job *cluster.UserMailJobRecord, code string, now time.Time) error {
+	return s.failJobWithRetry(ctx, job, code, now, true)
+}
+
+func (s *Service) failJobWithRetry(ctx context.Context, job *cluster.UserMailJobRecord, code string, now time.Time, retryable bool) error {
+	retryAfter := time.Minute << max(job.Attempts-1, 0)
+	if retryAfter > 15*time.Minute {
+		retryAfter = 15 * time.Minute
+	}
+	maxAttempts := mailJobMaxAttempts
+	if !retryable {
+		maxAttempts = job.Attempts
+	}
+	errFail := s.repo.FailUserMailJob(ctx, job, s.workerID, code, now, retryAfter, maxAttempts)
+	if errors.Is(errFail, cluster.ErrUserMailJobClaimLost) {
+		return nil
+	}
+	return errFail
+}
+
+func (s *Service) supersedeJob(ctx context.Context, jobID uint, now time.Time) error {
+	errSupersede := s.repo.SupersedeUserMailJob(ctx, jobID, s.workerID, now)
+	if errors.Is(errSupersede, cluster.ErrUserMailJobClaimLost) {
+		return nil
+	}
+	return errSupersede
+}
+
+type deliveryFailure struct {
+	code       string
+	retryable  bool
+	smtpStatus int
+}
+
+func classifyDeliveryFailure(err error) deliveryFailure {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return deliveryFailure{code: "smtp_timeout", retryable: true}
+	}
+	if errors.Is(err, context.Canceled) {
+		return deliveryFailure{code: "smtp_canceled", retryable: true}
+	}
+	if errors.Is(err, errSMTPStartTLSUnsupported) {
+		return deliveryFailure{code: "smtp_starttls_unsupported", retryable: false}
+	}
+	if errors.Is(err, errSMTPAuthUnsupported) {
+		return deliveryFailure{code: "smtp_auth_unsupported", retryable: false}
+	}
+	var protocolError *textproto.Error
+	if errors.As(err, &protocolError) {
+		failure := deliveryFailure{code: "smtp_rejected", retryable: protocolError.Code < 500, smtpStatus: protocolError.Code}
+		if protocolError.Code >= 400 && protocolError.Code < 500 {
+			failure.code = "smtp_transient_rejection"
+		}
+		if protocolError.Code >= 500 {
+			failure.code = "smtp_permanent_rejection"
+		}
+		return failure
+	}
+	var networkError net.Error
+	if errors.As(err, &networkError) && networkError.Timeout() {
+		return deliveryFailure{code: "smtp_timeout", retryable: true}
+	}
+	return deliveryFailure{code: "smtp_delivery_failed", retryable: true}
+}
+
+func messageForPurpose(purpose string, cfg ResolvedConfig, username string) (time.Duration, string, Message) {
+	username = mailGreetingName(username)
+	switch purpose {
+	case cluster.UserSecurityTokenPurposeEmailVerification:
+		return cfg.VerificationTTL, "/user/verify-email", Message{
+			Subject: "Verify your CLIProxyAPIHome email",
+			Text:    "Hello " + username + ",\n\nConfirm this email address for your CLIProxyAPIHome account:\n\n{{LINK}}\n\nIf you did not request this, you can ignore this message.",
+		}
+	case cluster.UserSecurityTokenPurposePasswordReset:
+		return cfg.ResetTTL, "/user/reset-password", Message{
+			Subject: "Reset your CLIProxyAPIHome password",
+			Text:    "Hello " + username + ",\n\nUse this link to set a new password for your CLIProxyAPIHome account:\n\n{{LINK}}\n\nThis link is single-use and expires soon. TOTP and Passkey protections remain enabled.",
+		}
+	default:
+		return 0, "", Message{}
+	}
+}
+
+func mailGreetingName(username string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			return ' '
+		}
+		return r
+	}, username)
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	if cleaned == "" {
+		return "there"
+	}
+	runes := []rune(cleaned)
+	if len(runes) > 80 {
+		cleaned = strings.TrimSpace(string(runes[:80]))
+	}
+	return cleaned
+}
+
+func buildUserLink(base *url.URL, route string, token string) string {
+	if base == nil {
+		return ""
+	}
+	next := *base
+	next.RawQuery = ""
+	next.Fragment = route + "?token=" + url.QueryEscape(token)
+	return next.String()
+}
+
+func randomMailToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, errRead := rand.Read(buf); errRead != nil {
+		return "", errRead
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func newWorkerID() string {
+	host, _ := os.Hostname()
+	suffix, errToken := randomMailToken()
+	if errToken != nil || len(suffix) < 8 {
+		suffix = fmt.Sprintf("%d", time.Now().UnixNano())
+	} else {
+		suffix = suffix[:8]
+	}
+	return fmt.Sprintf("%s-%d-%s", strings.TrimSpace(host), os.Getpid(), suffix)
+}

--- a/internal/usermail/service_test.go
+++ b/internal/usermail/service_test.go
@@ -1,0 +1,359 @@
+package usermail
+
+import (
+	"context"
+	"errors"
+	"net/textproto"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"gorm.io/gorm"
+)
+
+type recordingSender struct {
+	messages []Message
+	err      error
+}
+
+func (s *recordingSender) Send(_ context.Context, message Message) error {
+	s.messages = append(s.messages, message)
+	return s.err
+}
+
+func TestResolveConfigValidation(t *testing.T) {
+	cfg := userMailTestConfig()
+	resolved, errResolve := ResolveConfig(cfg)
+	if errResolve != nil {
+		t.Fatalf("ResolveConfig(valid) error = %v", errResolve)
+	}
+	if resolved.PublicUserURL.String() != "http://127.0.0.1/user.html" || resolved.VerificationTTL != 24*time.Hour || resolved.ResetTTL != 30*time.Minute {
+		t.Fatalf("resolved config = %#v", resolved)
+	}
+	if !Enabled(cfg) {
+		t.Fatal("Enabled(valid) = false")
+	}
+
+	invalid := userMailTestConfig()
+	invalid.UserEmail.PublicUserURL = "http://example.com/user.html"
+	if _, errInvalid := ResolveConfig(invalid); errInvalid == nil {
+		t.Fatal("ResolveConfig(insecure remote URL) succeeded")
+	}
+	invalid = userMailTestConfig()
+	invalid.UserEmail.Sender.SMTP.Host = "smtp.example.com"
+	invalid.UserEmail.Sender.SMTP.StartTLS = false
+	if _, errInvalid := ResolveConfig(invalid); errInvalid == nil {
+		t.Fatal("ResolveConfig(insecure remote SMTP) succeeded")
+	}
+	invalid = userMailTestConfig()
+	invalid.UserEmail.Sender.SMTP.Port = 465
+	if _, errInvalid := ResolveConfig(invalid); errInvalid == nil {
+		t.Fatal("ResolveConfig(implicit TLS port) succeeded")
+	}
+	invalid = userMailTestConfig()
+	invalid.UserEmail.FromName = "CLIProxyAPIHome\r\nBcc: victim@example.com"
+	if _, errInvalid := ResolveConfig(invalid); errInvalid == nil {
+		t.Fatal("ResolveConfig(injected from name) succeeded")
+	}
+	invalid = userMailTestConfig()
+	invalid.UserEmail.Sender.SMTP.Username = "smtp-user"
+	invalid.UserEmail.Sender.SMTP.PasswordEnv = "MISSING_USER_EMAIL_SMTP_PASSWORD"
+	if _, errInvalid := ResolveConfig(invalid); errInvalid == nil {
+		t.Fatal("ResolveConfig(empty password environment) succeeded")
+	}
+}
+
+func TestServiceProcessOneStoresOnlyTokenHashAndBuildsFragmentLink(t *testing.T) {
+	repo, db := newUserMailTestRepository(t)
+	cfg := userMailTestConfig()
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	if _, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, cluster.UserSecurityTokenPurposeEmailVerification, user.EmailVersion, time.Now().UTC()); errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	sender := &recordingSender{}
+	service := NewService(repo, func() *appconfig.Config { return cfg })
+	service.senderFactory = func(ResolvedConfig) Sender { return sender }
+	worked, errProcess := service.ProcessOne(ctx)
+	if errProcess != nil || !worked {
+		t.Fatalf("ProcessOne() = %v, %v", worked, errProcess)
+	}
+	if len(sender.messages) != 1 {
+		t.Fatalf("sent messages = %d, want 1", len(sender.messages))
+	}
+	message := sender.messages[0]
+	if message.To != email || strings.Contains(message.Subject, email) {
+		t.Fatalf("message metadata = %#v", message)
+	}
+	link := firstHTTPLink(message.Text)
+	parsed, errParse := url.Parse(link)
+	if errParse != nil {
+		t.Fatalf("parse mail link %q: %v", link, errParse)
+	}
+	fragment, errFragment := url.Parse(parsed.Fragment)
+	if errFragment != nil {
+		t.Fatalf("parse fragment %q: %v", parsed.Fragment, errFragment)
+	}
+	if fragment.Path != "/user/verify-email" {
+		t.Fatalf("fragment path = %q", fragment.Path)
+	}
+	rawToken := fragment.Query().Get("token")
+	if rawToken == "" {
+		t.Fatal("verification link token is empty")
+	}
+	var stored cluster.UserSecurityTokenRecord
+	if errLoad := db.Where("user_id = ? AND purpose = ?", user.ID, cluster.UserSecurityTokenPurposeEmailVerification).Order("id DESC").First(&stored).Error; errLoad != nil {
+		t.Fatalf("load stored token: %v", errLoad)
+	}
+	if stored.TokenHash == rawToken || stored.TokenHash != cluster.HashUserSecurityValue(rawToken) {
+		t.Fatalf("stored token hash = %q, raw token leaked or hash mismatch", stored.TokenHash)
+	}
+	var job cluster.UserMailJobRecord
+	if errLoad := db.Where("user_id = ?", user.ID).First(&job).Error; errLoad != nil {
+		t.Fatalf("load mail job: %v", errLoad)
+	}
+	if job.Status != cluster.UserMailJobStatusSent || job.ClaimedBy != "" {
+		t.Fatalf("mail job = %#v", job)
+	}
+}
+
+func TestServiceSupersedesExpiredQueuedRequest(t *testing.T) {
+	repo, db := newUserMailTestRepository(t)
+	cfg := userMailTestConfig()
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	verifiedAt := time.Now().UTC()
+	if errUpdate := db.Model(&cluster.UserRecord{}).Where("id = ?", user.ID).Update("email_verified_at", verifiedAt).Error; errUpdate != nil {
+		t.Fatalf("mark email verified: %v", errUpdate)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, cluster.UserSecurityTokenPurposePasswordReset, user.EmailVersion, time.Now().UTC())
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	if errUpdate := db.Model(&cluster.UserMailJobRecord{}).Where("id = ?", job.ID).Update("created_at", time.Now().UTC().Add(-time.Hour)).Error; errUpdate != nil {
+		t.Fatalf("age mail job: %v", errUpdate)
+	}
+	sender := &recordingSender{}
+	service := NewService(repo, func() *appconfig.Config { return cfg })
+	service.senderFactory = func(ResolvedConfig) Sender { return sender }
+	worked, errProcess := service.ProcessOne(ctx)
+	if errProcess != nil || !worked {
+		t.Fatalf("ProcessOne() = %v, %v", worked, errProcess)
+	}
+	if len(sender.messages) != 0 {
+		t.Fatalf("sent stale messages = %d", len(sender.messages))
+	}
+	if errLoad := db.Where("id = ?", job.ID).First(job).Error; errLoad != nil {
+		t.Fatalf("reload mail job: %v", errLoad)
+	}
+	if job.Status != cluster.UserMailJobStatusSuperseded {
+		t.Fatalf("stale mail job status = %q", job.Status)
+	}
+}
+
+func TestServiceFailureInvalidatesTokenAndSchedulesBoundedRetry(t *testing.T) {
+	repo, db := newUserMailTestRepository(t)
+	cfg := userMailTestConfig()
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, cluster.UserSecurityTokenPurposeEmailVerification, user.EmailVersion, time.Now().UTC())
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	sender := &recordingSender{err: errors.New("recipient@example.com rejected")}
+	service := NewService(repo, func() *appconfig.Config { return cfg })
+	service.senderFactory = func(ResolvedConfig) Sender { return sender }
+	for attempt := 1; attempt <= mailJobMaxAttempts; attempt++ {
+		worked, errProcess := service.ProcessOne(ctx)
+		if errProcess != nil || !worked {
+			t.Fatalf("ProcessOne(attempt %d) = %v, %v", attempt, worked, errProcess)
+		}
+		if errLoad := db.Where("id = ?", job.ID).First(job).Error; errLoad != nil {
+			t.Fatalf("reload mail job: %v", errLoad)
+		}
+		if attempt < mailJobMaxAttempts {
+			if job.Status != cluster.UserMailJobStatusPending {
+				t.Fatalf("attempt %d status = %q", attempt, job.Status)
+			}
+			if errReady := db.Model(&cluster.UserMailJobRecord{}).Where("id = ?", job.ID).Update("next_attempt_at", time.Now().UTC().Add(-time.Second)).Error; errReady != nil {
+				t.Fatalf("make retry ready: %v", errReady)
+			}
+		}
+	}
+	if job.Status != cluster.UserMailJobStatusFailed || job.Attempts != mailJobMaxAttempts || job.LastErrorCode != "smtp_delivery_failed" {
+		t.Fatalf("failed mail job = %#v", job)
+	}
+	var activeTokens int64
+	if errCount := db.Model(&cluster.UserSecurityTokenRecord{}).Where("user_id = ? AND used_at IS NULL", user.ID).Count(&activeTokens).Error; errCount != nil {
+		t.Fatalf("count active tokens: %v", errCount)
+	}
+	if activeTokens != 0 {
+		t.Fatalf("active tokens after failed delivery = %d", activeTokens)
+	}
+}
+
+func TestServiceDoesNotRetryPermanentSMTPRejection(t *testing.T) {
+	repo, db := newUserMailTestRepository(t)
+	cfg := userMailTestConfig()
+	ctx := context.Background()
+	username := "alice"
+	email := "alice@example.com"
+	user, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &username, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser() error = %v", errCreate)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, user.ID, cluster.UserSecurityTokenPurposeEmailVerification, user.EmailVersion, time.Now().UTC())
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	sender := &recordingSender{err: &textproto.Error{Code: 550, Msg: "mailbox unavailable"}}
+	service := NewService(repo, func() *appconfig.Config { return cfg })
+	service.senderFactory = func(ResolvedConfig) Sender { return sender }
+	worked, errProcess := service.ProcessOne(ctx)
+	if errProcess != nil || !worked {
+		t.Fatalf("ProcessOne() = %v, %v", worked, errProcess)
+	}
+	if errLoad := db.Where("id = ?", job.ID).First(job).Error; errLoad != nil {
+		t.Fatalf("reload mail job: %v", errLoad)
+	}
+	if job.Status != cluster.UserMailJobStatusFailed || job.Attempts != 1 || job.LastErrorCode != "smtp_permanent_rejection" {
+		t.Fatalf("permanently rejected mail job = %#v", job)
+	}
+}
+
+func TestServiceSuppressesVerificationForAddressOwnedByAnotherUser(t *testing.T) {
+	repo, db := newUserMailTestRepository(t)
+	cfg := userMailTestConfig()
+	ctx := context.Background()
+	email := "shared@example.com"
+	ownerName := "owner"
+	owner, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &ownerName, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(owner) error = %v", errCreate)
+	}
+	claimantName := "claimant"
+	claimant, errCreate := repo.CreateUser(ctx, cluster.UserUpdate{Username: &claimantName, Email: &email})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(claimant) error = %v", errCreate)
+	}
+	verifiedAt := time.Now().UTC()
+	if errVerify := db.Model(&cluster.UserRecord{}).Where("id = ?", owner.ID).Update("email_verified_at", verifiedAt).Error; errVerify != nil {
+		t.Fatalf("mark owner email verified: %v", errVerify)
+	}
+	job, errEnqueue := repo.EnqueueUserMailJob(ctx, claimant.ID, cluster.UserSecurityTokenPurposeEmailVerification, claimant.EmailVersion, verifiedAt)
+	if errEnqueue != nil {
+		t.Fatalf("EnqueueUserMailJob() error = %v", errEnqueue)
+	}
+	sender := &recordingSender{}
+	service := NewService(repo, func() *appconfig.Config { return cfg })
+	service.senderFactory = func(ResolvedConfig) Sender { return sender }
+	worked, errProcess := service.ProcessOne(ctx)
+	if errProcess != nil || !worked {
+		t.Fatalf("ProcessOne() = %v, %v", worked, errProcess)
+	}
+	if len(sender.messages) != 0 {
+		t.Fatalf("messages sent to owned address = %d, want 0", len(sender.messages))
+	}
+	if errLoad := db.Where("id = ?", job.ID).First(job).Error; errLoad != nil {
+		t.Fatalf("reload mail job: %v", errLoad)
+	}
+	if job.Status != cluster.UserMailJobStatusSuperseded {
+		t.Fatalf("mail job status = %q, want superseded", job.Status)
+	}
+}
+
+func TestClassifyDeliveryFailureTreatsUnsupportedSecurityAsPermanent(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code string
+	}{
+		{name: "starttls", err: errSMTPStartTLSUnsupported, code: "smtp_starttls_unsupported"},
+		{name: "auth", err: errSMTPAuthUnsupported, code: "smtp_auth_unsupported"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			failure := classifyDeliveryFailure(test.err)
+			if failure.retryable || failure.code != test.code {
+				t.Fatalf("delivery failure = %#v, want permanent %q", failure, test.code)
+			}
+		})
+	}
+}
+
+func TestMessageForPurposeSanitizesUsername(t *testing.T) {
+	_, _, message := messageForPurpose(cluster.UserSecurityTokenPurposeEmailVerification, ResolvedConfig{VerificationTTL: time.Hour}, "Alice\r\nIgnore\u202ethe link above")
+	if strings.Contains(message.Text, "Alice\r\n") {
+		t.Fatalf("mail greeting contains injected line break: %q", message.Text)
+	}
+	if strings.ContainsRune(message.Text, '\u202e') {
+		t.Fatalf("mail greeting contains bidi override: %q", message.Text)
+	}
+	if !strings.HasPrefix(message.Text, "Hello Alice Ignore the link above,") {
+		t.Fatalf("sanitized mail greeting = %q", message.Text)
+	}
+}
+
+func userMailTestConfig() *appconfig.Config {
+	cfg := &appconfig.Config{
+		UserEmail: appconfig.UserEmailConfig{
+			Enabled:              true,
+			PublicUserURL:        "http://127.0.0.1/user.html",
+			FromAddress:          "no-reply@example.com",
+			FromName:             "CLIProxyAPIHome",
+			VerificationTokenTTL: "24h",
+			ResetTokenTTL:        "30m",
+			Sender: appconfig.UserEmailSenderConfig{
+				Type: "smtp",
+				SMTP: appconfig.UserEmailSMTPConfig{Host: "127.0.0.1", Port: 2525},
+			},
+		},
+	}
+	cfg.NormalizeUserEmailConfig()
+	return cfg
+}
+
+func newUserMailTestRepository(t *testing.T) (*cluster.Repository, *gorm.DB) {
+	t.Helper()
+	db, errOpen := cluster.OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if errMigrate := cluster.AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	return cluster.NewRepository(db), db
+}
+
+func firstHTTPLink(text string) string {
+	for _, field := range strings.Fields(text) {
+		if strings.HasPrefix(field, "http://") || strings.HasPrefix(field, "https://") {
+			return field
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- add optional `user-email` configuration for verified email registration and password recovery
- expose User API capability discovery without leaking SMTP configuration or user data
- support optional registration email, privacy-safe masked email status, email updates/removal, verification delivery, and token verification
- add enumeration-resistant forgot-password and one-time password-reset flows
- enforce verified-email ownership so unverified addresses cannot reserve or squat an email
- invalidate outstanding security tokens and existing bearer sessions transactionally after password or email security changes
- add durable database-backed mail jobs with claim renewal, retry handling, and permanent SMTP failure classification
- require SMTP STARTTLS with TLS 1.2 or newer for non-loopback hosts and load SMTP passwords only from environment variables
- add database-backed registration, verification, recovery, per-IP, per-address, and global rate limits with accurate `Retry-After` responses
- add explicit `trusted-proxies` configuration so public deployments can safely derive client IPs behind known reverse proxies
- harden the public User API with request-body, token, and bcrypt password limits and generic `5xx` responses
- document the User API, Management API configuration, SMTP requirements, and production deployment behavior in English and Chinese

## Configuration notes

- the feature remains disabled by default
- production public user URLs must use HTTPS
- non-loopback SMTP servers must support STARTTLS
- SMTP passwords are never stored in `config.yaml`
- direct deployments should leave `trusted-proxies` empty
- reverse-proxy deployments should trust only the exact proxy IP addresses or CIDRs

Closes #51