### PR TITLE
feat(users): complete period-limit management API parity

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1121,7 +1121,7 @@ Example request:
 
 Response: same shape as `GET /users/:id`.
 
-Validation failures return HTTP `400` with a structured `field_errors` array so clients can localize and anchor errors without parsing message strings:
+Semantic validation failures and identifiable type mismatches in structurally valid JSON return HTTP `400` with a structured `field_errors` array so clients can localize and anchor errors without parsing message strings:
 
 ```json
 {
@@ -1134,11 +1134,14 @@ Validation failures return HTTP `400` with a structured `field_errors` array so 
 | `field_errors[].code` | `field_errors[].field` | Meaning |
 | --- | --- | --- |
 | `required` | `username` | Username is missing or empty. |
-| `invalid_timezone` | `timezone` | Not a valid IANA timezone. |
-| `invalid_limit` | `limit_5h_credits`, `limit_1d_credits`, `limit_7d_credits`, `limit_30d_credits` | Limit is negative or not a finite number. |
-| `invalid_window_mode` | `window_mode_5h`, `window_mode_1d`, `window_mode_7d`, `window_mode_30d` | Unsupported window mode (`calendar` is rejected for `5h`). |
-| `invalid_week_reset_day` | `week_reset_day` | Outside `1`–`7`. |
-| `invalid_week_reset_hour` | `week_reset_hour` | Outside `0`–`23`. |
+| `invalid_type` | `credits_unlimited` | Value is not a boolean or `null`. |
+| `invalid_timezone` | `timezone` | Invalid IANA timezone, or a value whose type is not string/`null`. |
+| `invalid_limit` | `limit_5h_credits`, `limit_1d_credits`, `limit_7d_credits`, `limit_30d_credits` | Limit is negative, not finite, or not a number/`null`. |
+| `invalid_window_mode` | `window_mode_5h`, `window_mode_1d`, `window_mode_7d`, `window_mode_30d` | Unsupported mode or a value other than a string/`null` (`calendar` is rejected for `5h`). |
+| `invalid_week_reset_day` | `week_reset_day` | Outside `1`–`7` or not an integer/`null`. |
+| `invalid_week_reset_hour` | `week_reset_hour` | Outside `0`–`23` or not an integer/`null`. |
+
+Malformed JSON, or JSON that cannot be decoded far enough to identify a specific field, still returns `400` with `error: "invalid body"` but may omit `field_errors`.
 
 ### PUT/PATCH `/users/:id`
 
@@ -1205,6 +1208,8 @@ Request body:
 | `windows` | string[] | no | Subset of `5h`/`1d`/`7d`/`30d`. Empty/omitted resets all windows. |
 | `mode` | string | no | `counter` (default): for each selected window set `usage_epoch_* = now` and clear the matching `period_window_start_*`. `window_only`: clear `period_window_start_*`; for `sliding`/`calendar` also set `usage_epoch_*` so used actually resets. |
 
+An empty request body, omitted `windows`, `windows: []`, or `windows: null` always targets all four windows in stable order (`5h`, `1d`, `7d`, `30d`), including windows that are currently disabled or inactive.
+
 Response:
 
 ```json
@@ -1238,7 +1243,7 @@ Response:
 
 `limits` is the complete post-reset status, rebuilt inside the same transaction; it is identical in shape to `GET /users/:id/period-limits`, so clients can update their local state directly from the response without an extra read.
 
-Validation failures return HTTP `400` with the `field_errors` contract described in the user write sections, using codes `invalid_reset_mode` (field `mode`) and `invalid_reset_windows` (field `windows`).
+Validation and identifiable JSON type failures return HTTP `400` with the `field_errors` contract described in the user write sections, using codes `invalid_reset_mode` (field `mode`) and `invalid_reset_windows` (field `windows`). Malformed JSON may omit `field_errors`.
 
 Period limits are enforced at dispatch for every API key owned by the user (`user_credits_insufficient` and `user_period_limit_exceeded`). When `credits_unlimited=true`, the total-balance check is skipped, but enabled period windows are still enforced.
 

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1068,6 +1068,10 @@ Example response:
     "password_set": true,
     "credits": 10.5,
     "credits_unlimited": false,
+    "period_limits_summary": {
+      "enabled_windows": ["5h", "1d"],
+      "zero_limit_windows": []
+    },
     "mfa": { "enabled": true },
     "passkey": [{ "id": "credential-id" }],
     "created_at": "2026-05-27T10:00:00Z",
@@ -1076,6 +1080,8 @@ Example response:
   }
 }
 ```
+
+User records include `period_limits_summary`, a lightweight overview derived from the record itself (no usage queries): `enabled_windows` lists the windows whose limit is configured (`5h`/`1d`/`7d`/`30d`), and `zero_limit_windows` lists enabled windows with a `0` limit (immediately blocking). Use `GET /users/:id/period-limits` for live used/remaining data.
 
 ### POST `/users`
 
@@ -1115,6 +1121,25 @@ Example request:
 
 Response: same shape as `GET /users/:id`.
 
+Validation failures return HTTP `400` with a structured `field_errors` array so clients can localize and anchor errors without parsing message strings:
+
+```json
+{
+  "error": "invalid body",
+  "message": "window_mode_5h: window mode must be \"first_use\" or \"sliding\"",
+  "field_errors": [{ "field": "window_mode_5h", "code": "invalid_window_mode" }]
+}
+```
+
+| `field_errors[].code` | `field_errors[].field` | Meaning |
+| --- | --- | --- |
+| `required` | `username` | Username is missing or empty. |
+| `invalid_timezone` | `timezone` | Not a valid IANA timezone. |
+| `invalid_limit` | `limit_5h_credits`, `limit_1d_credits`, `limit_7d_credits`, `limit_30d_credits` | Limit is negative or not a finite number. |
+| `invalid_window_mode` | `window_mode_5h`, `window_mode_1d`, `window_mode_7d`, `window_mode_30d` | Unsupported window mode (`calendar` is rejected for `5h`). |
+| `invalid_week_reset_day` | `week_reset_day` | Outside `1`–`7`. |
+| `invalid_week_reset_hour` | `week_reset_hour` | Outside `0`–`23`. |
+
 ### PUT/PATCH `/users/:id`
 
 Updates a user. `PUT` and `PATCH` currently have the same partial-update behavior: only fields present in the body are modified.
@@ -1134,6 +1159,8 @@ Example request:
 All request fields are optional, but `username`, if present, must not be empty. `credits`, if present, replaces the user's current credit balance. For billing workflows, prefer `/billing/balance-records/recharge` and `/billing/balance-records/deduct` so balance changes have ledger records.
 Set `credits_unlimited` to `true` when the user should have unlimited total balance but still be constrained by configured period limits.
 When `password` is present, a successful update increments the user's session version and invalidates all previously issued User API bearer tokens. The Management API does not issue a replacement user session.
+
+Validation failures use the same `field_errors` contract as `POST /users`.
 
 Response: same shape as `GET /users/:id`.
 
@@ -1185,9 +1212,33 @@ Response:
   "status": "ok",
   "user_id": 1,
   "reset": { "mode": "counter", "windows": ["5h", "1d"], "at": "2026-07-09T12:00:00Z" },
-  "limits": { "user_id": 1, "windows": [] }
+  "limits": {
+    "user_id": 1,
+    "timezone": "Asia/Shanghai",
+    "credits": 10.5,
+    "credits_unlimited": false,
+    "windows": [
+      {
+        "id": "5h",
+        "enabled": true,
+        "limit": 5,
+        "used": 0,
+        "remaining": 5,
+        "mode": "first_use",
+        "active": false,
+        "window_start": null,
+        "window_end": null,
+        "reset_at": null,
+        "usage_epoch": "2026-07-09T12:00:00Z"
+      }
+    ]
+  }
 }
 ```
+
+`limits` is the complete post-reset status, rebuilt inside the same transaction; it is identical in shape to `GET /users/:id/period-limits`, so clients can update their local state directly from the response without an extra read.
+
+Validation failures return HTTP `400` with the `field_errors` contract described in the user write sections, using codes `invalid_reset_mode` (field `mode`) and `invalid_reset_windows` (field `windows`).
 
 Period limits are enforced at dispatch for every API key owned by the user (`user_credits_insufficient` and `user_period_limit_exceeded`). When `credits_unlimited=true`, the total-balance check is skipped, but enabled period windows are still enforced.
 
@@ -2541,6 +2592,9 @@ Response fields:
 | `capabilities.logs` | boolean | Whether application log APIs are available. |
 | `capabilities.request_error_logs` | boolean | Whether request error log file list/download APIs are available. |
 | `capabilities.topology` | boolean | Whether `GET /topology` is available for Home + CPA cluster topology. |
+| `capabilities.users` | boolean | Whether the `/users` user-management routes are available. |
+| `capabilities.access_groups` | boolean | Whether the `/channel-groups` and `/model-groups` access-scope routes are available. |
+| `capabilities.user_period_limits` | boolean | Whether user period-limit configuration fields plus `GET /users/:id/period-limits` and `POST /users/:id/period-limits/reset` are available. |
 | `server_info.home_version` | string | Home build version. |
 | `server_info.home_commit` | string | Home build commit. |
 | `server_info.home_build_date` | string | Home build time. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1121,7 +1121,7 @@ Path 参数：
 
 输出：与 `GET /users/:id` 相同。
 
-校验失败返回 HTTP `400`，并携带结构化的 `field_errors` 数组，客户端无需解析 message 字符串即可本地化并定位字段：
+语义校验失败，以及结构合法 JSON 中可定位的字段类型错误，会返回 HTTP `400` 并携带结构化的 `field_errors` 数组，客户端无需解析 message 字符串即可本地化并定位字段：
 
 ```json
 {
@@ -1134,11 +1134,14 @@ Path 参数：
 | `field_errors[].code` | `field_errors[].field` | 含义 |
 | --- | --- | --- |
 | `required` | `username` | 用户名缺失或为空。 |
-| `invalid_timezone` | `timezone` | 不是合法的 IANA 时区。 |
-| `invalid_limit` | `limit_5h_credits`、`limit_1d_credits`、`limit_7d_credits`、`limit_30d_credits` | 限额为负数或不是有限数字。 |
-| `invalid_window_mode` | `window_mode_5h`、`window_mode_1d`、`window_mode_7d`、`window_mode_30d` | 不支持的窗口模式（`5h` 拒绝 `calendar`）。 |
-| `invalid_week_reset_day` | `week_reset_day` | 超出 `1`–`7`。 |
-| `invalid_week_reset_hour` | `week_reset_hour` | 超出 `0`–`23`。 |
+| `invalid_type` | `credits_unlimited` | 值不是 boolean 或 `null`。 |
+| `invalid_timezone` | `timezone` | IANA 时区无效，或值的类型不是 string/`null`。 |
+| `invalid_limit` | `limit_5h_credits`、`limit_1d_credits`、`limit_7d_credits`、`limit_30d_credits` | 限额为负数、不是有限数字，或不是 number/`null`。 |
+| `invalid_window_mode` | `window_mode_5h`、`window_mode_1d`、`window_mode_7d`、`window_mode_30d` | 模式不受支持，或值不是 string/`null`（`5h` 拒绝 `calendar`）。 |
+| `invalid_week_reset_day` | `week_reset_day` | 超出 `1`–`7`，或不是 integer/`null`。 |
+| `invalid_week_reset_hour` | `week_reset_hour` | 超出 `0`–`23`，或不是 integer/`null`。 |
+
+JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时，仍返回 `400` 和 `error: "invalid body"`，但可能不包含 `field_errors`。
 
 ### PUT/PATCH `/users/:id`
 
@@ -1205,6 +1208,8 @@ Path 参数：
 | `windows` | string[] | 否 | `5h`/`1d`/`7d`/`30d` 子集。空/省略表示全部。 |
 | `mode` | string | 否 | `counter`（默认）：对选中窗口设置 `usage_epoch_* = now` 并清除对应 `period_window_start_*`。`window_only`：清除 `period_window_start_*`；对 `sliding`/`calendar` 窗口同时写 `usage_epoch_*`（否则无法真正清零 used）。 |
 
+空请求体、省略 `windows`、`windows: []` 或 `windows: null` 都固定重置四个窗口，并按稳定顺序返回 `5h`、`1d`、`7d`、`30d`；即使某个窗口当前未启用或未激活，也会包含在目标集合中。
+
 响应：
 
 ```json
@@ -1238,7 +1243,7 @@ Path 参数：
 
 `limits` 是重置后的完整状态（在同一事务内重建），结构与 `GET /users/:id/period-limits` 完全一致；客户端可直接用响应更新本地状态，无需额外读取。
 
-校验失败返回 HTTP `400`，携带用户写入章节描述的 `field_errors` 契约，错误码为 `invalid_reset_mode`（字段 `mode`）与 `invalid_reset_windows`（字段 `windows`）。
+校验失败和可定位的 JSON 类型错误返回 HTTP `400`，携带用户写入章节描述的 `field_errors` 契约，错误码为 `invalid_reset_mode`（字段 `mode`）与 `invalid_reset_windows`（字段 `windows`）。JSON 语法错误可能不包含 `field_errors`。
 
 周期限额在派发时对用户名下所有 API key 生效（`user_credits_insufficient` 与 `user_period_limit_exceeded`）。当 `credits_unlimited=true` 时跳过总余额检查，但已启用的周期窗口仍会拦截。
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1068,6 +1068,10 @@ Path 参数：
     "password_set": true,
     "credits": 10.5,
     "credits_unlimited": false,
+    "period_limits_summary": {
+      "enabled_windows": ["5h", "1d"],
+      "zero_limit_windows": []
+    },
     "mfa": { "enabled": true },
     "passkey": [{ "id": "credential-id" }],
     "created_at": "2026-05-27T10:00:00Z",
@@ -1076,6 +1080,8 @@ Path 参数：
   }
 }
 ```
+
+用户记录包含 `period_limits_summary`：由记录本身推导的轻量概览（不查询用量）。`enabled_windows` 列出已配置限额的窗口（`5h`/`1d`/`7d`/`30d`），`zero_limit_windows` 列出限额为 `0`（立即阻断）的窗口。实时 used/remaining 请使用 `GET /users/:id/period-limits`。
 
 ### POST `/users`
 
@@ -1115,6 +1121,25 @@ Path 参数：
 
 输出：与 `GET /users/:id` 相同。
 
+校验失败返回 HTTP `400`，并携带结构化的 `field_errors` 数组，客户端无需解析 message 字符串即可本地化并定位字段：
+
+```json
+{
+  "error": "invalid body",
+  "message": "window_mode_5h: window mode must be \"first_use\" or \"sliding\"",
+  "field_errors": [{ "field": "window_mode_5h", "code": "invalid_window_mode" }]
+}
+```
+
+| `field_errors[].code` | `field_errors[].field` | 含义 |
+| --- | --- | --- |
+| `required` | `username` | 用户名缺失或为空。 |
+| `invalid_timezone` | `timezone` | 不是合法的 IANA 时区。 |
+| `invalid_limit` | `limit_5h_credits`、`limit_1d_credits`、`limit_7d_credits`、`limit_30d_credits` | 限额为负数或不是有限数字。 |
+| `invalid_window_mode` | `window_mode_5h`、`window_mode_1d`、`window_mode_7d`、`window_mode_30d` | 不支持的窗口模式（`5h` 拒绝 `calendar`）。 |
+| `invalid_week_reset_day` | `week_reset_day` | 超出 `1`–`7`。 |
+| `invalid_week_reset_hour` | `week_reset_hour` | 超出 `0`–`23`。 |
+
 ### PUT/PATCH `/users/:id`
 
 更新用户。`PUT` 和 `PATCH` 当前都是局部更新语义：只修改请求体中出现的字段。
@@ -1134,6 +1159,8 @@ Path 参数：
 所有字段均可选；如果出现 `username`，则不能为空。`credits` 如果出现，会替换用户当前点数余额。对于计费工作流，优先使用 `/billing/balance-records/recharge` 和 `/billing/balance-records/deduct`，以便余额变更拥有分类账记录。
 当用户需要无限总余额、但仍受独立周期限额约束时，将 `credits_unlimited` 设为 `true`。
 请求中出现 `password` 且更新成功时，会递增用户 session version，使此前签发的所有 User API bearer token 失效。Management API 不会签发替换用户 session。
+
+校验失败使用与 `POST /users` 相同的 `field_errors` 契约。
 
 输出：与 `GET /users/:id` 相同。
 
@@ -1185,9 +1212,33 @@ Path 参数：
   "status": "ok",
   "user_id": 1,
   "reset": { "mode": "counter", "windows": ["5h", "1d"], "at": "2026-07-09T12:00:00Z" },
-  "limits": { "user_id": 1, "windows": [] }
+  "limits": {
+    "user_id": 1,
+    "timezone": "Asia/Shanghai",
+    "credits": 10.5,
+    "credits_unlimited": false,
+    "windows": [
+      {
+        "id": "5h",
+        "enabled": true,
+        "limit": 5,
+        "used": 0,
+        "remaining": 5,
+        "mode": "first_use",
+        "active": false,
+        "window_start": null,
+        "window_end": null,
+        "reset_at": null,
+        "usage_epoch": "2026-07-09T12:00:00Z"
+      }
+    ]
+  }
 }
 ```
+
+`limits` 是重置后的完整状态（在同一事务内重建），结构与 `GET /users/:id/period-limits` 完全一致；客户端可直接用响应更新本地状态，无需额外读取。
+
+校验失败返回 HTTP `400`，携带用户写入章节描述的 `field_errors` 契约，错误码为 `invalid_reset_mode`（字段 `mode`）与 `invalid_reset_windows`（字段 `windows`）。
 
 周期限额在派发时对用户名下所有 API key 生效（`user_credits_insufficient` 与 `user_period_limit_exceeded`）。当 `credits_unlimited=true` 时跳过总余额检查，但已启用的周期窗口仍会拦截。
 
@@ -2541,6 +2592,9 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 | `capabilities.logs` | boolean | 是否支持应用日志接口。 |
 | `capabilities.request_error_logs` | boolean | 是否支持 request error log file list/download。 |
 | `capabilities.topology` | boolean | 是否支持 `GET /topology` Home + CPA 集群拓扑接口。 |
+| `capabilities.users` | boolean | 是否支持 `/users` 用户管理路由。 |
+| `capabilities.access_groups` | boolean | 是否支持 `/channel-groups` 与 `/model-groups` 访问范围路由。 |
+| `capabilities.user_period_limits` | boolean | 是否支持用户周期限额配置字段，以及 `GET /users/:id/period-limits` 和 `POST /users/:id/period-limits/reset`。 |
 | `server_info.home_version` | string | Home 构建版本。 |
 | `server_info.home_commit` | string | Home 构建 commit。 |
 | `server_info.home_build_date` | string | Home 构建时间。 |

--- a/internal/cluster/management/server.go
+++ b/internal/cluster/management/server.go
@@ -130,6 +130,24 @@ func respondError(c *gin.Context, status int, code string, err error) {
 	c.JSON(status, gin.H{"error": code, "message": message})
 }
 
+// fieldErrorItem identifies one request field that failed validation together
+// with a stable machine-readable code clients can localize.
+type fieldErrorItem struct {
+	Field string `json:"field"`
+	Code  string `json:"code"`
+}
+
+// respondErrorWithFieldErrors writes the same envelope as respondError plus a
+// field_errors array so clients can anchor and localize validation failures
+// without parsing message strings.
+func respondErrorWithFieldErrors(c *gin.Context, status int, code string, err error, fieldErrors []fieldErrorItem) {
+	message := strings.TrimSpace(code)
+	if err != nil && strings.TrimSpace(err.Error()) != "" {
+		message = err.Error()
+	}
+	c.JSON(status, gin.H{"error": code, "message": message, "field_errors": fieldErrors})
+}
+
 // respondOK handles a respond ok.
 func respondOK(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -56,6 +56,9 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 			"logs":                    true,
 			"request_error_logs":      true,
 			"topology":                true,
+			"users":                   true,
+			"access_groups":           true,
+			"user_period_limits":      true,
 		},
 		"server_info": gin.H{
 			"home_version":    buildinfo.Version,

--- a/internal/cluster/management/users.go
+++ b/internal/cluster/management/users.go
@@ -63,6 +63,45 @@ type userPeriodLimitResetRequest struct {
 	Mode    string   `json:"mode"`
 }
 
+type userJSONFieldType uint8
+
+const userJSONFieldErrInvalidType = "invalid_type"
+
+const (
+	userJSONFieldBoolean userJSONFieldType = iota
+	userJSONFieldString
+	userJSONFieldNumber
+	userJSONFieldInteger
+	userJSONFieldStringArray
+)
+
+type userJSONFieldSpec struct {
+	Field    string
+	Code     string
+	Expected string
+	Type     userJSONFieldType
+}
+
+var userWriteJSONFieldSpecs = []userJSONFieldSpec{
+	{Field: "credits_unlimited", Code: userJSONFieldErrInvalidType, Expected: "a boolean or null", Type: userJSONFieldBoolean},
+	{Field: "timezone", Code: cluster.PeriodLimitErrInvalidTimezone, Expected: "a string or null", Type: userJSONFieldString},
+	{Field: "limit_5h_credits", Code: cluster.PeriodLimitErrInvalidLimit, Expected: "a number or null", Type: userJSONFieldNumber},
+	{Field: "window_mode_5h", Code: cluster.PeriodLimitErrInvalidWindowMode, Expected: "a string or null", Type: userJSONFieldString},
+	{Field: "limit_1d_credits", Code: cluster.PeriodLimitErrInvalidLimit, Expected: "a number or null", Type: userJSONFieldNumber},
+	{Field: "window_mode_1d", Code: cluster.PeriodLimitErrInvalidWindowMode, Expected: "a string or null", Type: userJSONFieldString},
+	{Field: "limit_7d_credits", Code: cluster.PeriodLimitErrInvalidLimit, Expected: "a number or null", Type: userJSONFieldNumber},
+	{Field: "window_mode_7d", Code: cluster.PeriodLimitErrInvalidWindowMode, Expected: "a string or null", Type: userJSONFieldString},
+	{Field: "week_reset_day", Code: cluster.PeriodLimitErrInvalidWeekResetDay, Expected: "an integer or null", Type: userJSONFieldInteger},
+	{Field: "week_reset_hour", Code: cluster.PeriodLimitErrInvalidWeekResetHour, Expected: "an integer or null", Type: userJSONFieldInteger},
+	{Field: "limit_30d_credits", Code: cluster.PeriodLimitErrInvalidLimit, Expected: "a number or null", Type: userJSONFieldNumber},
+	{Field: "window_mode_30d", Code: cluster.PeriodLimitErrInvalidWindowMode, Expected: "a string or null", Type: userJSONFieldString},
+}
+
+var userPeriodLimitResetJSONFieldSpecs = []userJSONFieldSpec{
+	{Field: "windows", Code: cluster.PeriodLimitErrInvalidResetWindows, Expected: "an array of strings or null", Type: userJSONFieldStringArray},
+	{Field: "mode", Code: cluster.PeriodLimitErrInvalidResetMode, Expected: "a string or null", Type: userJSONFieldString},
+}
+
 // ListUsers returns users.
 func (h *Handler) ListUsers(c *gin.Context) {
 	ctx, cancel := h.requestContext(c)
@@ -100,8 +139,8 @@ func (h *Handler) GetUser(c *gin.Context) {
 // CreateUser creates a user.
 func (h *Handler) CreateUser(c *gin.Context) {
 	var body userWriteRequest
-	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
-		respondError(c, http.StatusBadRequest, "invalid body", errBindJSON)
+	if errBindJSON := c.ShouldBindBodyWithJSON(&body); errBindJSON != nil {
+		respondUserJSONBindError(c, errBindJSON, userWriteJSONFieldSpecs)
 		return
 	}
 	update, ok := userUpdateFromRequest(c, body, true)
@@ -133,8 +172,8 @@ func (h *Handler) UpdateUser(c *gin.Context) {
 		return
 	}
 	var body userWriteRequest
-	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
-		respondError(c, http.StatusBadRequest, "invalid body", errBindJSON)
+	if errBindJSON := c.ShouldBindBodyWithJSON(&body); errBindJSON != nil {
+		respondUserJSONBindError(c, errBindJSON, userWriteJSONFieldSpecs)
 		return
 	}
 	update, ok := userUpdateFromRequest(c, body, false)
@@ -194,12 +233,9 @@ func (h *Handler) ResetUserPeriodLimits(c *gin.Context) {
 		return
 	}
 	var body userPeriodLimitResetRequest
-	if c.Request != nil && c.Request.Body != nil {
-		decoder := json.NewDecoder(c.Request.Body)
-		if errDecode := decoder.Decode(&body); errDecode != nil && !errors.Is(errDecode, io.EOF) {
-			respondError(c, http.StatusBadRequest, "invalid body", errDecode)
-			return
-		}
+	if errBindJSON := c.ShouldBindBodyWithJSON(&body); errBindJSON != nil && !errors.Is(errBindJSON, io.EOF) {
+		respondUserJSONBindError(c, errBindJSON, userPeriodLimitResetJSONFieldSpecs)
+		return
 	}
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
@@ -221,6 +257,62 @@ func (h *Handler) ResetUserPeriodLimits(c *gin.Context) {
 		},
 		"limits": result.Limits,
 	})
+}
+
+func respondUserJSONBindError(c *gin.Context, err error, specs []userJSONFieldSpec) {
+	if item, message, ok := userJSONTypeFieldError(c, specs); ok {
+		respondErrorWithFieldErrors(c, http.StatusBadRequest, "invalid body", errors.New(message), []fieldErrorItem{item})
+		return
+	}
+	respondError(c, http.StatusBadRequest, "invalid body", err)
+}
+
+func userJSONTypeFieldError(c *gin.Context, specs []userJSONFieldSpec) (fieldErrorItem, string, bool) {
+	if c == nil {
+		return fieldErrorItem{}, "", false
+	}
+	rawBody, okBody := c.Get(gin.BodyBytesKey)
+	if !okBody {
+		return fieldErrorItem{}, "", false
+	}
+	body, okBytes := rawBody.([]byte)
+	if !okBytes || len(body) == 0 {
+		return fieldErrorItem{}, "", false
+	}
+	fields := map[string]json.RawMessage{}
+	if errUnmarshal := json.Unmarshal(body, &fields); errUnmarshal != nil {
+		return fieldErrorItem{}, "", false
+	}
+	for _, spec := range specs {
+		raw, exists := fields[spec.Field]
+		if !exists || userJSONFieldTypeMatches(raw, spec.Type) {
+			continue
+		}
+		return fieldErrorItem{Field: spec.Field, Code: spec.Code}, fmt.Sprintf("%s must be %s", spec.Field, spec.Expected), true
+	}
+	return fieldErrorItem{}, "", false
+}
+
+func userJSONFieldTypeMatches(raw json.RawMessage, expected userJSONFieldType) bool {
+	switch expected {
+	case userJSONFieldBoolean:
+		var value *bool
+		return json.Unmarshal(raw, &value) == nil
+	case userJSONFieldString:
+		var value *string
+		return json.Unmarshal(raw, &value) == nil
+	case userJSONFieldNumber:
+		var value *float64
+		return json.Unmarshal(raw, &value) == nil
+	case userJSONFieldInteger:
+		var value *int
+		return json.Unmarshal(raw, &value) == nil
+	case userJSONFieldStringArray:
+		var value []string
+		return json.Unmarshal(raw, &value) == nil
+	default:
+		return false
+	}
 }
 
 func userUpdateFromRequest(c *gin.Context, body userWriteRequest, requireUsername bool) (cluster.UserUpdate, bool) {

--- a/internal/cluster/management/users.go
+++ b/internal/cluster/management/users.go
@@ -117,8 +117,7 @@ func (h *Handler) CreateUser(c *gin.Context) {
 			respondError(c, http.StatusConflict, "user_exists", errCreate)
 			return
 		}
-		if isUserPeriodLimitValidationError(errCreate) {
-			respondError(c, http.StatusBadRequest, "invalid body", errCreate)
+		if respondUserPeriodLimitValidationError(c, errCreate) {
 			return
 		}
 		respondError(c, http.StatusInternalServerError, "user_create_failed", errCreate)
@@ -147,8 +146,7 @@ func (h *Handler) UpdateUser(c *gin.Context) {
 	defer cancel()
 	record, errUpdate := h.repo.UpdateUser(ctx, id, update)
 	if errUpdate != nil {
-		if isUserPeriodLimitValidationError(errUpdate) {
-			respondError(c, http.StatusBadRequest, "invalid body", errUpdate)
+		if respondUserPeriodLimitValidationError(c, errUpdate) {
 			return
 		}
 		respondUserRecordError(c, "user_update_failed", errUpdate)
@@ -207,8 +205,7 @@ func (h *Handler) ResetUserPeriodLimits(c *gin.Context) {
 	defer cancel()
 	result, errReset := h.repo.ResetUserPeriodLimits(ctx, id, body.Windows, body.Mode, time.Now().UTC())
 	if errReset != nil {
-		if isUserPeriodLimitValidationError(errReset) {
-			respondError(c, http.StatusBadRequest, "invalid body", errReset)
+		if respondUserPeriodLimitValidationError(c, errReset) {
 			return
 		}
 		respondUserRecordError(c, "user_period_limits_reset_failed", errReset)
@@ -231,12 +228,16 @@ func userUpdateFromRequest(c *gin.Context, body userWriteRequest, requireUsernam
 	username := body.username()
 	if username != nil {
 		if strings.TrimSpace(*username) == "" {
-			respondError(c, http.StatusBadRequest, "invalid body", errRequired("username"))
+			respondErrorWithFieldErrors(c, http.StatusBadRequest, "invalid body", errRequired("username"), []fieldErrorItem{
+				{Field: "username", Code: "required"},
+			})
 			return update, false
 		}
 		update.Username = username
 	} else if requireUsername {
-		respondError(c, http.StatusBadRequest, "invalid body", errRequired("username"))
+		respondErrorWithFieldErrors(c, http.StatusBadRequest, "invalid body", errRequired("username"), []fieldErrorItem{
+			{Field: "username", Code: "required"},
+		})
 		return update, false
 	}
 	password, errPassword := managementPasswordValue(body.Password)
@@ -348,24 +349,25 @@ func isUserPeriodLimitValidationError(err error) bool {
 		return false
 	}
 	var configErr cluster.PeriodLimitConfigError
-	if errors.As(err, &configErr) {
-		return true
-	}
-	// Fallback for wrapped field-prefix errors from applyUserPeriodLimitUpdate.
-	message := strings.ToLower(err.Error())
-	switch {
-	case strings.Contains(message, "limit_"),
-		strings.Contains(message, "window mode"),
-		strings.Contains(message, "window_mode"),
-		strings.Contains(message, "timezone"),
-		strings.Contains(message, "week_reset"),
-		strings.Contains(message, "period window"),
-		strings.Contains(message, "reset mode"),
-		strings.Contains(message, "non-negative"):
-		return true
-	default:
+	return errors.As(err, &configErr)
+}
+
+// respondUserPeriodLimitValidationError writes a 400 response carrying the
+// stable field_errors contract for period-limit validation failures. It
+// reports whether err was a validation error (and the response was written).
+func respondUserPeriodLimitValidationError(c *gin.Context, err error) bool {
+	if !isUserPeriodLimitValidationError(err) {
 		return false
 	}
+	var configErr cluster.PeriodLimitConfigError
+	if errors.As(err, &configErr) && configErr.Code != "" {
+		respondErrorWithFieldErrors(c, http.StatusBadRequest, "invalid body", err, []fieldErrorItem{
+			{Field: configErr.Field, Code: configErr.Code},
+		})
+		return true
+	}
+	respondError(c, http.StatusBadRequest, "invalid body", err)
+	return true
 }
 
 func userRecordToMap(record *cluster.UserRecord) gin.H {
@@ -401,6 +403,7 @@ func userRecordToMap(record *cluster.UserRecord) gin.H {
 		"week_reset_hour":         record.WeekResetHour,
 		"limit_30d_credits":       record.Limit30dCredits,
 		"window_mode_30d":         windowMode30d,
+		"period_limits_summary":   userPeriodLimitsSummary(record),
 		"period_window_start_5h":  record.PeriodWindowStart5h,
 		"period_window_start_1d":  record.PeriodWindowStart1d,
 		"period_window_start_7d":  record.PeriodWindowStart7d,
@@ -414,5 +417,35 @@ func userRecordToMap(record *cluster.UserRecord) gin.H {
 		"created_at":              record.CreatedAt,
 		"updated_at":              record.UpdatedAt,
 		"deleted_at":              deletedAtValue(record.DeletedAt),
+	}
+}
+
+// userPeriodLimitsSummary derives a lightweight period-limit overview from the
+// user record alone (no billing queries), so list views can flag configured
+// and hard-blocked windows without per-user status calls.
+func userPeriodLimitsSummary(record *cluster.UserRecord) gin.H {
+	windows := []struct {
+		id    string
+		limit *float64
+	}{
+		{"5h", record.Limit5hCredits},
+		{"1d", record.Limit1dCredits},
+		{"7d", record.Limit7dCredits},
+		{"30d", record.Limit30dCredits},
+	}
+	enabled := make([]string, 0, len(windows))
+	zeroLimited := make([]string, 0, len(windows))
+	for _, window := range windows {
+		if window.limit == nil {
+			continue
+		}
+		enabled = append(enabled, window.id)
+		if *window.limit == 0 {
+			zeroLimited = append(zeroLimited, window.id)
+		}
+	}
+	return gin.H{
+		"enabled_windows":    enabled,
+		"zero_limit_windows": zeroLimited,
 	}
 }

--- a/internal/cluster/management/users_contract_test.go
+++ b/internal/cluster/management/users_contract_test.go
@@ -1,0 +1,542 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+type userManagementRecordResponse struct {
+	ID                uint            `json:"id"`
+	Username          string          `json:"username"`
+	PasswordSet       bool            `json:"password_set"`
+	Credits           float64         `json:"credits"`
+	CreditsUnlimited  bool            `json:"credits_unlimited"`
+	Timezone          string          `json:"timezone"`
+	Limit5hCredits    *float64        `json:"limit_5h_credits"`
+	WindowMode5h      string          `json:"window_mode_5h"`
+	Limit1dCredits    *float64        `json:"limit_1d_credits"`
+	WindowMode1d      string          `json:"window_mode_1d"`
+	Limit7dCredits    *float64        `json:"limit_7d_credits"`
+	WindowMode7d      string          `json:"window_mode_7d"`
+	WeekResetDay      int             `json:"week_reset_day"`
+	WeekResetHour     int             `json:"week_reset_hour"`
+	Limit30dCredits   *float64        `json:"limit_30d_credits"`
+	WindowMode30d     string          `json:"window_mode_30d"`
+	MFA               json.RawMessage `json:"mfa"`
+	Passkey           json.RawMessage `json:"passkey"`
+	PeriodLimitsBrief struct {
+		EnabledWindows   []string `json:"enabled_windows"`
+		ZeroLimitWindows []string `json:"zero_limit_windows"`
+	} `json:"period_limits_summary"`
+}
+
+type userManagementErrorResponse struct {
+	Error       string           `json:"error"`
+	Message     string           `json:"message"`
+	FieldErrors []fieldErrorItem `json:"field_errors"`
+}
+
+type userPeriodLimitResetHTTPResponse struct {
+	Status string `json:"status"`
+	UserID uint   `json:"user_id"`
+	Reset  struct {
+		Mode    string    `json:"mode"`
+		Windows []string  `json:"windows"`
+		At      time.Time `json:"at"`
+	} `json:"reset"`
+	Limits cluster.UserPeriodLimitsStatus `json:"limits"`
+}
+
+func TestUserManagementHTTPCreateAndPatchPeriodLimits(t *testing.T) {
+	handler, engine, closeRepo := newUserManagementHTTPTestServer(t)
+	defer closeRepo()
+
+	createPayload := `{
+		"username":"alice",
+		"password":"secret-password",
+		"credits":50,
+		"credits_unlimited":true,
+		"timezone":"America/New_York",
+		"limit_5h_credits":0,
+		"window_mode_5h":"sliding",
+		"limit_1d_credits":12.5,
+		"window_mode_1d":"calendar",
+		"limit_7d_credits":25,
+		"window_mode_7d":"calendar",
+		"week_reset_day":7,
+		"week_reset_hour":6,
+		"limit_30d_credits":100,
+		"window_mode_30d":"first_use",
+		"mfa":{"enabled":true},
+		"passkey":[{"id":"credential-1"}]
+	}`
+	createResp := performUserManagementRequest(t, engine, http.MethodPost, "/users", createPayload)
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", createResp.Code, createResp.Body.String())
+	}
+	var createBody struct {
+		User userManagementRecordResponse `json:"user"`
+	}
+	decodeUserManagementResponse(t, createResp, &createBody)
+	assertUserManagementCreateRecord(t, createBody.User)
+
+	patchPayload := `{"limit_5h_credits":null,"limit_1d_credits":0,"timezone":"Asia/Tokyo"}`
+	patchResp := performUserManagementRequest(t, engine, http.MethodPatch, fmt.Sprintf("/users/%d", createBody.User.ID), patchPayload)
+	if patchResp.Code != http.StatusOK {
+		t.Fatalf("patch status = %d, body = %s", patchResp.Code, patchResp.Body.String())
+	}
+	var patchBody struct {
+		User userManagementRecordResponse `json:"user"`
+	}
+	decodeUserManagementResponse(t, patchResp, &patchBody)
+	user := patchBody.User
+	if user.Username != "alice" || !user.PasswordSet || user.Credits != 50 || !user.CreditsUnlimited {
+		t.Fatalf("patch changed unrelated user fields: %+v", user)
+	}
+	if user.Timezone != "Asia/Tokyo" || user.Limit5hCredits != nil {
+		t.Fatalf("patch timezone/5h = %q/%v", user.Timezone, user.Limit5hCredits)
+	}
+	if user.Limit1dCredits == nil || *user.Limit1dCredits != 0 {
+		t.Fatalf("limit_1d_credits = %v, want enabled zero", user.Limit1dCredits)
+	}
+	if user.WindowMode5h != cluster.PeriodWindowModeSliding || user.WindowMode1d != cluster.PeriodWindowModeCalendar {
+		t.Fatalf("patch changed window modes: 5h=%q 1d=%q", user.WindowMode5h, user.WindowMode1d)
+	}
+	assertUserManagementSecurityJSON(t, user)
+
+	getResp := performUserManagementRequest(t, engine, http.MethodGet, fmt.Sprintf("/users/%d", user.ID), "")
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("get status = %d, body = %s", getResp.Code, getResp.Body.String())
+	}
+	var getBody struct {
+		User userManagementRecordResponse `json:"user"`
+	}
+	decodeUserManagementResponse(t, getResp, &getBody)
+	gotUser := getBody.User
+	if gotUser.ID != user.ID || gotUser.Username != user.Username || gotUser.Timezone != user.Timezone || !gotUser.PasswordSet || !gotUser.CreditsUnlimited {
+		t.Fatalf("get user = %+v, want patched user", gotUser)
+	}
+	if gotUser.Limit5hCredits != nil || gotUser.Limit1dCredits == nil || *gotUser.Limit1dCredits != 0 {
+		t.Fatalf("get limits = 5h:%v 1d:%v", gotUser.Limit5hCredits, gotUser.Limit1dCredits)
+	}
+	assertStringSlice(t, "get enabled_windows", gotUser.PeriodLimitsBrief.EnabledWindows, []string{"1d", "7d", "30d"})
+	assertStringSlice(t, "get zero_limit_windows", gotUser.PeriodLimitsBrief.ZeroLimitWindows, []string{"1d"})
+	assertUserManagementSecurityJSON(t, gotUser)
+
+	record, errGet := handler.repo.GetUser(context.Background(), user.ID)
+	if errGet != nil {
+		t.Fatalf("GetUser() error = %v", errGet)
+	}
+	if record.Password == "" || record.Credits != 50 || !record.CreditsUnlimited || len(record.MFA) == 0 || len(record.Passkey) == 0 {
+		t.Fatalf("persisted unrelated fields were lost: %+v", record)
+	}
+	if record.Limit5hCredits != nil || record.Limit1dCredits == nil || *record.Limit1dCredits != 0 {
+		t.Fatalf("persisted limits = 5h:%v 1d:%v", record.Limit5hCredits, record.Limit1dCredits)
+	}
+
+	listResp := performUserManagementRequest(t, engine, http.MethodGet, "/users", "")
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", listResp.Code, listResp.Body.String())
+	}
+	var listBody struct {
+		Users []userManagementRecordResponse `json:"users"`
+	}
+	decodeUserManagementResponse(t, listResp, &listBody)
+	if len(listBody.Users) != 1 {
+		t.Fatalf("users = %d, want 1", len(listBody.Users))
+	}
+	assertStringSlice(t, "enabled_windows", listBody.Users[0].PeriodLimitsBrief.EnabledWindows, []string{"1d", "7d", "30d"})
+	assertStringSlice(t, "zero_limit_windows", listBody.Users[0].PeriodLimitsBrief.ZeroLimitWindows, []string{"1d"})
+}
+
+func TestUserManagementHTTPPeriodLimitStatusAndReset(t *testing.T) {
+	handler, engine, closeRepo := newUserManagementHTTPTestServer(t)
+	defer closeRepo()
+
+	createResp := performUserManagementRequest(t, engine, http.MethodPost, "/users", `{
+		"username":"status-user",
+		"credits":0,
+		"credits_unlimited":true,
+		"timezone":"Asia/Shanghai",
+		"limit_5h_credits":10,
+		"window_mode_5h":"first_use",
+		"limit_1d_credits":12,
+		"window_mode_1d":"sliding",
+		"limit_7d_credits":20,
+		"window_mode_7d":"calendar",
+		"week_reset_day":1,
+		"week_reset_hour":0,
+		"limit_30d_credits":40,
+		"window_mode_30d":"calendar"
+	}`)
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", createResp.Code, createResp.Body.String())
+	}
+	var createBody struct {
+		User userManagementRecordResponse `json:"user"`
+	}
+	decodeUserManagementResponse(t, createResp, &createBody)
+	userID := createBody.User.ID
+
+	apiKey := "period-status-key"
+	if _, errKey := handler.repo.CreateAPIKeyForUser(context.Background(), userID, cluster.APIKeyUserUpdate{APIKey: &apiKey}); errKey != nil {
+		t.Fatalf("CreateAPIKeyForUser() error = %v", errKey)
+	}
+	if _, errPrice := handler.repo.CreateBillingModelPrice(context.Background(), cluster.BillingModelPriceUpdate{
+		Provider: "openai", Model: "period-test-model", RequestPrice: 4, Enabled: true,
+	}); errPrice != nil {
+		t.Fatalf("CreateBillingModelPrice() error = %v", errPrice)
+	}
+	appendUserManagementCharge(t, handler, apiKey, "period-request-1")
+
+	statusResp := performUserManagementRequest(t, engine, http.MethodGet, fmt.Sprintf("/users/%d/period-limits", userID), "")
+	if statusResp.Code != http.StatusOK {
+		t.Fatalf("status code = %d, body = %s", statusResp.Code, statusResp.Body.String())
+	}
+	var status cluster.UserPeriodLimitsStatus
+	decodeUserManagementResponse(t, statusResp, &status)
+	if status.UserID != userID || !status.CreditsUnlimited || status.Timezone != "Asia/Shanghai" || len(status.Windows) != 4 {
+		t.Fatalf("period status = %+v", status)
+	}
+	window5h := userManagementWindow(t, status, cluster.PeriodWindow5h)
+	assertUserManagementWindowAmounts(t, window5h, 10, 4, 6)
+	if !window5h.Active || window5h.WindowStart == nil || window5h.WindowEnd == nil || window5h.ResetAt == nil {
+		t.Fatalf("5h window bounds = %+v", window5h)
+	}
+	window1d := userManagementWindow(t, status, cluster.PeriodWindow1d)
+	assertUserManagementWindowAmounts(t, window1d, 12, 4, 8)
+	if !window1d.Active || window1d.Mode != cluster.PeriodWindowModeSliding || window1d.WindowStart == nil || window1d.WindowEnd == nil || window1d.ResetAt != nil {
+		t.Fatalf("1d sliding status = %+v", window1d)
+	}
+	window7d := userManagementWindow(t, status, cluster.PeriodWindow7d)
+	assertUserManagementWindowAmounts(t, window7d, 20, 4, 16)
+	if window7d.Mode != cluster.PeriodWindowModeCalendar || window7d.ResetAt == nil || window7d.WeekResetDay == nil || *window7d.WeekResetDay != 1 {
+		t.Fatalf("7d calendar status = %+v", window7d)
+	}
+	window30d := userManagementWindow(t, status, cluster.PeriodWindow30d)
+	assertUserManagementWindowAmounts(t, window30d, 40, 4, 36)
+	if !window30d.Active || window30d.Mode != cluster.PeriodWindowModeCalendar || window30d.WindowStart == nil || window30d.WindowEnd == nil || window30d.ResetAt == nil {
+		t.Fatalf("30d calendar status = %+v", window30d)
+	}
+
+	subsetResp := performUserManagementRequest(t, engine, http.MethodPost, fmt.Sprintf("/users/%d/period-limits/reset", userID), `{"windows":["5h"],"mode":"counter"}`)
+	if subsetResp.Code != http.StatusOK {
+		t.Fatalf("subset reset status = %d, body = %s", subsetResp.Code, subsetResp.Body.String())
+	}
+	var subset userPeriodLimitResetHTTPResponse
+	decodeUserManagementResponse(t, subsetResp, &subset)
+	assertStringSlice(t, "subset reset windows", subset.Reset.Windows, []string{"5h"})
+	if subset.Status != "ok" || subset.Reset.Mode != cluster.PeriodResetModeCounter {
+		t.Fatalf("subset reset response = %+v", subset)
+	}
+	if got := userManagementWindow(t, subset.Limits, cluster.PeriodWindow5h); got.Used != 0 || got.Active {
+		t.Fatalf("5h after subset reset = %+v", got)
+	}
+	if got := userManagementWindow(t, subset.Limits, cluster.PeriodWindow1d); !floatEqual(got.Used, 4) {
+		t.Fatalf("1d after subset reset = %+v", got)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "empty body", payload: ""},
+		{name: "omitted windows", payload: `{}`},
+		{name: "empty windows", payload: `{"windows":[],"mode":"counter"}`},
+		{name: "null windows", payload: `{"windows":null,"mode":"counter"}`},
+	} {
+		t.Run("reset all/"+tc.name, func(t *testing.T) {
+			resetResp := performUserManagementRequest(t, engine, http.MethodPost, fmt.Sprintf("/users/%d/period-limits/reset", userID), tc.payload)
+			if resetResp.Code != http.StatusOK {
+				t.Fatalf("all reset status = %d, body = %s", resetResp.Code, resetResp.Body.String())
+			}
+			var reset userPeriodLimitResetHTTPResponse
+			decodeUserManagementResponse(t, resetResp, &reset)
+			assertStringSlice(t, "all reset windows", reset.Reset.Windows, []string{"5h", "1d", "7d", "30d"})
+			if len(reset.Limits.Windows) != 4 {
+				t.Fatalf("reset limits windows = %d, want 4", len(reset.Limits.Windows))
+			}
+			for _, window := range reset.Limits.Windows {
+				if window.UsageEpoch == nil {
+					t.Fatalf("window %s usage_epoch = nil after all-window counter reset", window.ID)
+				}
+			}
+		})
+	}
+
+	appendUserManagementCharge(t, handler, apiKey, "period-request-2")
+	windowOnlyResp := performUserManagementRequest(t, engine, http.MethodPost, fmt.Sprintf("/users/%d/period-limits/reset", userID), `{"windows":["5h"],"mode":"window_only"}`)
+	if windowOnlyResp.Code != http.StatusOK {
+		t.Fatalf("window_only status = %d, body = %s", windowOnlyResp.Code, windowOnlyResp.Body.String())
+	}
+	var windowOnly userPeriodLimitResetHTTPResponse
+	decodeUserManagementResponse(t, windowOnlyResp, &windowOnly)
+	if windowOnly.Reset.Mode != cluster.PeriodResetModeWindowOnly {
+		t.Fatalf("window_only mode = %q", windowOnly.Reset.Mode)
+	}
+	if got := userManagementWindow(t, windowOnly.Limits, cluster.PeriodWindow5h); got.Active || got.Used != 0 {
+		t.Fatalf("5h after window_only reset = %+v", got)
+	}
+
+	missingStatus := performUserManagementRequest(t, engine, http.MethodGet, "/users/999999/period-limits", "")
+	if missingStatus.Code != http.StatusNotFound {
+		t.Fatalf("missing status code = %d, body = %s", missingStatus.Code, missingStatus.Body.String())
+	}
+	missingReset := performUserManagementRequest(t, engine, http.MethodPost, "/users/999999/period-limits/reset", `{}`)
+	if missingReset.Code != http.StatusNotFound {
+		t.Fatalf("missing reset code = %d, body = %s", missingReset.Code, missingReset.Body.String())
+	}
+}
+
+func TestUserManagementHTTPPeriodLimitFieldErrors(t *testing.T) {
+	_, engine, closeRepo := newUserManagementHTTPTestServer(t)
+	defer closeRepo()
+
+	createResp := performUserManagementRequest(t, engine, http.MethodPost, "/users", `{"username":"validation-user"}`)
+	if createResp.Code != http.StatusOK {
+		t.Fatalf("create status = %d, body = %s", createResp.Code, createResp.Body.String())
+	}
+	var createBody struct {
+		User userManagementRecordResponse `json:"user"`
+	}
+	decodeUserManagementResponse(t, createResp, &createBody)
+	userID := createBody.User.ID
+
+	typeCases := []struct {
+		name      string
+		method    string
+		path      string
+		payload   string
+		wantField string
+		wantCode  string
+	}{
+		{name: "credits unlimited", method: http.MethodPost, path: "/users", payload: `{"username":"bad","credits_unlimited":"true"}`, wantField: "credits_unlimited", wantCode: userJSONFieldErrInvalidType},
+		{name: "timezone", method: http.MethodPost, path: "/users", payload: `{"username":"bad","timezone":1}`, wantField: "timezone", wantCode: cluster.PeriodLimitErrInvalidTimezone},
+		{name: "5h limit", method: http.MethodPatch, path: fmt.Sprintf("/users/%d", userID), payload: `{"limit_5h_credits":"5"}`, wantField: "limit_5h_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "5h mode", method: http.MethodPost, path: "/users", payload: `{"username":"bad","window_mode_5h":1}`, wantField: "window_mode_5h", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "1d limit", method: http.MethodPost, path: "/users", payload: `{"username":"bad","limit_1d_credits":"5"}`, wantField: "limit_1d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "1d mode", method: http.MethodPost, path: "/users", payload: `{"username":"bad","window_mode_1d":1}`, wantField: "window_mode_1d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "7d limit", method: http.MethodPost, path: "/users", payload: `{"username":"bad","limit_7d_credits":"5"}`, wantField: "limit_7d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "7d mode", method: http.MethodPost, path: "/users", payload: `{"username":"bad","window_mode_7d":1}`, wantField: "window_mode_7d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "week reset day", method: http.MethodPost, path: "/users", payload: `{"username":"bad","week_reset_day":"1"}`, wantField: "week_reset_day", wantCode: cluster.PeriodLimitErrInvalidWeekResetDay},
+		{name: "week reset hour", method: http.MethodPost, path: "/users", payload: `{"username":"bad","week_reset_hour":"0"}`, wantField: "week_reset_hour", wantCode: cluster.PeriodLimitErrInvalidWeekResetHour},
+		{name: "30d limit", method: http.MethodPost, path: "/users", payload: `{"username":"bad","limit_30d_credits":"5"}`, wantField: "limit_30d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "30d mode", method: http.MethodPost, path: "/users", payload: `{"username":"bad","window_mode_30d":1}`, wantField: "window_mode_30d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "reset windows", method: http.MethodPost, path: fmt.Sprintf("/users/%d/period-limits/reset", userID), payload: `{"windows":"5h"}`, wantField: "windows", wantCode: cluster.PeriodLimitErrInvalidResetWindows},
+		{name: "reset windows element", method: http.MethodPost, path: fmt.Sprintf("/users/%d/period-limits/reset", userID), payload: `{"windows":["5h",1]}`, wantField: "windows", wantCode: cluster.PeriodLimitErrInvalidResetWindows},
+		{name: "reset mode", method: http.MethodPost, path: fmt.Sprintf("/users/%d/period-limits/reset", userID), payload: `{"mode":1}`, wantField: "mode", wantCode: cluster.PeriodLimitErrInvalidResetMode},
+	}
+	for _, tc := range typeCases {
+		t.Run("type/"+tc.name, func(t *testing.T) {
+			assertUserManagementFieldError(t, engine, tc.method, tc.path, tc.payload, tc.wantField, tc.wantCode)
+		})
+	}
+
+	semanticCases := []struct {
+		name      string
+		path      string
+		payload   string
+		wantField string
+		wantCode  string
+	}{
+		{name: "timezone", path: "/users", payload: `{"username":"bad","timezone":"Mars/Olympus"}`, wantField: "timezone", wantCode: cluster.PeriodLimitErrInvalidTimezone},
+		{name: "5h limit", path: "/users", payload: `{"username":"bad","limit_5h_credits":-1}`, wantField: "limit_5h_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "1d limit", path: "/users", payload: `{"username":"bad","limit_1d_credits":-1}`, wantField: "limit_1d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "7d limit", path: "/users", payload: `{"username":"bad","limit_7d_credits":-1}`, wantField: "limit_7d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "30d limit", path: "/users", payload: `{"username":"bad","limit_30d_credits":-1}`, wantField: "limit_30d_credits", wantCode: cluster.PeriodLimitErrInvalidLimit},
+		{name: "5h mode", path: "/users", payload: `{"username":"bad","window_mode_5h":"calendar"}`, wantField: "window_mode_5h", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "1d mode", path: "/users", payload: `{"username":"bad","window_mode_1d":"bogus"}`, wantField: "window_mode_1d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "7d mode", path: "/users", payload: `{"username":"bad","window_mode_7d":"bogus"}`, wantField: "window_mode_7d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "30d mode", path: "/users", payload: `{"username":"bad","window_mode_30d":"bogus"}`, wantField: "window_mode_30d", wantCode: cluster.PeriodLimitErrInvalidWindowMode},
+		{name: "week reset day", path: "/users", payload: `{"username":"bad","week_reset_day":0}`, wantField: "week_reset_day", wantCode: cluster.PeriodLimitErrInvalidWeekResetDay},
+		{name: "week reset hour", path: "/users", payload: `{"username":"bad","week_reset_hour":24}`, wantField: "week_reset_hour", wantCode: cluster.PeriodLimitErrInvalidWeekResetHour},
+		{name: "reset windows", path: fmt.Sprintf("/users/%d/period-limits/reset", userID), payload: `{"windows":["2h"],"mode":"counter"}`, wantField: "windows", wantCode: cluster.PeriodLimitErrInvalidResetWindows},
+		{name: "reset mode", path: fmt.Sprintf("/users/%d/period-limits/reset", userID), payload: `{"windows":["5h"],"mode":"bogus"}`, wantField: "mode", wantCode: cluster.PeriodLimitErrInvalidResetMode},
+	}
+	for _, tc := range semanticCases {
+		t.Run("semantic/"+tc.name, func(t *testing.T) {
+			assertUserManagementFieldError(t, engine, http.MethodPost, tc.path, tc.payload, tc.wantField, tc.wantCode)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "create", path: "/users"},
+		{name: "reset", path: fmt.Sprintf("/users/%d/period-limits/reset", userID)},
+	} {
+		t.Run("malformed/"+tc.name, func(t *testing.T) {
+			malformedResp := performUserManagementRequest(t, engine, http.MethodPost, tc.path, `{"broken":`)
+			if malformedResp.Code != http.StatusBadRequest {
+				t.Fatalf("malformed status = %d, body = %s", malformedResp.Code, malformedResp.Body.String())
+			}
+			var malformed userManagementErrorResponse
+			decodeUserManagementResponse(t, malformedResp, &malformed)
+			if malformed.Error != "invalid body" || len(malformed.FieldErrors) != 0 {
+				t.Fatalf("malformed response = %+v, want generic invalid body", malformed)
+			}
+		})
+	}
+}
+
+func newUserManagementHTTPTestServer(t *testing.T) (*Handler, *gin.Engine, func()) {
+	t.Helper()
+	db, errOpen := cluster.OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	closeRepo := func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}
+	if errMigrate := cluster.AutoMigrate(db); errMigrate != nil {
+		closeRepo()
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	handler := NewHandler(cluster.NewRepository(db), nil, "127.0.0.1", 0)
+	engine := gin.New()
+	engine.GET("/users", handler.ListUsers)
+	engine.POST("/users", handler.CreateUser)
+	engine.GET("/users/:id", handler.GetUser)
+	engine.PATCH("/users/:id", handler.UpdateUser)
+	engine.GET("/users/:id/period-limits", handler.GetUserPeriodLimits)
+	engine.POST("/users/:id/period-limits/reset", handler.ResetUserPeriodLimits)
+	return handler, engine, closeRepo
+}
+
+func performUserManagementRequest(t *testing.T, engine *gin.Engine, method, path, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+	var body *strings.Reader
+	if payload == "" {
+		body = strings.NewReader("")
+	} else {
+		body = strings.NewReader(payload)
+	}
+	req := httptest.NewRequest(method, path, body)
+	if payload != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	engine.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeUserManagementResponse(t *testing.T, rec *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), target); errDecode != nil {
+		t.Fatalf("decode response %q: %v", rec.Body.String(), errDecode)
+	}
+}
+
+func assertUserManagementCreateRecord(t *testing.T, user userManagementRecordResponse) {
+	t.Helper()
+	if user.ID == 0 || user.Username != "alice" || !user.PasswordSet || user.Credits != 50 || !user.CreditsUnlimited {
+		t.Fatalf("create user = %+v", user)
+	}
+	if user.Timezone != "America/New_York" || user.Limit5hCredits == nil || *user.Limit5hCredits != 0 {
+		t.Fatalf("create timezone/5h = %q/%v", user.Timezone, user.Limit5hCredits)
+	}
+	if user.Limit1dCredits == nil || *user.Limit1dCredits != 12.5 || user.WindowMode1d != cluster.PeriodWindowModeCalendar {
+		t.Fatalf("create 1d = limit:%v mode:%q", user.Limit1dCredits, user.WindowMode1d)
+	}
+	if user.Limit7dCredits == nil || *user.Limit7dCredits != 25 || user.WeekResetDay != 7 || user.WeekResetHour != 6 {
+		t.Fatalf("create 7d = limit:%v day:%d hour:%d", user.Limit7dCredits, user.WeekResetDay, user.WeekResetHour)
+	}
+	if user.Limit30dCredits == nil || *user.Limit30dCredits != 100 || user.WindowMode30d != cluster.PeriodWindowModeFirstUse {
+		t.Fatalf("create 30d = limit:%v mode:%q", user.Limit30dCredits, user.WindowMode30d)
+	}
+	assertStringSlice(t, "create enabled_windows", user.PeriodLimitsBrief.EnabledWindows, []string{"5h", "1d", "7d", "30d"})
+	assertStringSlice(t, "create zero_limit_windows", user.PeriodLimitsBrief.ZeroLimitWindows, []string{"5h"})
+	assertUserManagementSecurityJSON(t, user)
+}
+
+func assertUserManagementSecurityJSON(t *testing.T, user userManagementRecordResponse) {
+	t.Helper()
+	var mfa struct {
+		Enabled bool `json:"enabled"`
+	}
+	if errMFA := json.Unmarshal(user.MFA, &mfa); errMFA != nil || !mfa.Enabled {
+		t.Fatalf("mfa = %s, error = %v", string(user.MFA), errMFA)
+	}
+	var passkeys []struct {
+		ID string `json:"id"`
+	}
+	if errPasskey := json.Unmarshal(user.Passkey, &passkeys); errPasskey != nil || len(passkeys) != 1 || passkeys[0].ID != "credential-1" {
+		t.Fatalf("passkey = %s, error = %v", string(user.Passkey), errPasskey)
+	}
+}
+
+func appendUserManagementCharge(t *testing.T, handler *Handler, apiKey, requestID string) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"timestamp":%q,"provider":"openai","model":"period-test-model","api_key":%q,"request_id":%q,"tokens":{"input_tokens":1,"total_tokens":1}}`, time.Now().UTC().Format(time.RFC3339Nano), apiKey, requestID)
+	if _, errUsage := handler.repo.AppendUsage(context.Background(), payload, "192.0.2.10"); errUsage != nil {
+		t.Fatalf("AppendUsage() error = %v", errUsage)
+	}
+}
+
+func userManagementWindow(t *testing.T, status cluster.UserPeriodLimitsStatus, id string) cluster.UserPeriodWindowStatus {
+	t.Helper()
+	for _, window := range status.Windows {
+		if window.ID == id {
+			return window
+		}
+	}
+	t.Fatalf("window %q not found in %+v", id, status.Windows)
+	return cluster.UserPeriodWindowStatus{}
+}
+
+func assertUserManagementWindowAmounts(t *testing.T, window cluster.UserPeriodWindowStatus, limit, used, remaining float64) {
+	t.Helper()
+	if !window.Enabled || window.Limit == nil || window.Remaining == nil || !floatEqual(*window.Limit, limit) || !floatEqual(window.Used, used) || !floatEqual(*window.Remaining, remaining) {
+		t.Fatalf("window amounts = %+v, want limit=%g used=%g remaining=%g", window, limit, used, remaining)
+	}
+}
+
+func floatEqual(left, right float64) bool {
+	return math.Abs(left-right) < 1e-9
+}
+
+func assertUserManagementFieldError(t *testing.T, engine *gin.Engine, method, path, payload, wantField, wantCode string) {
+	t.Helper()
+	rec := performUserManagementRequest(t, engine, method, path, payload)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var body userManagementErrorResponse
+	decodeUserManagementResponse(t, rec, &body)
+	if body.Error != "invalid body" || len(body.FieldErrors) != 1 {
+		t.Fatalf("error response = %+v", body)
+	}
+	if body.FieldErrors[0].Field != wantField || body.FieldErrors[0].Code != wantCode {
+		t.Fatalf("field error = %+v, want %s/%s", body.FieldErrors[0], wantField, wantCode)
+	}
+}
+
+func assertStringSlice(t *testing.T, label string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
+	}
+}

--- a/internal/cluster/management/users_test.go
+++ b/internal/cluster/management/users_test.go
@@ -2,8 +2,12 @@ package management
 
 import (
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -115,5 +119,105 @@ func TestUserRecordToMapIncludesPeriodLimitFields(t *testing.T) {
 	}
 	if item["credits_unlimited"] != true {
 		t.Fatalf("credits_unlimited = %v, want true", item["credits_unlimited"])
+	}
+}
+
+func TestUserRecordToMapIncludesPeriodLimitsSummary(t *testing.T) {
+	t.Parallel()
+
+	limit5h := 0.0
+	limit1d := 25.5
+	item := userRecordToMap(&cluster.UserRecord{
+		Username:       "alice",
+		Limit5hCredits: &limit5h,
+		Limit1dCredits: &limit1d,
+	})
+	summary, ok := item["period_limits_summary"].(gin.H)
+	if !ok {
+		t.Fatalf("period_limits_summary missing or wrong type: %#v", item["period_limits_summary"])
+	}
+	enabled, ok := summary["enabled_windows"].([]string)
+	if !ok || len(enabled) != 2 || enabled[0] != "5h" || enabled[1] != "1d" {
+		t.Fatalf("enabled_windows = %#v, want [5h 1d]", summary["enabled_windows"])
+	}
+	zero, ok := summary["zero_limit_windows"].([]string)
+	if !ok || len(zero) != 1 || zero[0] != "5h" {
+		t.Fatalf("zero_limit_windows = %#v, want [5h]", summary["zero_limit_windows"])
+	}
+
+	empty := userRecordToMap(&cluster.UserRecord{Username: "bob"})["period_limits_summary"].(gin.H)
+	if got := len(empty["enabled_windows"].([]string)); got != 0 {
+		t.Fatalf("enabled_windows = %d entries, want 0", got)
+	}
+	if got := len(empty["zero_limit_windows"].([]string)); got != 0 {
+		t.Fatalf("zero_limit_windows = %d entries, want 0", got)
+	}
+}
+
+func TestRespondUserPeriodLimitValidationErrorWritesFieldErrors(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/users", nil)
+
+	validationErr := cluster.PeriodLimitConfigError{
+		Message: "timezone: invalid timezone \"Mars/Olympus\"",
+		Field:   "timezone",
+		Code:    cluster.PeriodLimitErrInvalidTimezone,
+	}
+	if !respondUserPeriodLimitValidationError(ginCtx, validationErr) {
+		t.Fatal("respondUserPeriodLimitValidationError() = false, want true")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if payload["error"] != "invalid body" {
+		t.Fatalf("error = %v, want invalid body", payload["error"])
+	}
+	fieldErrors, ok := payload["field_errors"].([]any)
+	if !ok || len(fieldErrors) != 1 {
+		t.Fatalf("field_errors = %#v, want one entry", payload["field_errors"])
+	}
+	entry, ok := fieldErrors[0].(map[string]any)
+	if !ok {
+		t.Fatalf("field_errors[0] = %#v, want object", fieldErrors[0])
+	}
+	if entry["field"] != "timezone" || entry["code"] != cluster.PeriodLimitErrInvalidTimezone {
+		t.Fatalf("field_errors[0] = %#v", entry)
+	}
+
+	if respondUserPeriodLimitValidationError(ginCtx, errors.New("boom")) {
+		t.Fatal("respondUserPeriodLimitValidationError() = true for non-validation error")
+	}
+}
+
+func TestGetCapabilitiesDeclaresUserDomain(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/capabilities", nil)
+
+	handler := &Handler{}
+	handler.GetCapabilities(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var payload struct {
+		Capabilities map[string]bool `json:"capabilities"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	for _, key := range []string{"users", "access_groups", "user_period_limits"} {
+		if !payload.Capabilities[key] {
+			t.Fatalf("capabilities[%q] missing or false", key)
+		}
 	}
 }

--- a/internal/cluster/user_period_limit.go
+++ b/internal/cluster/user_period_limit.go
@@ -47,9 +47,27 @@ const (
 
 // OptionalFloatUpdate captures a three-state float patch: absent / null / value.
 
+// Stable machine-readable codes for period-limit validation failures. The
+// Management API surfaces them in field_errors so clients can localize and
+// anchor errors without parsing message strings.
+const (
+	PeriodLimitErrInvalidLimit         = "invalid_limit"
+	PeriodLimitErrInvalidWindowMode    = "invalid_window_mode"
+	PeriodLimitErrInvalidTimezone      = "invalid_timezone"
+	PeriodLimitErrInvalidWeekResetDay  = "invalid_week_reset_day"
+	PeriodLimitErrInvalidWeekResetHour = "invalid_week_reset_hour"
+	PeriodLimitErrInvalidResetMode     = "invalid_reset_mode"
+	PeriodLimitErrInvalidResetWindows  = "invalid_reset_windows"
+)
+
 // PeriodLimitConfigError is returned for invalid period-limit configuration inputs.
 type PeriodLimitConfigError struct {
 	Message string
+	// Field is the Management API field that failed validation (for example
+	// "limit_5h_credits" or "timezone"). Empty when not field-specific.
+	Field string
+	// Code is one of the PeriodLimitErr* constants. Empty for legacy errors.
+	Code string
 }
 
 func (e PeriodLimitConfigError) Error() string {
@@ -61,6 +79,12 @@ func (e PeriodLimitConfigError) Error() string {
 
 func periodLimitConfigErrorf(format string, args ...any) error {
 	return PeriodLimitConfigError{Message: fmt.Sprintf(format, args...)}
+}
+
+// periodLimitFieldError keeps the historic message text while attaching the
+// stable field/code pair exposed through the Management API.
+func periodLimitFieldError(field, code, message string) error {
+	return PeriodLimitConfigError{Message: message, Field: field, Code: code}
 }
 
 type OptionalFloatUpdate struct {
@@ -707,7 +731,7 @@ func (r *Repository) ResetUserPeriodLimits(ctx context.Context, userID uint, win
 		mode = PeriodResetModeCounter
 	}
 	if mode != PeriodResetModeCounter && mode != PeriodResetModeWindowOnly {
-		return UserPeriodLimitResetResult{}, periodLimitConfigErrorf("reset mode must be %q or %q", PeriodResetModeCounter, PeriodResetModeWindowOnly)
+		return UserPeriodLimitResetResult{}, periodLimitFieldError("mode", PeriodLimitErrInvalidResetMode, fmt.Sprintf("reset mode must be %q or %q", PeriodResetModeCounter, PeriodResetModeWindowOnly))
 	}
 	now = now.UTC()
 
@@ -820,7 +844,7 @@ func normalizeResetWindows(windows []string) ([]string, error) {
 		case "":
 			continue
 		default:
-			return nil, periodLimitConfigErrorf("unknown period window %q", raw)
+			return nil, periodLimitFieldError("windows", PeriodLimitErrInvalidResetWindows, fmt.Sprintf("unknown period window %q", raw))
 		}
 	}
 	return out, nil

--- a/internal/cluster/user_period_limit.go
+++ b/internal/cluster/user_period_limit.go
@@ -750,14 +750,7 @@ func (r *Repository) ResetUserPeriodLimits(ctx context.Context, userID uint, win
 
 		target := normalized
 		if len(target) == 0 {
-			for _, id := range []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d} {
-				if userLimitForWindow(user, id) != nil || userWindowStart(user, id) != nil {
-					target = append(target, id)
-				}
-			}
-			if len(target) == 0 {
-				target = []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d}
-			}
+			target = []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d}
 		}
 
 		updates := map[string]any{}
@@ -786,6 +779,9 @@ func (r *Repository) ResetUserPeriodLimits(ctx context.Context, userID uint, win
 				return errUpdate
 			}
 		}
+		// Reload into a zero-value record so database NULLs clear pointer fields
+		// retained in the locked pre-update snapshot.
+		user = &UserRecord{}
 		if errReload := tx.Where("id = ?", userID).First(user).Error; errReload != nil {
 			return errReload
 		}
@@ -806,24 +802,6 @@ func (r *Repository) ResetUserPeriodLimits(ctx context.Context, userID uint, win
 		return UserPeriodLimitResetResult{}, errTx
 	}
 	return result, nil
-}
-
-func userLimitForWindow(user *UserRecord, id string) *float64 {
-	if user == nil {
-		return nil
-	}
-	switch id {
-	case PeriodWindow5h:
-		return user.Limit5hCredits
-	case PeriodWindow1d:
-		return user.Limit1dCredits
-	case PeriodWindow7d:
-		return user.Limit7dCredits
-	case PeriodWindow30d:
-		return user.Limit30dCredits
-	default:
-		return nil
-	}
 }
 
 func normalizeResetWindows(windows []string) ([]string, error) {

--- a/internal/cluster/user_period_limit_test.go
+++ b/internal/cluster/user_period_limit_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -482,5 +483,93 @@ func TestWindowOnlyResetClearsSlidingUsage(t *testing.T) {
 	}
 	if _, _, errDispatch := repo.AllowedDispatchIDsForAPIKey(ctx, key); errDispatch != nil {
 		t.Fatalf("dispatch after window_only sliding reset error = %v", errDispatch)
+	}
+}
+
+func TestApplyUserPeriodLimitUpdateAttachesFieldAndCode(t *testing.T) {
+	t.Parallel()
+
+	badTimezone := "Mars/Olympus"
+	badMode := "calendar"
+	badHour := 24
+	tests := []struct {
+		name      string
+		update    UserUpdate
+		wantField string
+		wantCode  string
+	}{
+		{
+			name:      "timezone",
+			update:    UserUpdate{Timezone: &badTimezone},
+			wantField: "timezone",
+			wantCode:  PeriodLimitErrInvalidTimezone,
+		},
+		{
+			name:      "calendar rejected for 5h window",
+			update:    UserUpdate{WindowMode5h: &badMode},
+			wantField: "window_mode_5h",
+			wantCode:  PeriodLimitErrInvalidWindowMode,
+		},
+		{
+			name:      "negative limit",
+			update:    UserUpdate{Limit1dCredits: OptionalFloatUpdate{Set: true, Value: -1}},
+			wantField: "limit_1d_credits",
+			wantCode:  PeriodLimitErrInvalidLimit,
+		},
+		{
+			name:      "week reset hour out of range",
+			update:    UserUpdate{WeekResetHour: &badHour},
+			wantField: "week_reset_hour",
+			wantCode:  PeriodLimitErrInvalidWeekResetHour,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			record := &UserRecord{}
+			err := applyUserPeriodLimitUpdate(record, tc.update)
+			if err == nil {
+				t.Fatal("applyUserPeriodLimitUpdate() error = nil, want validation error")
+			}
+			var configErr PeriodLimitConfigError
+			if !errors.As(err, &configErr) {
+				t.Fatalf("error type = %T, want PeriodLimitConfigError", err)
+			}
+			if configErr.Field != tc.wantField || configErr.Code != tc.wantCode {
+				t.Fatalf("field/code = %q/%q, want %q/%q", configErr.Field, configErr.Code, tc.wantField, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestResetUserPeriodLimitsAttachesFieldAndCode(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-reset-field-errors", 100)
+
+	if _, err := repo.ResetUserPeriodLimits(ctx, user.ID, nil, "bogus", time.Now().UTC()); err != nil {
+		var configErr PeriodLimitConfigError
+		if !errors.As(err, &configErr) {
+			t.Fatalf("reset mode error type = %T, want PeriodLimitConfigError", err)
+		}
+		if configErr.Field != "mode" || configErr.Code != PeriodLimitErrInvalidResetMode {
+			t.Fatalf("field/code = %q/%q, want mode/%q", configErr.Field, configErr.Code, PeriodLimitErrInvalidResetMode)
+		}
+	} else {
+		t.Fatal("ResetUserPeriodLimits() error = nil, want invalid mode error")
+	}
+
+	if _, err := repo.ResetUserPeriodLimits(ctx, user.ID, []string{"2h"}, PeriodResetModeCounter, time.Now().UTC()); err != nil {
+		var configErr PeriodLimitConfigError
+		if !errors.As(err, &configErr) {
+			t.Fatalf("reset windows error type = %T, want PeriodLimitConfigError", err)
+		}
+		if configErr.Field != "windows" || configErr.Code != PeriodLimitErrInvalidResetWindows {
+			t.Fatalf("field/code = %q/%q, want windows/%q", configErr.Field, configErr.Code, PeriodLimitErrInvalidResetWindows)
+		}
+	} else {
+		t.Fatal("ResetUserPeriodLimits() error = nil, want unknown window error")
 	}
 }

--- a/internal/cluster/user_period_limit_test.go
+++ b/internal/cluster/user_period_limit_test.go
@@ -573,3 +573,47 @@ func TestResetUserPeriodLimitsAttachesFieldAndCode(t *testing.T) {
 		t.Fatal("ResetUserPeriodLimits() error = nil, want unknown window error")
 	}
 }
+
+func TestResetUserPeriodLimitsEmptyWindowsTargetsAllWindows(t *testing.T) {
+	t.Parallel()
+	repo, ctx, closeRepo := newPeriodLimitTestRepo(t)
+	defer closeRepo()
+
+	user := createPeriodLimitUser(t, repo, ctx, "u-reset-all-windows", 100)
+	limit := 5.0
+	if _, errUpdate := repo.UpdateUser(ctx, user.ID, UserUpdate{
+		Limit5hCredits: OptionalFloatUpdate{Set: true, Value: limit},
+	}); errUpdate != nil {
+		t.Fatalf("UpdateUser() error = %v", errUpdate)
+	}
+
+	now := time.Now().UTC()
+	result, errReset := repo.ResetUserPeriodLimits(ctx, user.ID, nil, PeriodResetModeCounter, now)
+	if errReset != nil {
+		t.Fatalf("ResetUserPeriodLimits() error = %v", errReset)
+	}
+	wantWindows := []string{PeriodWindow5h, PeriodWindow1d, PeriodWindow7d, PeriodWindow30d}
+	if len(result.Windows) != len(wantWindows) {
+		t.Fatalf("reset windows = %v, want %v", result.Windows, wantWindows)
+	}
+	for index, want := range wantWindows {
+		if result.Windows[index] != want {
+			t.Fatalf("reset windows = %v, want %v", result.Windows, wantWindows)
+		}
+	}
+
+	reloaded, errGet := repo.GetUser(ctx, user.ID)
+	if errGet != nil {
+		t.Fatalf("GetUser() error = %v", errGet)
+	}
+	for field, epoch := range map[string]*time.Time{
+		"usage_epoch_5h":  reloaded.UsageEpoch5h,
+		"usage_epoch_1d":  reloaded.UsageEpoch1d,
+		"usage_epoch_7d":  reloaded.UsageEpoch7d,
+		"usage_epoch_30d": reloaded.UsageEpoch30d,
+	} {
+		if epoch == nil || !epoch.Equal(now) {
+			t.Fatalf("%s = %v, want %v", field, epoch, now)
+		}
+	}
+}

--- a/internal/cluster/users.go
+++ b/internal/cluster/users.go
@@ -344,61 +344,61 @@ func applyUserPeriodLimitUpdate(record *UserRecord, update UserUpdate) error {
 	if update.Timezone != nil {
 		timezone, errTZ := normalizeUserTimezone(*update.Timezone)
 		if errTZ != nil {
-			return errTZ
+			return periodLimitFieldError("timezone", PeriodLimitErrInvalidTimezone, errTZ.Error())
 		}
 		record.Timezone = timezone
 	}
 	if errLimit := applyOptionalFloat(update.Limit5hCredits, &record.Limit5hCredits); errLimit != nil {
-		return fmt.Errorf("limit_5h_credits: %w", errLimit)
+		return periodLimitFieldError("limit_5h_credits", PeriodLimitErrInvalidLimit, fmt.Sprintf("limit_5h_credits: %s", errLimit.Error()))
 	}
 	if update.WindowMode5h != nil {
 		mode, errMode := normalizePeriodWindowMode(*update.WindowMode5h, false)
 		if errMode != nil {
-			return fmt.Errorf("window_mode_5h: %w", errMode)
+			return periodLimitFieldError("window_mode_5h", PeriodLimitErrInvalidWindowMode, fmt.Sprintf("window_mode_5h: %s", errMode.Error()))
 		}
 		record.WindowMode5h = mode
 	}
 	if errLimit := applyOptionalFloat(update.Limit1dCredits, &record.Limit1dCredits); errLimit != nil {
-		return fmt.Errorf("limit_1d_credits: %w", errLimit)
+		return periodLimitFieldError("limit_1d_credits", PeriodLimitErrInvalidLimit, fmt.Sprintf("limit_1d_credits: %s", errLimit.Error()))
 	}
 	if update.WindowMode1d != nil {
 		mode, errMode := normalizePeriodWindowMode(*update.WindowMode1d, true)
 		if errMode != nil {
-			return fmt.Errorf("window_mode_1d: %w", errMode)
+			return periodLimitFieldError("window_mode_1d", PeriodLimitErrInvalidWindowMode, fmt.Sprintf("window_mode_1d: %s", errMode.Error()))
 		}
 		record.WindowMode1d = mode
 	}
 	if errLimit := applyOptionalFloat(update.Limit7dCredits, &record.Limit7dCredits); errLimit != nil {
-		return fmt.Errorf("limit_7d_credits: %w", errLimit)
+		return periodLimitFieldError("limit_7d_credits", PeriodLimitErrInvalidLimit, fmt.Sprintf("limit_7d_credits: %s", errLimit.Error()))
 	}
 	if update.WindowMode7d != nil {
 		mode, errMode := normalizePeriodWindowMode(*update.WindowMode7d, true)
 		if errMode != nil {
-			return fmt.Errorf("window_mode_7d: %w", errMode)
+			return periodLimitFieldError("window_mode_7d", PeriodLimitErrInvalidWindowMode, fmt.Sprintf("window_mode_7d: %s", errMode.Error()))
 		}
 		record.WindowMode7d = mode
 	}
 	if update.WeekResetDay != nil {
 		day, errDay := normalizeWeekResetDay(*update.WeekResetDay)
 		if errDay != nil {
-			return errDay
+			return periodLimitFieldError("week_reset_day", PeriodLimitErrInvalidWeekResetDay, errDay.Error())
 		}
 		record.WeekResetDay = day
 	}
 	if update.WeekResetHour != nil {
 		hour, errHour := normalizeWeekResetHour(*update.WeekResetHour)
 		if errHour != nil {
-			return errHour
+			return periodLimitFieldError("week_reset_hour", PeriodLimitErrInvalidWeekResetHour, errHour.Error())
 		}
 		record.WeekResetHour = hour
 	}
 	if errLimit := applyOptionalFloat(update.Limit30dCredits, &record.Limit30dCredits); errLimit != nil {
-		return fmt.Errorf("limit_30d_credits: %w", errLimit)
+		return periodLimitFieldError("limit_30d_credits", PeriodLimitErrInvalidLimit, fmt.Sprintf("limit_30d_credits: %s", errLimit.Error()))
 	}
 	if update.WindowMode30d != nil {
 		mode, errMode := normalizePeriodWindowMode(*update.WindowMode30d, true)
 		if errMode != nil {
-			return fmt.Errorf("window_mode_30d: %w", errMode)
+			return periodLimitFieldError("window_mode_30d", PeriodLimitErrInvalidWindowMode, fmt.Sprintf("window_mode_30d: %s", errMode.Error()))
 		}
 		record.WindowMode30d = mode
 	}


### PR DESCRIPTION
## Summary

- add stable `field_errors` for user period-limit semantic validation and identifiable JSON type errors while preserving the existing error envelope
- expose `period_limits_summary` on user records so list views can identify enabled and zero-limit windows without additional usage queries
- advertise `users`, `access_groups`, and `user_period_limits` through `GET /capabilities`
- make empty, omitted, or `null` reset `windows` consistently target `5h`, `1d`, `7d`, and `30d`
- return a fresh, complete post-reset `limits` state without stale active-window data
- update the English and Chinese Management API documentation
- add comprehensive repository and HTTP contract tests

## API contract

- structurally valid requests with identifiable field errors return stable `{field, code}` entries in `field_errors`
- malformed JSON continues to return `400 invalid body` and may omit `field_errors`
- partial user updates preserve unrelated fields and distinguish disabled (`null`) limits from enabled zero-value limits
- reset responses contain the complete post-reset period-limit status
- no database migration is required

## Testing

- `go test ./internal/cluster ./internal/cluster/management`
- `go test ./...`
- `go build -o test-output ./cmd/home && rm test-output`