### PR TITLE
feat(quota): add upstream workbench quota capabilities

### DIFF
--- a/cmd/home/main.go
+++ b/cmd/home/main.go
@@ -395,6 +395,7 @@ func run() int {
 			NodePort:         clusterAdvertisedPort,
 			HeartbeatTimeout: nodeCfg.HeartbeatTimeout,
 			ForwardTLSConfig: clusterTLSConfig,
+			QuotaRecollect:   quotaCollector,
 		}))
 	}
 	mgmtBuild, errMgmt := managementhttp.Build(cfgPath, mgmtOpts...)

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -107,6 +107,7 @@ The table below is extracted from the final Home route registry built by `intern
 | `GET` | `/capabilities` |
 | `GET` | `/quota/credentials` |
 | `GET` | `/quota/credentials/:credential_id` |
+| `POST` | `/quota/collect` |
 | `DELETE` | `/api-keys` |
 | `GET` | `/api-keys` |
 | `PATCH` | `/api-keys` |
@@ -2580,6 +2581,7 @@ Response fields:
 | `capabilities.usage` | boolean | Whether the legacy `GET /api-key-usage` capability is available. |
 | `capabilities.quota_snapshots` | boolean | Whether the DB-backed `GET /quota/credentials` snapshot list is available. |
 | `capabilities.quota_snapshot_details` | boolean | Whether `GET /quota/credentials/:credential_id` is available. |
+| `capabilities.quota_recollect` | boolean | Whether `POST /quota/collect` on-demand collection is available. |
 | `capabilities.usage_overview` | boolean | Whether `GET /usage/overview` is available. |
 | `capabilities.usage_records` | boolean | Whether `GET /usage/records` is available. |
 | `capabilities.usage_record_details` | boolean | Whether `GET /usage/records/:id` is available. |
@@ -2612,7 +2614,7 @@ All timestamps are RFC3339 UTC values or `null`. Ratios are numbers in `[0,1]`. 
 
 Current passive collection extracts a bounded `quota_headers` object from the CPA usage event `response_headers`. Home preserves only the Codex `X-Codex-*` quota allowlist plus a syntax-validated, non-secret-like upstream request ID, and removes the raw `response_headers` object before writing the usage payload. The reported `auth_index` is resolved against the active auth UUID, runtime index, and ID before the snapshot is stored under the stable UUID. Codex Header observations are normalized and upserted in the same database transaction as the usage record; invalid quota metadata is isolated so it cannot roll back the core usage or billing write. Timestamps more than five minutes ahead of Home's receive time are normalized to the receive time. Older observations cannot replace a newer snapshot or window, including concurrent first writes. A newer Header observation invalidates an in-flight active-probe lease. Partial Header updates retain only still-valid older windows; expired windows cannot make a new snapshot appear healthy or exhausted.
 
-Home also runs fixed-target active collectors for Claude, Antigravity, Codex, Kimi, and xAI OAuth/file credentials. Codex reads the official usage endpoint; Claude reads usage and profile, reporting `partial` when quota succeeds but profile metadata fails; Antigravity tries its fixed backend candidates with the credential `project_id`; Kimi reads coding usage and preserves both the account usage summary and each returned limit window while accepting numeric fields encoded as numbers or strings; xAI reads billing and converts provider cents into explicit USD currency values. Provider API-key credentials that cannot use these OAuth collectors are returned as `unsupported`.
+Home also runs fixed-target active collectors for Claude, Antigravity, Codex, Kimi, and xAI OAuth/file credentials. Codex reads the official usage endpoint; Claude reads usage and profile, reporting `partial` when quota succeeds but profile metadata fails; Antigravity tries its fixed backend candidates with the credential `project_id`; Kimi reads coding usage and preserves both the account usage summary and each returned limit window while accepting numeric fields encoded as numbers or strings. Kimi provider limits take primary-window priority over its aggregate summary so weekly and duration limits remain visible in list views. xAI calls the Grok CLI billing endpoint with the CLI token-auth, client-version, user-agent, and optional user-ID headers. It accepts camelCase or snake_case billing fields and `{ "val": ... }`, numeric, or string cent values. `monthlyLimit=15000` maps to SuperGrok and `monthlyLimit=150000` maps to SuperGrok Heavy. Positive `onDemandCap` plus explicit or derived `onDemandUsed` values produce the `xai-on-demand` monthly USD window; a missing or zero cap means pay-as-you-go is disabled and no such window is emitted. Provider API-key credentials that cannot use these OAuth collectors are returned as `unsupported`.
 
 Collectors read DB credentials directly and never accept a URL from HMC. Before probing, they resolve the latest DB credential and refresh OAuth state when the runtime refresh policy says it is due. They use the current hot-reloaded global proxy unless the credential has its own proxy. They use a 20-second request timeout, a per-provider concurrency limit of 3 on PostgreSQL and a global limit of 1 on SQLite, a per-credential DB lease, and a five-minute exponential retry backoff with per-credential jitter capped near one hour. `Retry-After` can extend the next attempt. Disabled credentials and credentials whose retry deadline is still in the future are not actively probed; persisted unavailable/error state no longer blocks recovery after that deadline. Successful snapshots are fresh for 30 minutes. Failures preserve last-known windows and store only structured, redacted error metadata.
 
@@ -2639,6 +2641,7 @@ Credential fields:
 | `window_count` | integer | Number of all current windows. |
 | `error` | object/null | Redacted collection error. Messages are capped at 500 bytes. |
 | `runtime` | object/null | Home and CPA ownership metadata. |
+| `plan` | object/null | Provider subscription plan metadata derived by the collector (for example xAI monthly billing limits). Shape: `{"name": "SuperGrok", "premium": false}`. A successful authoritative probe clears an older plan when the current payload no longer maps to one. |
 
 Quota window fields:
 
@@ -2668,6 +2671,7 @@ Returns filtered, paginated current credential snapshots.
 | `limit` | integer | `50` | Page size from 1 to 200. |
 | `offset` | integer | `0` | Non-negative result offset. |
 | `search` | string | none | Case-insensitive contains match over label, account, project, auth index, and provider. |
+| `ids` | string/CSV | none | One or more exact, case-sensitive credential IDs for direct batch joins. ID-filtered reads load quota windows only for the requested credentials while `global_summary` remains unfiltered. |
 | `provider` | string/CSV | none | One or more provider IDs. |
 | `quota_status` | string/CSV | none | One or more quota statuses. |
 | `freshness` | string/CSV | none | `fresh`, `stale`, or `never`. |
@@ -2755,6 +2759,29 @@ Returns the same credential core object, every current window in stable order, c
   "generated_at": "2026-07-16T01:01:00Z"
 }
 ```
+
+### POST `/quota/collect`
+
+Starts an asynchronous on-demand quota collection round and returns how many credentials were accepted into the local collector queue. This is the only quota endpoint that is not read-only. On-demand jobs share the same process-wide provider concurrency controls as scheduled collection and are deduplicated per credential while queued or running.
+
+Request body (all fields optional; an empty body collects every eligible credential):
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `credential_ids` | string array | Only these credential IDs are collected. |
+| `providers` | string array | Only these providers are collected: `claude`, `antigravity`, `codex`, `kimi`, `xai`; `grok` is accepted as an alias for `xai`. Other values return `400`. Both filters combine with AND semantics. |
+
+Response `202`:
+
+```json
+{
+  "accepted": 2,
+  "running": true
+}
+```
+
+`accepted` counts eligible credentials newly queued by this request. Disabled, execution-cooldown, collector-unsupported, and already queued/running local credentials are skipped. When a queued job reaches a concurrency slot it force-claims the DB probe lease: an active lease is still respected, but snapshot freshness, `next_probe_at`, and quota retry backoff do not suppress the requested attempt. The collection round runs in the background; read updated snapshots through `GET /quota/credentials` after it finishes. When the runtime has no quota collector wired, the route returns `404` with `QUOTA_RECOLLECT_UNSUPPORTED` and `capabilities.quota_recollect` is `false`.
+
 
 Quota endpoint validation errors use:
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -107,6 +107,7 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `GET` | `/capabilities` |
 | `GET` | `/quota/credentials` |
 | `GET` | `/quota/credentials/:credential_id` |
+| `POST` | `/quota/collect` |
 | `DELETE` | `/api-keys` |
 | `GET` | `/api-keys` |
 | `PATCH` | `/api-keys` |
@@ -2580,6 +2581,7 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 | `capabilities.usage` | boolean | 是否支持旧版 `GET /api-key-usage` 能力。 |
 | `capabilities.quota_snapshots` | boolean | 是否支持 DB-backed `GET /quota/credentials` 额度快照列表。 |
 | `capabilities.quota_snapshot_details` | boolean | 是否支持 `GET /quota/credentials/:credential_id`。 |
+| `capabilities.quota_recollect` | boolean | 是否支持 `POST /quota/collect` 按需额度采集。 |
 | `capabilities.usage_overview` | boolean | 是否支持 `GET /usage/overview`。 |
 | `capabilities.usage_records` | boolean | 是否支持 `GET /usage/records`。 |
 | `capabilities.usage_record_details` | boolean | 是否支持 `GET /usage/records/:id`。 |
@@ -2612,7 +2614,7 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 
 当前被动采集从 CPA usage 事件的 `response_headers` 中提取受限 `quota_headers`。Home 只保留 Codex `X-Codex-*` 额度 Header allowlist，以及通过语法校验且不具有 secret 特征的 upstream request ID，并在 usage payload 入库前删除 raw `response_headers`。入库前会按 active auth UUID、runtime index、ID 依次解析上报的 `auth_index`，快照始终使用稳定 UUID。Codex Header 观测与 usage record 在同一事务中归一化并 upsert；非法额度元数据会被隔离，不能回滚核心 usage 或 billing 写入。比 Home 接收时间超前五分钟以上的时间戳会归一化为接收时间。迟到事件不能覆盖更新快照，首次并发写入也遵守该规则。更新的 Header 观测会使正在运行的主动探测租约失效；部分 Header 更新只保留仍有效的旧窗口，已过期窗口不会参与新快照状态汇总。
 
-Home 同时为 Claude、Antigravity、Codex、Kimi、xAI 的 OAuth/file credential 运行固定目标主动 collector。Codex 读取官方 usage endpoint；Claude 查询 usage 和 profile，额度成功但 profile 元数据失败时返回 `partial`；Antigravity 携带 credential `project_id` 按固定候选端点顺序尝试；Kimi 查询 coding usage，保留账号 usage 汇总和每个 limit 窗口，并兼容数字或字符串形式的数值字段；xAI 查询 billing，并把 Provider cents 转成显式 USD currency 数值。无法使用这些 OAuth collector 的 Provider API-key credential 返回 `unsupported`。
+Home 同时为 Claude、Antigravity、Codex、Kimi、xAI 的 OAuth/file credential 运行固定目标主动 collector。Codex 读取官方 usage endpoint；Claude 查询 usage 和 profile，额度成功但 profile 元数据失败时返回 `partial`；Antigravity 携带 credential `project_id` 按固定候选端点顺序尝试；Kimi 查询 coding usage，保留账号 usage 汇总和每个 limit 窗口，并兼容数字或字符串形式的数值字段。Kimi 的 Provider limit 优先进入 `primary_windows`，避免聚合 summary 挤掉周限额或 duration 限额。xAI 使用 Grok CLI token-auth、client-version、user-agent 及可选 user-ID Header 请求 billing endpoint；支持 camelCase/snake_case 字段，以及 `{ "val": ... }`、数字或字符串 cents。`monthlyLimit=15000` 推导为 SuperGrok，`monthlyLimit=150000` 推导为 SuperGrok Heavy；正数 `onDemandCap` 配合显式或推导出的 `onDemandUsed` 生成 `xai-on-demand` 月度 USD 窗口，cap 缺失或为 0 表示未启用按量付费，不输出该窗口。无法使用这些 OAuth collector 的 Provider API-key credential 返回 `unsupported`。
 
 collector 直接读取 DB 凭证，不接受 HMC 提交 URL。探测前会重新解析最新 DB 凭证，并在 runtime 刷新策略判定到期时刷新 OAuth 状态；全局代理使用热更新后的当前配置，凭证级代理仍优先。统一使用 20 秒 timeout、PostgreSQL 下每个 Provider 并发上限 3（SQLite 下全局为 1）、单凭证 DB 租约，以及从 5 分钟开始、带凭证级 jitter、约 1 小时封顶的指数退避；`Retry-After` 可延后下次尝试。禁用凭证以及 retry deadline 仍在未来的凭证不会被主动探测；deadline 过期后，持久化的 unavailable/error 状态不再永久阻止恢复探测。成功快照默认 30 分钟有效。探测失败时保留最后已知窗口，只写结构化脱敏错误。
 
@@ -2639,6 +2641,7 @@ collector 直接读取 DB 凭证，不接受 HMC 提交 URL。探测前会重新
 | `window_count` | integer | 全部当前窗口数。 |
 | `error` | object/null | 已脱敏采集错误，message 最多 500 bytes。 |
 | `runtime` | object/null | Home 和 CPA 归属元数据。 |
+| `plan` | object/null | collector 推导的 Provider 订阅套餐元数据(如 xAI 月度 billing limit)。形状:`{"name": "SuperGrok", "premium": false}`。权威主动探测成功后，如果当前 payload 不再映射到套餐，会清除旧值。 |
 
 额度窗口包含稳定 `id`、可选 `label/scope_id/currency`、`scope`、`mode`、窗口 `status`、显式 `unit`、可空 `used/remaining/limit`、`[0,1]` 比例、`is_unlimited`、可空 `reset_at/window_seconds`、结构化 `period_unit/period_value`、`source` 和实际 `observed_at`。`period_unit` 可为 `minute`、`hour`、`day`、`week`、`month` 或 `unknown`；已知周期的 `period_value` 必须为正数，`unknown` 时为 `null`。
 
@@ -2651,6 +2654,7 @@ collector 直接读取 DB 凭证，不接受 HMC 提交 URL。探测前会重新
 | `limit` | integer | `50` | 1 到 200。 |
 | `offset` | integer | `0` | 非负偏移。 |
 | `search` | string | 无 | 对 label、account、project、auth index 和 provider 做不区分大小写包含匹配。 |
+| `ids` | string/CSV | 无 | 一个或多个大小写敏感的精确 credential ID，用于直接批量 join。带 IDs 的读取只加载目标凭证的 quota windows，`global_summary` 仍保持全局未筛选语义。 |
 | `provider` | string/CSV | 无 | 一个或多个 Provider。 |
 | `quota_status` | string/CSV | 无 | 一个或多个额度状态。 |
 | `freshness` | string/CSV | 无 | `fresh`、`stale`、`never`。 |
@@ -2738,6 +2742,29 @@ collector 直接读取 DB 凭证，不接受 HMC 提交 URL。探测前会重新
   "generated_at": "2026-07-16T01:01:00Z"
 }
 ```
+
+### POST `/quota/collect`
+
+启动一轮异步按需额度采集，返回进入本地 collector 队列的凭证数量。这是唯一非只读的额度端点。按需任务与定时采集共享进程级 Provider 并发限制；同一凭证在本地排队或执行期间会去重。
+
+请求体(所有字段可选;空 body 采集全部符合条件的凭证):
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `credential_ids` | string array | 仅采集这些 credential ID。 |
+| `providers` | string array | 仅采集这些 provider：`claude`、`antigravity`、`codex`、`kimi`、`xai`；`grok` 作为 `xai` alias 接受。其他值返回 `400`。两个过滤条件按 AND 语义组合。 |
+
+响应 `202`:
+
+```json
+{
+  "accepted": 2,
+  "running": true
+}
+```
+
+`accepted` 统计本次新进入队列的符合条件凭证数。disabled、执行 cooldown、collector 不支持，以及已在本地排队/执行的凭证会跳过。任务取得并发槽后会强制申请 DB probe lease：已有未过期 lease 仍优先，但 snapshot freshness、`next_probe_at` 和额度 retry backoff 不会阻止这次人工请求。采集在后台运行；完成后通过 `GET /quota/credentials` 读取更新快照。运行时未接入 quota collector 时，该路由返回 `404`（`QUOTA_RECOLLECT_UNSUPPORTED`），且 `capabilities.quota_recollect` 为 `false`。
+
 
 非法筛选、排序或分页返回 `400`，错误体为 `{"error":{"code":"INVALID_FILTER","message":"...","request_id":"","retryable":false}}`；凭证不存在返回 `404`；临时数据库/上下文不可用返回 `503`，其他数据库读取失败返回 `500`。
 

--- a/internal/cluster/management/oauth_patch_fields_xai_test.go
+++ b/internal/cluster/management/oauth_patch_fields_xai_test.go
@@ -1,0 +1,35 @@
+package management
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+)
+
+// xAI OAuth auth files share the same generic websockets patch path as Codex:
+// PATCH /auth-files/fields persists metadata.websockets and syncs the
+// effective attributes.websockets flag without provider gating.
+func TestApplyOAuthFieldPatchXaiWebsockets(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "xai-auth",
+		Provider: "xai",
+		Metadata: map[string]any{
+			"type": "xai",
+		},
+	}
+	fields := mustRawFields(t, `{"websockets":true}`)
+
+	changed, errPatch := applyOAuthFieldPatch(auth, fields)
+	if errPatch != nil {
+		t.Fatalf("applyOAuthFieldPatch returned error: %v", errPatch)
+	}
+	if !changed {
+		t.Fatalf("applyOAuthFieldPatch changed = false, want true")
+	}
+	if got, ok := auth.Metadata["websockets"].(bool); !ok || !got {
+		t.Fatalf("metadata.websockets = %#v, want true", auth.Metadata["websockets"])
+	}
+	if got := auth.Attributes["websockets"]; got != "true" {
+		t.Fatalf("attributes.websockets = %q, want true", got)
+	}
+}

--- a/internal/cluster/management/quota_ids_filter_test.go
+++ b/internal/cluster/management/quota_ids_filter_test.go
@@ -1,0 +1,86 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+func TestQuotaManagementListFiltersByIDs(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	now := time.Now().UTC().Truncate(time.Second)
+	mixedCaseID := "ABCDEF12-3456-4789-ABCD-EF1234567890"
+	for _, id := range []string{mixedCaseID, "quota-id-b", "quota-id-c"} {
+		auth := &coreauth.Auth{ID: id, Index: id, Provider: "codex", Label: id, Status: coreauth.StatusActive, Metadata: map[string]any{"type": "codex", "access_token": "token-" + id}, CreatedAt: now, UpdatedAt: now}
+		if _, errUpsert := handler.repo.UpsertAuth(context.Background(), auth, "test"); errUpsert != nil {
+			t.Fatalf("UpsertAuth(%s) error = %v", id, errUpsert)
+		}
+	}
+	used, remaining, limit, periodValue := 25.0, 75.0, 100.0, 1.0
+	if _, errUpsert := handler.repo.UpsertQuotaSnapshot(context.Background(), cluster.QuotaSnapshotWrite{
+		CredentialID: mixedCaseID, QuotaStatus: "healthy", CollectionStatus: "success", Source: "active_probe", ObservedAt: &now, ReplaceWindows: true,
+		Windows: []cluster.QuotaWindow{{ID: "mixed-case-window", Scope: "account", Mode: "fixed", Status: "healthy", Unit: "requests", Used: &used, Remaining: &remaining, Limit: &limit, PeriodUnit: "month", PeriodValue: &periodValue, Source: "active_probe", ObservedAt: now}},
+	}); errUpsert != nil {
+		t.Fatalf("UpsertQuotaSnapshot(%s) error = %v", mixedCaseID, errUpsert)
+	}
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/quota/credentials", handler.ListQuotaCredentials)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/quota/credentials?ids="+mixedCaseID+",quota-id-c", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", response.Code, response.Body.String())
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode list: %v", errDecode)
+	}
+	if payload["total"] != float64(2) {
+		t.Fatalf("ids filter total = %v, want 2", payload["total"])
+	}
+	globalSummary, ok := payload["global_summary"].(map[string]any)
+	if !ok || globalSummary["total_credentials"] != float64(3) {
+		t.Fatalf("ids filter global_summary = %#v, want all three credentials", payload["global_summary"])
+	}
+	items, ok := payload["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("ids filter items = %#v, want two", payload["items"])
+	}
+	seen := map[string]bool{}
+	for _, raw := range items {
+		if item, okItem := raw.(map[string]any); okItem {
+			credentialID := item["credential_id"].(string)
+			seen[credentialID] = true
+			if credentialID == mixedCaseID && item["window_count"] != float64(1) {
+				t.Fatalf("mixed-case credential window_count = %v, want 1", item["window_count"])
+			}
+		}
+	}
+	if !seen[mixedCaseID] || !seen["quota-id-c"] || seen["quota-id-b"] {
+		t.Fatalf("ids filter returned wrong credentials: %v", seen)
+	}
+
+	wrongCaseResponse := httptest.NewRecorder()
+	engine.ServeHTTP(wrongCaseResponse, httptest.NewRequest(http.MethodGet, "/quota/credentials?ids="+strings.ToLower(mixedCaseID), nil))
+	if wrongCaseResponse.Code != http.StatusOK {
+		t.Fatalf("wrong-case list status = %d body=%s", wrongCaseResponse.Code, wrongCaseResponse.Body.String())
+	}
+	var wrongCasePayload map[string]any
+	if errDecode := json.Unmarshal(wrongCaseResponse.Body.Bytes(), &wrongCasePayload); errDecode != nil {
+		t.Fatalf("decode wrong-case list: %v", errDecode)
+	}
+	if wrongCasePayload["total"] != float64(0) {
+		t.Fatalf("wrong-case ids filter total = %v, want 0", wrongCasePayload["total"])
+	}
+}

--- a/internal/cluster/management/quota_recollect.go
+++ b/internal/cluster/management/quota_recollect.go
@@ -1,0 +1,83 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// QuotaRecollectTrigger starts an asynchronous quota collection round. It is
+// implemented by the quota collector and injected at server build time.
+type QuotaRecollectTrigger interface {
+	TriggerCollection(ctx context.Context, credentialIDs map[string]struct{}, providers map[string]struct{}) (int, error)
+}
+
+// quotaRecollectProviders lists the providers with an active quota collector.
+var quotaRecollectProviders = map[string]struct{}{
+	"claude":      {},
+	"antigravity": {},
+	"codex":       {},
+	"kimi":        {},
+	"xai":         {},
+}
+
+func (h *Handler) SetQuotaRecollectTrigger(trigger QuotaRecollectTrigger) {
+	if h == nil {
+		return
+	}
+	h.quotaRecollect = trigger
+}
+
+// CollectQuota handles POST /quota/collect: kick off an asynchronous quota
+// collection round for the selected credentials (empty body = all eligible).
+func (h *Handler) CollectQuota(c *gin.Context) {
+	if h.quotaRecollect == nil {
+		respondQuotaHTTPError(c, http.StatusNotFound, "QUOTA_RECOLLECT_UNSUPPORTED", "quota recollection is not available on this runtime", false)
+		return
+	}
+	var body struct {
+		CredentialIDs []string `json:"credential_ids"`
+		Providers     []string `json:"providers"`
+	}
+	if c.Request != nil && c.Request.Body != nil {
+		decoder := json.NewDecoder(c.Request.Body)
+		if errDecode := decoder.Decode(&body); errDecode != nil && !errors.Is(errDecode, io.EOF) {
+			respondQuotaHTTPError(c, http.StatusBadRequest, "INVALID_BODY", "quota collect body must be a JSON object", false)
+			return
+		}
+	}
+	credentialIDs := make(map[string]struct{}, len(body.CredentialIDs))
+	for _, raw := range body.CredentialIDs {
+		if value := strings.TrimSpace(raw); value != "" {
+			credentialIDs[value] = struct{}{}
+		}
+	}
+	providers := make(map[string]struct{}, len(body.Providers))
+	for _, raw := range body.Providers {
+		value := strings.ToLower(strings.TrimSpace(raw))
+		if value == "" {
+			continue
+		}
+		if value == "grok" {
+			value = "xai"
+		}
+		if _, ok := quotaRecollectProviders[value]; !ok {
+			respondQuotaHTTPError(c, http.StatusBadRequest, "INVALID_FILTER", "providers contains an unsupported value: "+value, false)
+			return
+		}
+		providers[value] = struct{}{}
+	}
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	accepted, errTrigger := h.quotaRecollect.TriggerCollection(ctx, credentialIDs, providers)
+	if errTrigger != nil {
+		respondQuotaHTTPError(c, http.StatusInternalServerError, "QUOTA_COLLECT_FAILED", "failed to start quota collection", true)
+		return
+	}
+	c.JSON(http.StatusAccepted, gin.H{"accepted": accepted, "running": accepted > 0})
+}

--- a/internal/cluster/management/quota_recollect_test.go
+++ b/internal/cluster/management/quota_recollect_test.go
@@ -1,0 +1,141 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+type fakeQuotaRecollectTrigger struct {
+	accepted      int
+	err           error
+	credentialIDs map[string]struct{}
+	providers     map[string]struct{}
+	calls         int
+}
+
+func (f *fakeQuotaRecollectTrigger) TriggerCollection(_ context.Context, credentialIDs map[string]struct{}, providers map[string]struct{}) (int, error) {
+	f.calls++
+	f.credentialIDs = credentialIDs
+	f.providers = providers
+	return f.accepted, f.err
+}
+
+func TestCollectQuotaAcceptedWithFilters(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	trigger := &fakeQuotaRecollectTrigger{accepted: 2}
+	handler.SetQuotaRecollectTrigger(trigger)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/quota/collect", handler.CollectQuota)
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/quota/collect", strings.NewReader(`{"credential_ids":["auth-a"," auth-b "],"providers":["xai"]}`))
+	request.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("collect status = %d body=%s", response.Code, response.Body.String())
+	}
+	var payload map[string]any
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode collect response: %v", errDecode)
+	}
+	if payload["accepted"] != float64(2) || payload["running"] != true {
+		t.Fatalf("unexpected collect payload: %#v", payload)
+	}
+	if trigger.calls != 1 {
+		t.Fatalf("trigger calls = %d, want 1", trigger.calls)
+	}
+	if len(trigger.credentialIDs) != 2 || len(trigger.providers) != 1 {
+		t.Fatalf("unexpected trigger filters: ids=%v providers=%v", trigger.credentialIDs, trigger.providers)
+	}
+	if _, ok := trigger.credentialIDs["auth-b"]; !ok {
+		t.Fatalf("credential id whitespace was not trimmed: %v", trigger.credentialIDs)
+	}
+}
+
+func TestCollectQuotaEmptyBodyCollectsAll(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	trigger := &fakeQuotaRecollectTrigger{accepted: 5}
+	handler.SetQuotaRecollectTrigger(trigger)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/quota/collect", handler.CollectQuota)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/quota/collect", nil))
+
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("collect status = %d body=%s", response.Code, response.Body.String())
+	}
+	if trigger.calls != 1 || len(trigger.credentialIDs) != 0 || len(trigger.providers) != 0 {
+		t.Fatalf("unexpected trigger invocation: calls=%d ids=%v providers=%v", trigger.calls, trigger.credentialIDs, trigger.providers)
+	}
+}
+
+func TestCollectQuotaRejectsUnsupportedProvider(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	trigger := &fakeQuotaRecollectTrigger{}
+	handler.SetQuotaRecollectTrigger(trigger)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/quota/collect", handler.CollectQuota)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/quota/collect", strings.NewReader(`{"providers":["gemini"]}`)))
+
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("collect status = %d body=%s", response.Code, response.Body.String())
+	}
+	if trigger.calls != 0 {
+		t.Fatalf("trigger should not be called for invalid providers")
+	}
+}
+
+func TestCollectQuotaNormalizesGrokProvider(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	trigger := &fakeQuotaRecollectTrigger{accepted: 1}
+	handler.SetQuotaRecollectTrigger(trigger)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/quota/collect", handler.CollectQuota)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/quota/collect", strings.NewReader(`{"providers":["grok"]}`)))
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("collect status = %d body=%s", response.Code, response.Body.String())
+	}
+	if _, ok := trigger.providers["xai"]; !ok || len(trigger.providers) != 1 {
+		t.Fatalf("normalized providers = %v, want xai", trigger.providers)
+	}
+}
+
+func TestCollectQuotaUnsupportedWithoutTrigger(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/quota/collect", handler.CollectQuota)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/quota/collect", nil))
+
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("collect status = %d body=%s", response.Code, response.Body.String())
+	}
+}

--- a/internal/cluster/management/quota_snapshots.go
+++ b/internal/cluster/management/quota_snapshots.go
@@ -94,6 +94,7 @@ func parseQuotaListQuery(c *gin.Context) (cluster.QuotaListQuery, *quotaHTTPErro
 		query.Offset = offset
 	}
 	query.Search = strings.TrimSpace(c.Query("search"))
+	query.IDs = quotaExactCSVSet(c.Query("ids"))
 	query.Providers = quotaCSVSet(c.Query("provider"))
 	var errFilter *quotaHTTPError
 	if query.QuotaStatuses, errFilter = quotaEnumCSVSet(c.Query("quota_status"), "quota_status", "healthy", "low", "exhausted", "unknown", "error", "unsupported"); errFilter != nil {
@@ -118,6 +119,20 @@ func parseQuotaListQuery(c *gin.Context) (cluster.QuotaListQuery, *quotaHTTPErro
 		query.Sort = rawSort
 	}
 	return query, nil
+}
+
+func quotaExactCSVSet(raw string) map[string]struct{} {
+	values := make(map[string]struct{})
+	for _, candidate := range strings.Split(raw, ",") {
+		value := strings.TrimSpace(candidate)
+		if value != "" {
+			values[value] = struct{}{}
+		}
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	return values
 }
 
 func quotaCSVSet(raw string) map[string]struct{} {

--- a/internal/cluster/management/server.go
+++ b/internal/cluster/management/server.go
@@ -25,6 +25,7 @@ type Handler struct {
 	pluginStoreHTTPClient pluginstore.HTTPDoer
 	modelsDevHTTPClient   *http.Client
 	pluginStoreAuth       *pluginauth.Service
+	quotaRecollect        QuotaRecollectTrigger
 }
 
 // NewHandler creates a new handler.

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -28,6 +28,7 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 		"capabilities": gin.H{
 			"quota_snapshots":         true,
 			"quota_snapshot_details":  true,
+			"quota_recollect":         h.quotaRecollect != nil,
 			"usage":                   true,
 			"usage_overview":          true,
 			"usage_records":           true,

--- a/internal/cluster/quota_snapshots.go
+++ b/internal/cluster/quota_snapshots.go
@@ -58,6 +58,8 @@ type QuotaSnapshotRecord struct {
 	HomeLabel           string     `gorm:"column:home_label;size:256"`
 	CPANodeID           string     `gorm:"column:cpa_node_id;size:256"`
 	CPANodeLabel        string     `gorm:"column:cpa_node_label;size:256"`
+	PlanName            string     `gorm:"column:plan_name;size:64"`
+	PlanPremium         *bool      `gorm:"column:plan_premium"`
 	ProbeLeaseOwner     string     `gorm:"column:probe_lease_owner;size:256"`
 	ProbeLeaseExpiresAt *time.Time `gorm:"column:probe_lease_expires_at;index"`
 	ParserVersion       int        `gorm:"column:parser_version;not null;default:1"`
@@ -139,6 +141,13 @@ type QuotaRuntime struct {
 	CPANodeLabel string `json:"cpa_node_label"`
 }
 
+// QuotaPlan carries subscription plan metadata derived from a provider's quota
+// response (for example xAI SuperGrok / SuperGrok Heavy).
+type QuotaPlan struct {
+	Name    string `json:"name"`
+	Premium bool   `json:"premium"`
+}
+
 type QuotaCredentialSnapshot struct {
 	CredentialID       string                `json:"credential_id"`
 	AuthIndex          *string               `json:"auth_index"`
@@ -163,6 +172,7 @@ type QuotaCredentialSnapshot struct {
 	WindowCount        int                   `json:"window_count"`
 	Error              *QuotaCollectionError `json:"error"`
 	Runtime            *QuotaRuntime         `json:"runtime"`
+	Plan               *QuotaPlan            `json:"plan,omitempty"`
 	Windows            []QuotaWindow         `json:"-"`
 }
 
@@ -180,6 +190,8 @@ type QuotaSnapshotWrite struct {
 	ConsecutiveFailure    int
 	Error                 *QuotaCollectionError
 	Runtime               *QuotaRuntime
+	Plan                  *QuotaPlan
+	ReplacePlan           bool
 	ParserVersion         int
 	CollectorVersion      int
 	ExpectedProbeOwner    string
@@ -192,6 +204,7 @@ type QuotaListQuery struct {
 	Limit              int
 	Offset             int
 	Search             string
+	IDs                map[string]struct{}
 	Providers          map[string]struct{}
 	QuotaStatuses      map[string]struct{}
 	Freshness          map[string]struct{}
@@ -286,6 +299,10 @@ func upsertQuotaSnapshotDB(ctx context.Context, db *gorm.DB, input QuotaSnapshot
 			}
 			if record.CPANodeLabel == "" {
 				record.CPANodeLabel = existing.CPANodeLabel
+			}
+			if input.Plan == nil && !input.ReplacePlan {
+				record.PlanName = existing.PlanName
+				record.PlanPremium = existing.PlanPremium
 			}
 			if !input.ClearProbeLease {
 				record.ProbeLeaseOwner = existing.ProbeLeaseOwner
@@ -448,15 +465,21 @@ func quotaWindowRecordAggregateSource(windows []QuotaWindowRecord) string {
 }
 
 func (r *Repository) ClaimQuotaProbe(ctx context.Context, credentialID string, owner string, now time.Time, leaseDuration time.Duration) (bool, error) {
-	return r.claimQuotaProbe(ctx, credentialID, owner, now, leaseDuration, false)
+	return r.claimQuotaProbe(ctx, credentialID, owner, now, leaseDuration, false, false)
 }
 
 // ClaimEligibleQuotaProbe claims a lease only while the current DB credential remains eligible.
 func (r *Repository) ClaimEligibleQuotaProbe(ctx context.Context, credentialID string, owner string, now time.Time, leaseDuration time.Duration) (bool, error) {
-	return r.claimQuotaProbe(ctx, credentialID, owner, now, leaseDuration, true)
+	return r.claimQuotaProbe(ctx, credentialID, owner, now, leaseDuration, true, false)
 }
 
-func (r *Repository) claimQuotaProbe(ctx context.Context, credentialID string, owner string, now time.Time, leaseDuration time.Duration, requireEligible bool) (bool, error) {
+// ForceClaimEligibleQuotaProbe claims an eligible credential while ignoring its
+// snapshot freshness and retry schedule. An unexpired probe lease still wins.
+func (r *Repository) ForceClaimEligibleQuotaProbe(ctx context.Context, credentialID string, owner string, now time.Time, leaseDuration time.Duration) (bool, error) {
+	return r.claimQuotaProbe(ctx, credentialID, owner, now, leaseDuration, true, true)
+}
+
+func (r *Repository) claimQuotaProbe(ctx context.Context, credentialID string, owner string, now time.Time, leaseDuration time.Duration, requireEligible bool, force bool) (bool, error) {
 	credentialID = strings.TrimSpace(credentialID)
 	owner = strings.TrimSpace(owner)
 	if credentialID == "" || owner == "" {
@@ -505,7 +528,7 @@ func (r *Repository) claimQuotaProbe(ctx context.Context, credentialID string, o
 				return nil
 			}
 			observationInFuture = record.ObservedAt != nil && record.ObservedAt.After(now.Add(quotaMaxFutureObservationSkew))
-			if !observationInFuture {
+			if !force && !observationInFuture {
 				if record.NextProbeAt != nil && record.NextProbeAt.After(now) {
 					return nil
 				}
@@ -604,12 +627,19 @@ func (r *Repository) FailQuotaProbeAt(ctx context.Context, credentialID string, 
 }
 
 func (r *Repository) ListQuotaCredentials(ctx context.Context, query QuotaListQuery) (QuotaListResult, error) {
-	all, errList := r.loadQuotaCredentials(ctx, query.Now)
+	all, errList := r.loadQuotaCredentials(ctx, query.Now, nil, len(query.IDs) == 0)
 	if errList != nil {
 		return QuotaListResult{}, errList
 	}
-	filtered := make([]QuotaCredentialSnapshot, 0, len(all))
-	for _, item := range all {
+	candidates := all
+	if len(query.IDs) > 0 {
+		candidates, errList = r.loadQuotaCredentials(ctx, query.Now, query.IDs, true)
+		if errList != nil {
+			return QuotaListResult{}, errList
+		}
+	}
+	filtered := make([]QuotaCredentialSnapshot, 0, len(candidates))
+	for _, item := range candidates {
 		if quotaCredentialMatches(item, query) {
 			filtered = append(filtered, item)
 		}
@@ -679,7 +709,7 @@ func (r *Repository) GetQuotaCredential(ctx context.Context, credentialID string
 	return &item, nil
 }
 
-func (r *Repository) loadQuotaCredentials(ctx context.Context, now time.Time) ([]QuotaCredentialSnapshot, error) {
+func (r *Repository) loadQuotaCredentials(ctx context.Context, now time.Time, ids map[string]struct{}, includeWindows bool) ([]QuotaCredentialSnapshot, error) {
 	db, errDB := r.database()
 	if errDB != nil {
 		return nil, errDB
@@ -690,17 +720,32 @@ func (r *Repository) loadQuotaCredentials(ctx context.Context, now time.Time) ([
 		now = now.UTC()
 	}
 	ctx = contextOrBackground(ctx)
+	idValues := quotaExactSetValues(ids)
 	var authRecords []AuthRecord
-	if errFind := db.WithContext(ctx).Order("uuid ASC").Find(&authRecords).Error; errFind != nil {
+	authQuery := db.WithContext(ctx).Order("uuid ASC")
+	if len(idValues) > 0 {
+		authQuery = authQuery.Where("uuid IN ?", idValues)
+	}
+	if errFind := authQuery.Find(&authRecords).Error; errFind != nil {
 		return nil, errFind
 	}
 	var snapshots []QuotaSnapshotRecord
-	if errFind := db.WithContext(ctx).Find(&snapshots).Error; errFind != nil {
+	snapshotQuery := db.WithContext(ctx)
+	if len(idValues) > 0 {
+		snapshotQuery = snapshotQuery.Where("credential_id IN ?", idValues)
+	}
+	if errFind := snapshotQuery.Find(&snapshots).Error; errFind != nil {
 		return nil, errFind
 	}
 	var windowRecords []QuotaWindowRecord
-	if errFind := db.WithContext(ctx).Order("credential_id ASC, priority ASC, window_id ASC").Find(&windowRecords).Error; errFind != nil {
-		return nil, errFind
+	if includeWindows {
+		windowQuery := db.WithContext(ctx).Order("credential_id ASC, priority ASC, window_id ASC")
+		if len(idValues) > 0 {
+			windowQuery = windowQuery.Where("credential_id IN ?", idValues)
+		}
+		if errFind := windowQuery.Find(&windowRecords).Error; errFind != nil {
+			return nil, errFind
+		}
 	}
 	snapshotByCredential := make(map[string]QuotaSnapshotRecord, len(snapshots))
 	for _, snapshot := range snapshots {
@@ -812,6 +857,9 @@ func quotaCredentialFromAuth(record AuthRecord, auth *coreauth.Auth, snapshot Qu
 	item.Error = quotaCollectionErrorFromRecord(snapshot)
 	if snapshot.HomeID != "" || snapshot.CPANodeID != "" || snapshot.HomeLabel != "" || snapshot.CPANodeLabel != "" {
 		item.Runtime = &QuotaRuntime{HomeID: snapshot.HomeID, HomeLabel: snapshot.HomeLabel, CPANodeID: snapshot.CPANodeID, CPANodeLabel: snapshot.CPANodeLabel}
+	}
+	if snapshot.PlanName != "" {
+		item.Plan = &QuotaPlan{Name: snapshot.PlanName, Premium: snapshot.PlanPremium != nil && *snapshot.PlanPremium}
 	}
 	item.PrimaryWindows = quotaPrimaryWindows(displayWindows)
 	return item
@@ -979,6 +1027,11 @@ func quotaSnapshotRecordFromWrite(input QuotaSnapshotWrite) QuotaSnapshotRecord 
 		record.CPANodeID = quotaBoundedText(input.Runtime.CPANodeID, quotaWindowTextMaxLength)
 		record.CPANodeLabel = quotaBoundedText(input.Runtime.CPANodeLabel, quotaWindowTextMaxLength)
 	}
+	if input.Plan != nil {
+		record.PlanName = quotaBoundedText(input.Plan.Name, 64)
+		premium := input.Plan.Premium
+		record.PlanPremium = &premium
+	}
 	if input.Error != nil {
 		record.ErrorCode = strings.TrimSpace(input.Error.Code)
 		record.ErrorMessage = quotaSafeErrorMessage(input.Error.Message)
@@ -1017,7 +1070,7 @@ func quotaWindowDTO(record QuotaWindowRecord) QuotaWindow {
 }
 
 func quotaCredentialMatches(item QuotaCredentialSnapshot, query QuotaListQuery) bool {
-	if !quotaSetMatches(query.Providers, item.Provider) || !quotaSetMatches(query.QuotaStatuses, item.QuotaStatus) ||
+	if !quotaExactSetMatches(query.IDs, item.CredentialID) || !quotaSetMatches(query.Providers, item.Provider) || !quotaSetMatches(query.QuotaStatuses, item.QuotaStatus) ||
 		!quotaSetMatches(query.Freshness, item.Freshness) || !quotaSetMatches(query.Sources, quotaSourceValue(item.Source)) ||
 		!quotaSetMatches(query.CredentialStatuses, item.CredentialStatus) || !quotaSetMatches(query.CollectionStatuses, item.CollectionStatus) {
 		return false
@@ -1322,6 +1375,25 @@ func quotaSetMatches(values map[string]struct{}, value string) bool {
 	}
 	_, ok := values[strings.ToLower(strings.TrimSpace(value))]
 	return ok
+}
+
+func quotaExactSetMatches(values map[string]struct{}, value string) bool {
+	if len(values) == 0 {
+		return true
+	}
+	_, ok := values[strings.TrimSpace(value)]
+	return ok
+}
+
+func quotaExactSetValues(values map[string]struct{}) []string {
+	items := make([]string, 0, len(values))
+	for value := range values {
+		if normalized := strings.TrimSpace(value); normalized != "" {
+			items = append(items, normalized)
+		}
+	}
+	sort.Strings(items)
+	return items
 }
 func quotaAllowed(value string, allowed ...string) bool {
 	value = strings.TrimSpace(value)

--- a/internal/cluster/quota_snapshots_test.go
+++ b/internal/cluster/quota_snapshots_test.go
@@ -272,6 +272,33 @@ func TestClaimQuotaProbeUsesExpiringLease(t *testing.T) {
 	}
 }
 
+func TestForceClaimEligibleQuotaProbeBypassesFreshnessButNotLease(t *testing.T) {
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+	now := time.Date(2026, 7, 16, 6, 30, 0, 0, time.UTC)
+	seedQuotaSnapshotAuth(t, repo, "force-fresh-auth", "codex", "Force Fresh", map[string]any{"type": "codex"})
+	expiresAt := now.Add(30 * time.Minute)
+	if _, errSeed := repo.UpsertQuotaSnapshot(ctx, QuotaSnapshotWrite{
+		CredentialID: "force-fresh-auth", QuotaStatus: "healthy", CollectionStatus: "success", Source: "active_probe",
+		ObservedAt: &now, ExpiresAt: &expiresAt, NextProbeAt: &expiresAt, LastSuccessAt: &now,
+	}); errSeed != nil {
+		t.Fatalf("UpsertQuotaSnapshot() error = %v", errSeed)
+	}
+	claimed, errClaim := repo.ClaimEligibleQuotaProbe(ctx, "force-fresh-auth", "home-a", now, time.Minute)
+	if errClaim != nil || claimed {
+		t.Fatalf("normal fresh claim = %v, %v, want false, nil", claimed, errClaim)
+	}
+	claimed, errClaim = repo.ForceClaimEligibleQuotaProbe(ctx, "force-fresh-auth", "home-a", now, time.Minute)
+	if errClaim != nil || !claimed {
+		t.Fatalf("forced fresh claim = %v, %v, want true, nil", claimed, errClaim)
+	}
+	claimed, errClaim = repo.ForceClaimEligibleQuotaProbe(ctx, "force-fresh-auth", "home-b", now.Add(30*time.Second), time.Minute)
+	if errClaim != nil || claimed {
+		t.Fatalf("forced leased claim = %v, %v, want false, nil", claimed, errClaim)
+	}
+}
+
 func TestQuotaProbeCompletionRequiresCurrentLeaseOwner(t *testing.T) {
 	ctx := context.Background()
 	repo, closeRepo := newBillingTestRepository(t, ctx)

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -111,6 +111,7 @@ type ClusterManagementOption struct {
 	NodePort         int
 	HeartbeatTimeout time.Duration
 	ForwardTLSConfig *tls.Config
+	QuotaRecollect   clustermanagement.QuotaRecollectTrigger
 }
 
 type DatabaseManagementOption = ClusterManagementOption
@@ -140,6 +141,7 @@ func WithDatabaseManagement(opt DatabaseManagementOption) RouteOption {
 		handler := clustermanagement.NewHandler(opt.Repository, opt.Runtime, opt.NodeIP, opt.NodePort)
 		handler.SetHeartbeatTimeout(opt.HeartbeatTimeout)
 		handler.SetForwardTLSConfig(opt.ForwardTLSConfig)
+		handler.SetQuotaRecollectTrigger(opt.QuotaRecollect)
 		registerClusterManagementRoutes(r, handler)
 	}
 }
@@ -205,6 +207,7 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodGet, "/capabilities", handler.GetCapabilities)
 	r.Set(http.MethodGet, "/quota/credentials", handler.ListQuotaCredentials)
 	r.Set(http.MethodGet, "/quota/credentials/:credential_id", handler.GetQuotaCredential)
+	r.Set(http.MethodPost, "/quota/collect", handler.CollectQuota)
 	r.Set(http.MethodGet, "/usage/overview", handler.GetUsageOverview)
 	r.Set(http.MethodGet, "/usage/records", handler.ListUsageRecords)
 	r.Set(http.MethodGet, "/usage/records/:id", handler.GetUsageRecord)

--- a/internal/quota/codex.go
+++ b/internal/quota/codex.go
@@ -128,13 +128,21 @@ func quotaProbeStatus(remaining float64) string {
 }
 
 func quotaWindowAggregateStatus(windows []cluster.QuotaWindow) string {
-	status := "healthy"
+	status := "unknown"
 	for _, window := range windows {
-		if window.Status == "exhausted" {
+		switch window.Status {
+		case "exhausted":
 			return "exhausted"
-		}
-		if window.Status == "low" {
+		case "low":
 			status = "low"
+		case "error":
+			if status != "low" {
+				status = "error"
+			}
+		case "healthy":
+			if status == "unknown" {
+				status = "healthy"
+			}
 		}
 	}
 	return status

--- a/internal/quota/collector.go
+++ b/internal/quota/collector.go
@@ -36,6 +36,11 @@ const (
 	xaiBillingURL              = "https://cli-chat-proxy.grok.com/v1/billing"
 	codexUserAgent             = "codex_cli_rs/0.76.0 (Debian 13.0.0; x86_64) WindowsTerminal"
 	antigravityUserAgent       = "antigravity/1.11.5 windows/amd64"
+	xaiTokenAuthHeader         = "X-XAI-Token-Auth"
+	xaiTokenAuthValue          = "xai-grok-cli"
+	xaiClientVersionHeader     = "x-grok-client-version"
+	xaiClientVersionValue      = "0.2.93"
+	xaiGrokUserAgent           = "xai-grok-workspace/0.2.93"
 )
 
 var defaultAntigravityURLs = []string{
@@ -66,8 +71,14 @@ type Options struct {
 }
 
 type Collector struct {
-	repo    *cluster.Repository
-	options Options
+	repo          *cluster.Repository
+	options       Options
+	globalSem     chan struct{}
+	providerSemMu sync.Mutex
+	providerSem   map[string]chan struct{}
+	onDemandMu    sync.Mutex
+	onDemandJobs  map[string]struct{}
+	background    sync.WaitGroup
 }
 
 func NewCollector(repo *cluster.Repository, options Options) *Collector {
@@ -90,11 +101,10 @@ func NewCollector(repo *cluster.Repository, options Options) *Collector {
 	if options.SnapshotFreshness <= 0 {
 		options.SnapshotFreshness = defaultSnapshotFreshness
 	}
-	if options.ProviderConcurrency <= 0 {
+	if repo.DialectName() == "sqlite" {
+		options.ProviderConcurrency = 1
+	} else if options.ProviderConcurrency <= 0 {
 		options.ProviderConcurrency = defaultProviderConcurrency
-		if repo.DialectName() == "sqlite" {
-			options.ProviderConcurrency = 1
-		}
 	}
 	if strings.TrimSpace(options.CodexUsageURL) == "" {
 		options.CodexUsageURL = codexUsageURL
@@ -126,7 +136,16 @@ func NewCollector(repo *cluster.Repository, options Options) *Collector {
 			return quotaHTTPClient(auth, globalProxyURL, timeout)
 		}
 	}
-	return &Collector{repo: repo, options: options}
+	collector := &Collector{
+		repo:         repo,
+		options:      options,
+		providerSem:  make(map[string]chan struct{}),
+		onDemandJobs: make(map[string]struct{}),
+	}
+	if repo.DialectName() == "sqlite" {
+		collector.globalSem = make(chan struct{}, options.ProviderConcurrency)
+	}
+	return collector
 }
 
 func (c *Collector) Start(ctx context.Context) {
@@ -160,43 +179,129 @@ func (c *Collector) collect(ctx context.Context) {
 		log.WithError(errAuths).Warn("quota collector: list credentials failed")
 		return
 	}
-	var globalSem chan struct{}
-	providerSem := make(map[string]chan struct{})
-	if c.repo.DialectName() == "sqlite" {
-		globalSem = make(chan struct{}, c.options.ProviderConcurrency)
+	c.collectCredentials(ctx, auths, false)
+}
+
+// TriggerCollection queues an asynchronous forced collection round for the
+// matching credentials and returns how many new local jobs were accepted.
+// Empty filters accept every eligible credential. The round runs on a detached
+// context so it outlives the caller (for example an HTTP request).
+func (c *Collector) TriggerCollection(ctx context.Context, credentialIDs map[string]struct{}, providers map[string]struct{}) (int, error) {
+	if c == nil || c.repo == nil {
+		return 0, fmt.Errorf("quota collector is unavailable")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	auths, errAuths := c.repo.ListAuths(ctx)
+	if errAuths != nil {
+		return 0, errAuths
+	}
+	accepted := make([]*coreauth.Auth, 0, len(auths))
+	now := c.options.Now().UTC()
+	c.onDemandMu.Lock()
+	for _, auth := range auths {
+		if !quotaProbeEligible(auth, now) {
+			continue
+		}
+		if len(credentialIDs) > 0 {
+			if _, ok := credentialIDs[strings.TrimSpace(auth.ID)]; !ok {
+				continue
+			}
+		}
+		if len(providers) > 0 {
+			if _, ok := providers[normalizedQuotaProvider(auth.Provider)]; !ok {
+				continue
+			}
+		}
+		credentialID := strings.TrimSpace(auth.ID)
+		if _, exists := c.onDemandJobs[credentialID]; exists {
+			continue
+		}
+		c.onDemandJobs[credentialID] = struct{}{}
+		accepted = append(accepted, auth)
+	}
+	c.onDemandMu.Unlock()
+	if len(accepted) > 0 {
+		c.background.Add(1)
+		go func() {
+			defer c.background.Done()
+			c.collectCredentials(context.WithoutCancel(ctx), accepted, true)
+		}()
+	}
+	return len(accepted), nil
+}
+
+// Wait waits for asynchronous on-demand collection rounds to finish. It is
+// primarily useful for deterministic tests.
+func (c *Collector) Wait() {
+	if c == nil {
+		return
+	}
+	c.background.Wait()
+}
+
+func (c *Collector) collectCredentials(ctx context.Context, auths []*coreauth.Auth, force bool) {
 	var wait sync.WaitGroup
 	for _, auth := range auths {
 		if !quotaProbeEligible(auth, c.options.Now().UTC()) {
+			if force {
+				c.releaseOnDemandJob(auth)
+			}
 			continue
 		}
-		sem := globalSem
-		if sem == nil {
-			provider := normalizedQuotaProvider(auth.Provider)
-			sem = providerSem[provider]
-			if sem == nil {
-				sem = make(chan struct{}, c.options.ProviderConcurrency)
-				providerSem[provider] = sem
-			}
-		}
+		sem := c.quotaSemaphore(auth.Provider)
 		wait.Add(1)
 		go func(candidate *coreauth.Auth, release chan struct{}) {
 			defer wait.Done()
+			if force {
+				defer c.releaseOnDemandJob(candidate)
+			}
 			select {
 			case release <- struct{}{}:
 			case <-ctx.Done():
 				return
 			}
 			defer func() { <-release }()
-			c.collectCredential(ctx, candidate)
+			c.collectCredential(ctx, candidate, force)
 		}(auth, sem)
 	}
 	wait.Wait()
 }
 
-func (c *Collector) collectCredential(ctx context.Context, auth *coreauth.Auth) {
+func (c *Collector) quotaSemaphore(provider string) chan struct{} {
+	if c.globalSem != nil {
+		return c.globalSem
+	}
+	provider = normalizedQuotaProvider(provider)
+	c.providerSemMu.Lock()
+	defer c.providerSemMu.Unlock()
+	sem := c.providerSem[provider]
+	if sem == nil {
+		sem = make(chan struct{}, c.options.ProviderConcurrency)
+		c.providerSem[provider] = sem
+	}
+	return sem
+}
+
+func (c *Collector) releaseOnDemandJob(auth *coreauth.Auth) {
+	if c == nil || auth == nil {
+		return
+	}
+	c.onDemandMu.Lock()
+	delete(c.onDemandJobs, strings.TrimSpace(auth.ID))
+	c.onDemandMu.Unlock()
+}
+
+func (c *Collector) collectCredential(ctx context.Context, auth *coreauth.Auth, force bool) {
 	now := c.options.Now().UTC()
-	claimed, errClaim := c.repo.ClaimEligibleQuotaProbe(ctx, auth.ID, c.options.Owner, now, c.options.LeaseDuration)
+	var claimed bool
+	var errClaim error
+	if force {
+		claimed, errClaim = c.repo.ForceClaimEligibleQuotaProbe(ctx, auth.ID, c.options.Owner, now, c.options.LeaseDuration)
+	} else {
+		claimed, errClaim = c.repo.ClaimEligibleQuotaProbe(ctx, auth.ID, c.options.Owner, now, c.options.LeaseDuration)
+	}
 	if errClaim != nil {
 		log.WithError(errClaim).WithField("credential_id", auth.ID).Warn("quota collector: claim failed")
 		return
@@ -229,7 +334,7 @@ func (c *Collector) collectCredential(ctx context.Context, auth *coreauth.Auth) 
 	input := cluster.QuotaSnapshotWrite{
 		CredentialID: auth.ID, QuotaStatus: status, CollectionStatus: collectionStatus, Source: "active_probe",
 		ObservedAt: &observedAt, MaxAcceptedObservedAt: &observedAt, ExpiresAt: &expiresAt, LastAttemptAt: &observedAt, LastSuccessAt: &observedAt,
-		NextProbeAt: &expiresAt, ConsecutiveFailure: 0, Error: result.collectionError, ParserVersion: 1, CollectorVersion: 1,
+		NextProbeAt: &expiresAt, ConsecutiveFailure: 0, Error: result.collectionError, Plan: result.plan, ReplacePlan: true, ParserVersion: 1, CollectorVersion: 1,
 		ExpectedProbeOwner: c.options.Owner, ClearProbeLease: true, ReplaceWindows: result.replaceWindows, Windows: result.windows,
 	}
 	if strings.TrimSpace(c.options.HomeID) != "" {
@@ -258,6 +363,7 @@ func (c *Collector) collectCredential(ctx context.Context, auth *coreauth.Auth) 
 
 type probeResult struct {
 	windows         []cluster.QuotaWindow
+	plan            *cluster.QuotaPlan
 	partial         bool
 	replaceWindows  bool
 	collectionError *cluster.QuotaCollectionError
@@ -277,8 +383,8 @@ func (c *Collector) probeCredential(ctx context.Context, auth *coreauth.Auth) (p
 		windows, errProbe := c.probeKimi(ctx, auth)
 		return probeResult{windows: windows, replaceWindows: true}, errProbe
 	case "xai":
-		windows, errProbe := c.probeXAI(ctx, auth)
-		return probeResult{windows: windows, replaceWindows: true}, errProbe
+		windows, plan, errProbe := c.probeXAI(ctx, auth)
+		return probeResult{windows: windows, plan: plan, replaceWindows: true}, errProbe
 	default:
 		return probeResult{}, &probeError{code: "PROVIDER_UNSUPPORTED", message: "Credential provider does not have a quota collector.", retryable: false}
 	}

--- a/internal/quota/collector_test.go
+++ b/internal/quota/collector_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -175,14 +176,24 @@ func TestCollectorSupportsClaudeAntigravityKimiAndXAI(t *testing.T) {
 		{id: "claude-probe", provider: "claude", status: "healthy", windows: 3},
 		{id: "antigravity-probe", provider: "antigravity", status: "healthy", windows: 1},
 		{id: "kimi-probe", provider: "kimi", status: "healthy", windows: 2, assert: func(t *testing.T, item *cluster.QuotaCredentialSnapshot) {
-			summary := item.Windows[0]
+			var summary, limit *cluster.QuotaWindow
+			for index := range item.Windows {
+				switch item.Windows[index].ID {
+				case "kimi-usage":
+					summary = &item.Windows[index]
+				case "kimi-limit-1":
+					limit = &item.Windows[index]
+				}
+			}
+			if summary == nil || limit == nil {
+				t.Fatalf("missing Kimi windows: %+v", item.Windows)
+			}
 			if summary.ID != "kimi-usage" || summary.Used == nil || *summary.Used != 44 || summary.Limit == nil || *summary.Limit != 100 || summary.Remaining == nil || *summary.Remaining != 56 {
 				t.Fatalf("unexpected kimi summary window: %+v", summary)
 			}
 			if summary.ResetAt == nil || !summary.ResetAt.Equal(time.Date(2026, 7, 21, 13, 9, 11, 0, time.UTC)) {
 				t.Fatalf("unexpected kimi summary reset time: %+v", summary.ResetAt)
 			}
-			limit := item.Windows[1]
 			if limit.ID != "kimi-limit-1" || limit.Used == nil || *limit.Used != 10 || limit.Limit == nil || *limit.Limit != 100 || limit.Remaining == nil || *limit.Remaining != 90 {
 				t.Fatalf("unexpected kimi limit window: %+v", limit)
 			}
@@ -377,7 +388,7 @@ func TestCollectorSkipsStaleCandidateWhenDBCredentialBecameAPIKey(t *testing.T) 
 			return current, errGet
 		},
 	})
-	collector.collectCredential(context.Background(), candidate)
+	collector.collectCredential(context.Background(), candidate, false)
 	if resolved.Load() != 0 {
 		t.Fatalf("ResolveAuth calls = %d, want 0", resolved.Load())
 	}
@@ -502,7 +513,7 @@ func TestCollectorProbeTimeoutBecomesRetryableFailure(t *testing.T) {
 	}
 }
 
-func TestCollectorEnforcesProviderConcurrencyLimit(t *testing.T) {
+func TestCollectorEnforcesSQLiteSingleWriter(t *testing.T) {
 	repo := newCollectorTestRepository(t)
 	now := time.Date(2026, 7, 16, 11, 0, 0, 0, time.UTC)
 	for index := 0; index < 4; index++ {
@@ -510,6 +521,9 @@ func TestCollectorEnforcesProviderConcurrencyLimit(t *testing.T) {
 	}
 
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProbes := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProbes()
 	started := make(chan struct{}, 4)
 	var current atomic.Int32
 	var maximum atomic.Int32
@@ -542,26 +556,24 @@ func TestCollectorEnforcesProviderConcurrencyLimit(t *testing.T) {
 		close(done)
 	}()
 
-	for index := 0; index < 2; index++ {
-		select {
-		case <-started:
-		case <-time.After(time.Second):
-			t.Fatal("collector did not start the expected concurrent probes")
-		}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("collector did not start a probe")
 	}
 	select {
 	case <-started:
 		t.Fatal("collector exceeded the configured concurrency limit before a slot was released")
 	case <-time.After(50 * time.Millisecond):
 	}
-	close(release)
+	releaseProbes()
 	select {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("collector did not complete after releasing probe slots")
 	}
-	if maximum.Load() != 2 {
-		t.Fatalf("maximum concurrent probes = %d, want 2", maximum.Load())
+	if maximum.Load() != 1 {
+		t.Fatalf("maximum concurrent probes = %d, want 1", maximum.Load())
 	}
 }
 

--- a/internal/quota/collector_trigger_test.go
+++ b/internal/quota/collector_trigger_test.go
@@ -1,0 +1,190 @@
+package quota
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+func TestTriggerCollectionAcceptsEligibleCredentials(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 6, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "codex-a", "codex", map[string]any{"type": "codex", "access_token": "probe-secret"})
+	seedCollectorProviderAuth(t, repo, "kimi-a", "kimi", map[string]any{"type": "kimi", "access_token": "probe-secret"})
+	seedCollectorProviderAuth(t, repo, "gemini-a", "gemini", map[string]any{"type": "gemini"})
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		if strings.Contains(request.URL.String(), "kimi") {
+			_, _ = w.Write([]byte(`{"usage":{"used":10,"limit":100,"remaining":90},"limits":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"plan_type":"plus","rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000,"reset_after_seconds":600,"reset_at":1784160600}}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", CodexUsageURL: server.URL + "/codex", KimiUsageURL: server.URL + "/kimi", Now: func() time.Time { return now }})
+	accepted, errTrigger := collector.TriggerCollection(context.Background(), nil, nil)
+	if errTrigger != nil {
+		t.Fatalf("TriggerCollection() error = %v", errTrigger)
+	}
+	if accepted != 2 {
+		t.Fatalf("TriggerCollection() accepted = %d, want 2 (gemini unsupported)", accepted)
+	}
+	waitForProbeRequests(t, &requests, 2)
+	collector.Wait()
+}
+
+func TestTriggerCollectionFiltersByIDsAndProviders(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 6, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "codex-a", "codex", map[string]any{"type": "codex", "access_token": "probe-secret"})
+	seedCollectorProviderAuth(t, repo, "codex-b", "codex", map[string]any{"type": "codex", "access_token": "probe-secret"})
+	seedCollectorProviderAuth(t, repo, "kimi-a", "kimi", map[string]any{"type": "kimi", "access_token": "probe-secret"})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		_, _ = w.Write([]byte(`{"plan_type":"plus","rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000,"reset_after_seconds":600,"reset_at":1784160600}}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", CodexUsageURL: server.URL, KimiUsageURL: server.URL, Now: func() time.Time { return now }})
+
+	accepted, errTrigger := collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-b": {}}, nil)
+	if errTrigger != nil {
+		t.Fatalf("TriggerCollection(ids) error = %v", errTrigger)
+	}
+	if accepted != 1 {
+		t.Fatalf("TriggerCollection(ids) accepted = %d, want 1", accepted)
+	}
+
+	accepted, errTrigger = collector.TriggerCollection(context.Background(), nil, map[string]struct{}{"kimi": {}})
+	if errTrigger != nil {
+		t.Fatalf("TriggerCollection(providers) error = %v", errTrigger)
+	}
+	if accepted != 1 {
+		t.Fatalf("TriggerCollection(providers) accepted = %d, want 1", accepted)
+	}
+
+	accepted, errTrigger = collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-a": {}}, map[string]struct{}{"kimi": {}})
+	if errTrigger != nil {
+		t.Fatalf("TriggerCollection(ids+providers) error = %v", errTrigger)
+	}
+	if accepted != 0 {
+		t.Fatalf("TriggerCollection(ids+providers) accepted = %d, want 0 (intersection empty)", accepted)
+	}
+	collector.Wait()
+}
+
+func TestTriggerCollectionForcesFreshSnapshotAndDeduplicates(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 6, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "codex-fresh", "codex", map[string]any{"type": "codex", "access_token": "probe-secret"})
+	expiresAt := now.Add(30 * time.Minute)
+	if _, errSeed := repo.UpsertQuotaSnapshot(context.Background(), cluster.QuotaSnapshotWrite{
+		CredentialID: "codex-fresh", QuotaStatus: "healthy", CollectionStatus: "success", Source: "active_probe",
+		ObservedAt: &now, ExpiresAt: &expiresAt, NextProbeAt: &expiresAt, LastSuccessAt: &now,
+	}); errSeed != nil {
+		t.Fatalf("UpsertQuotaSnapshot() error = %v", errSeed)
+	}
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProbe := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProbe()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		started <- struct{}{}
+		<-release
+		_, _ = w.Write([]byte(`{"plan_type":"plus","rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000,"reset_after_seconds":600,"reset_at":1784160600}}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", CodexUsageURL: server.URL, Now: func() time.Time { return now }})
+	accepted, errTrigger := collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-fresh": {}}, nil)
+	if errTrigger != nil || accepted != 1 {
+		t.Fatalf("first TriggerCollection() = %d, %v, want 1, nil", accepted, errTrigger)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("forced quota probe did not start")
+	}
+	accepted, errTrigger = collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-fresh": {}}, nil)
+	if errTrigger != nil || accepted != 0 {
+		t.Fatalf("duplicate TriggerCollection() = %d, %v, want 0, nil", accepted, errTrigger)
+	}
+	releaseProbe()
+	collector.Wait()
+	if requests.Load() != 1 {
+		t.Fatalf("probe requests = %d, want 1", requests.Load())
+	}
+}
+
+func TestTriggerCollectionSharesConcurrencyAcrossRounds(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 6, 0, 0, 0, time.UTC)
+	for _, id := range []string{"codex-a", "codex-b", "codex-c", "codex-d"} {
+		seedCollectorProviderAuth(t, repo, id, "codex", map[string]any{"type": "codex", "access_token": "probe-secret"})
+	}
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseProbes := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseProbes()
+	var requests atomic.Int32
+	var active atomic.Int32
+	var maximum atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		current := active.Add(1)
+		for {
+			observed := maximum.Load()
+			if current <= observed || maximum.CompareAndSwap(observed, current) {
+				break
+			}
+		}
+		<-release
+		active.Add(-1)
+		_, _ = w.Write([]byte(`{"plan_type":"plus","rate_limit":{"primary_window":{"used_percent":10,"limit_window_seconds":18000,"reset_after_seconds":600,"reset_at":1784160600}}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", ProviderConcurrency: 1, CodexUsageURL: server.URL, Now: func() time.Time { return now }})
+	acceptedFirst, errFirst := collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-a": {}, "codex-b": {}}, nil)
+	acceptedSecond, errSecond := collector.TriggerCollection(context.Background(), map[string]struct{}{"codex-c": {}, "codex-d": {}}, nil)
+	if errFirst != nil || errSecond != nil || acceptedFirst != 2 || acceptedSecond != 2 {
+		t.Fatalf("TriggerCollection() results = (%d, %v), (%d, %v)", acceptedFirst, errFirst, acceptedSecond, errSecond)
+	}
+	waitForProbeRequests(t, &requests, 1)
+	time.Sleep(50 * time.Millisecond)
+	if requests.Load() != 1 || maximum.Load() > 1 {
+		t.Fatalf("concurrency before release: requests=%d maximum=%d", requests.Load(), maximum.Load())
+	}
+	releaseProbes()
+	collector.Wait()
+	if requests.Load() != 4 || maximum.Load() > 1 {
+		t.Fatalf("concurrency after completion: requests=%d maximum=%d", requests.Load(), maximum.Load())
+	}
+}
+
+func waitForProbeRequests(t *testing.T, requests *atomic.Int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if requests.Load() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("probe requests = %d, want at least %d", requests.Load(), want)
+}

--- a/internal/quota/providers.go
+++ b/internal/quota/providers.go
@@ -1,6 +1,7 @@
 package quota
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -84,16 +85,25 @@ func (c *Collector) probeKimi(ctx context.Context, auth *coreauth.Auth) ([]clust
 	return windows, nil
 }
 
-func (c *Collector) probeXAI(ctx context.Context, auth *coreauth.Auth) ([]cluster.QuotaWindow, *probeError) {
-	payload, _, errRequest := c.probeRequest(ctx, auth, http.MethodGet, c.options.XAIBillingURL, nil, nil)
+func (c *Collector) probeXAI(ctx context.Context, auth *coreauth.Auth) ([]cluster.QuotaWindow, *cluster.QuotaPlan, *probeError) {
+	headers := http.Header{
+		"Accept":               []string{"*/*"},
+		"User-Agent":           []string{xaiGrokUserAgent},
+		xaiTokenAuthHeader:     []string{xaiTokenAuthValue},
+		xaiClientVersionHeader: []string{xaiClientVersionValue},
+	}
+	if userID := quotaMetadataString(auth.Metadata, "sub", "subject", "user_id", "userId"); userID != "" {
+		headers.Set("x-userid", userID)
+	}
+	payload, _, errRequest := c.probeRequest(ctx, auth, http.MethodGet, c.options.XAIBillingURL, nil, headers)
 	if errRequest != nil {
-		return nil, errRequest
+		return nil, nil, errRequest
 	}
-	windows, errParse := parseXAIUsageWindows(payload, c.options.Now().UTC())
+	windows, plan, errParse := parseXAIUsageWindows(payload, c.options.Now().UTC())
 	if errParse != nil || len(windows) == 0 {
-		return nil, &probeError{code: "UPSTREAM_RESPONSE_INVALID", message: "xAI billing response did not contain usable quota.", retryable: true}
+		return nil, nil, &probeError{code: "UPSTREAM_RESPONSE_INVALID", message: "xAI billing response did not contain usable quota.", retryable: true}
 	}
-	return windows, nil
+	return windows, plan, nil
 }
 
 func probeCollectionError(failure *probeError, occurredAt time.Time) *cluster.QuotaCollectionError {
@@ -258,6 +268,19 @@ type flexFloat struct {
 
 func (f *flexFloat) UnmarshalJSON(data []byte) error {
 	*f = flexFloat{}
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var wrapped struct {
+			Val json.RawMessage `json:"val"`
+		}
+		if errDecode := json.Unmarshal(trimmed, &wrapped); errDecode != nil {
+			return nil
+		}
+		if len(wrapped.Val) == 0 {
+			return nil
+		}
+		data = wrapped.Val
+	}
 	raw, ok := flexibleNumberText(data)
 	if !ok {
 		return nil
@@ -367,13 +390,15 @@ func parseKimiUsageWindows(body []byte, observedAt time.Time) ([]cluster.QuotaWi
 	}
 	windows := make([]cluster.QuotaWindow, 0, len(payload.Limits)+1)
 	if window, ok := kimiSummaryWindow(payload.Usage, observedAt); ok {
+		// Keep the aggregate summary in detail responses without allowing it to
+		// displace provider-specific duration limits from primary_windows.
+		window.Priority = len(payload.Limits) + 1
 		windows = append(windows, window)
 	}
-	priorityOffset := len(windows)
 	for index, limit := range payload.Limits {
 		window, ok := kimiLimitWindow(limit, index, observedAt)
 		if ok {
-			window.Priority = priorityOffset + index
+			window.Priority = index
 			windows = append(windows, window)
 		}
 	}
@@ -429,35 +454,90 @@ func kimiSummaryWindow(input *kimiUsageDetail, observedAt time.Time) (cluster.Qu
 }
 
 type xaiBillingPayload struct {
-	Config *struct {
-		MonthlyLimit struct {
-			Val *float64 `json:"val"`
-		} `json:"monthlyLimit"`
-		Used struct {
-			Val *float64 `json:"val"`
-		} `json:"used"`
-		BillingPeriodEnd string `json:"billingPeriodEnd"`
-	} `json:"config"`
+	Config *xaiBillingConfig `json:"config"`
 }
 
-func parseXAIUsageWindows(body []byte, observedAt time.Time) ([]cluster.QuotaWindow, error) {
+type xaiBillingConfig struct {
+	MonthlyLimit      flexFloat `json:"monthlyLimit"`
+	MonthlyLimitSnake flexFloat `json:"monthly_limit"`
+	Used              flexFloat `json:"used"`
+	OnDemandCap       flexFloat `json:"onDemandCap"`
+	OnDemandCapSnake  flexFloat `json:"on_demand_cap"`
+	OnDemandUsed      flexFloat `json:"onDemandUsed"`
+	OnDemandUsedSnake flexFloat `json:"on_demand_used"`
+	BillingPeriodEnd  string    `json:"billingPeriodEnd"`
+	BillingEndSnake   string    `json:"billing_period_end"`
+}
+
+const (
+	xaiSuperGrokMonthlyLimitCents      = 15_000
+	xaiSuperGrokHeavyMonthlyLimitCents = 150_000
+)
+
+func xaiPlanFromMonthlyLimit(monthlyLimitCents *float64) *cluster.QuotaPlan {
+	if monthlyLimitCents == nil {
+		return nil
+	}
+	switch *monthlyLimitCents {
+	case xaiSuperGrokMonthlyLimitCents:
+		return &cluster.QuotaPlan{Name: "SuperGrok", Premium: false}
+	case xaiSuperGrokHeavyMonthlyLimitCents:
+		return &cluster.QuotaPlan{Name: "SuperGrok Heavy", Premium: true}
+	default:
+		return nil
+	}
+}
+
+func parseXAIUsageWindows(body []byte, observedAt time.Time) ([]cluster.QuotaWindow, *cluster.QuotaPlan, error) {
 	var payload xaiBillingPayload
 	if errDecode := json.Unmarshal(body, &payload); errDecode != nil {
-		return nil, fmt.Errorf("decode xai billing response: %w", errDecode)
+		return nil, nil, fmt.Errorf("decode xai billing response: %w", errDecode)
 	}
-	if payload.Config == nil || payload.Config.MonthlyLimit.Val == nil {
-		return nil, nil
+	if payload.Config == nil {
+		return nil, nil, nil
 	}
-	limit := math.Max(0, *payload.Config.MonthlyLimit.Val/100)
-	used := 0.0
-	if payload.Config.Used.Val != nil {
-		used = math.Max(0, *payload.Config.Used.Val/100)
+	config := payload.Config
+	monthlyLimitCents := firstFloat(flexFloatValue(config.MonthlyLimit), flexFloatValue(config.MonthlyLimitSnake))
+	usedCents := flexFloatValue(config.Used)
+	onDemandCapCents := firstFloat(flexFloatValue(config.OnDemandCap), flexFloatValue(config.OnDemandCapSnake))
+	onDemandUsedCents := firstFloat(flexFloatValue(config.OnDemandUsed), flexFloatValue(config.OnDemandUsedSnake))
+	billingPeriodEnd := firstNonEmptyString(config.BillingPeriodEnd, config.BillingEndSnake)
+
+	windows := make([]cluster.QuotaWindow, 0, 2)
+	if monthlyLimitCents != nil {
+		limit := math.Max(0, *monthlyLimitCents/100)
+		var used *float64
+		if usedCents != nil {
+			value := math.Min(limit, math.Max(0, *usedCents/100))
+			used = &value
+		}
+		window := cluster.QuotaWindow{ID: "xai-monthly-spend", Label: quotaStringPtr("Monthly Spend"), Scope: "account", Mode: "fixed", Status: "unknown", Unit: "currency", Currency: quotaStringPtr("USD"), Used: used, Limit: &limit, PeriodUnit: "month", PeriodValue: quotaFloatPtr(1), Source: "active_probe", ObservedAt: observedAt}
+		window.ResetAt = parseProviderTime(billingPeriodEnd)
+		normalizeWindowValues(&window)
+		windows = append(windows, window)
 	}
-	remaining := math.Max(0, limit-used)
-	window := cluster.QuotaWindow{ID: "xai-monthly-spend", Label: quotaStringPtr("Monthly Spend"), Scope: "account", Mode: "fixed", Status: "unknown", Unit: "currency", Currency: quotaStringPtr("USD"), Used: &used, Remaining: &remaining, Limit: &limit, PeriodUnit: "month", PeriodValue: quotaFloatPtr(1), Source: "active_probe", ObservedAt: observedAt}
-	window.ResetAt = parseProviderTime(payload.Config.BillingPeriodEnd)
-	normalizeWindowValues(&window)
-	return []cluster.QuotaWindow{window}, nil
+
+	if onDemandCapCents != nil && *onDemandCapCents > 0 {
+		limit := math.Max(0, *onDemandCapCents/100)
+		var used *float64
+		if onDemandUsedCents != nil {
+			value := math.Max(0, *onDemandUsedCents/100)
+			used = &value
+		} else if usedCents != nil && monthlyLimitCents != nil {
+			value := math.Max(0, (*usedCents-*monthlyLimitCents)/100)
+			used = &value
+		}
+		if used != nil {
+			value := math.Min(limit, *used)
+			used = &value
+		}
+		onDemandWindow := cluster.QuotaWindow{ID: "xai-on-demand", Label: quotaStringPtr("On-Demand"), Scope: "account", Mode: "balance", Status: "unknown", Unit: "currency", Currency: quotaStringPtr("USD"), Used: used, Limit: &limit, PeriodUnit: "month", PeriodValue: quotaFloatPtr(1), Source: "active_probe", ObservedAt: observedAt, Priority: 10}
+		onDemandWindow.ResetAt = parseProviderTime(billingPeriodEnd)
+		normalizeWindowValues(&onDemandWindow)
+		windows = append(windows, onDemandWindow)
+	}
+
+	return windows, xaiPlanFromMonthlyLimit(monthlyLimitCents), nil
 }
 
 func normalizedProviderRatio(value float64) float64 {

--- a/internal/quota/providers_kimi_quota_test.go
+++ b/internal/quota/providers_kimi_quota_test.go
@@ -1,0 +1,119 @@
+package quota
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+// Kimi weekly, duration, and aggregate usage limits must all be exposed as
+// generic windows with structured periods, ratios, and reset timestamps.
+func TestParseKimiUsageWindowsMultiLimitShapes(t *testing.T) {
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"usage": {"limit": "500", "used": "360", "remaining": "140", "resetTime": "2026-07-23T00:00:00Z", "title": "Weekly quota"},
+		"limits": [
+			{
+				"title": "Weekly limit",
+				"window": {"duration": 1, "timeUnit": "TIME_UNIT_WEEK"},
+				"detail": {"limit": "500", "used": "360", "remaining": "140", "resetTime": "2026-07-23T00:00:00Z"}
+			},
+			{
+				"title": "5h limit",
+				"window": {"duration": 5, "timeUnit": "TIME_UNIT_HOUR"},
+				"detail": {"limit": "100", "used": "59", "remaining": "41", "resetTime": "2026-07-16T14:00:00Z"}
+			},
+			{
+				"title": "Daily limit",
+				"window": {"duration": 1, "timeUnit": "TIME_UNIT_DAY"},
+				"detail": {"limit": "100", "used": "30", "remaining": "70", "resetTime": "2026-07-17T00:00:00Z"}
+			}
+		]
+	}`)
+	windows, errParse := parseKimiUsageWindows(body, now)
+	if errParse != nil {
+		t.Fatalf("parseKimiUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 4 {
+		t.Fatalf("windows = %d, want 4 (summary + weekly + 5h + daily)", len(windows))
+	}
+
+	summary := windows[0]
+	if summary.ID != "kimi-usage" || summary.Label == nil || *summary.Label != "Weekly quota" {
+		t.Fatalf("unexpected summary window: %+v", summary)
+	}
+	if summary.ResetAt == nil {
+		t.Fatalf("summary window missing reset_at: %+v", summary)
+	}
+
+	weekly := windows[1]
+	if weekly.PeriodUnit != "week" || weekly.PeriodValue == nil || *weekly.PeriodValue != 1 {
+		t.Fatalf("weekly limit period shape invalid: %+v", weekly)
+	}
+	if weekly.WindowSeconds == nil || *weekly.WindowSeconds != 604800 {
+		t.Fatalf("weekly limit window_seconds invalid: %+v", weekly.WindowSeconds)
+	}
+	if weekly.Limit == nil || *weekly.Limit != 500 || weekly.Remaining == nil || *weekly.Remaining != 140 {
+		t.Fatalf("weekly limit quantities invalid: %+v", weekly)
+	}
+	if weekly.ResetAt == nil {
+		t.Fatalf("weekly limit missing reset_at")
+	}
+
+	fiveHour := windows[2]
+	if fiveHour.PeriodUnit != "hour" || fiveHour.PeriodValue == nil || *fiveHour.PeriodValue != 5 {
+		t.Fatalf("5h limit period shape invalid: %+v", fiveHour)
+	}
+	if fiveHour.WindowSeconds == nil || *fiveHour.WindowSeconds != 18000 {
+		t.Fatalf("5h limit window_seconds invalid: %+v", fiveHour.WindowSeconds)
+	}
+
+	daily := windows[3]
+	if daily.PeriodUnit != "day" || daily.PeriodValue == nil || *daily.PeriodValue != 1 {
+		t.Fatalf("daily limit period shape invalid: %+v", daily)
+	}
+}
+
+func TestKimiPrimaryWindowsPreferDistinctProviderLimits(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 9, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "kimi-primary", "kimi", map[string]any{"type": "kimi", "access_token": "probe-secret"})
+	body := []byte(`{
+		"usage": {"limit": 500, "used": 360, "remaining": 140, "title": "Weekly quota"},
+		"limits": [
+			{"title": "Weekly limit", "window": {"duration": 1, "timeUnit": "TIME_UNIT_WEEK"}, "detail": {"limit": 500, "used": 360, "remaining": 140}},
+			{"title": "5h limit", "window": {"duration": 5, "timeUnit": "TIME_UNIT_HOUR"}, "detail": {"limit": 100, "used": 59, "remaining": 41}}
+		]
+	}`)
+	windows, errParse := parseKimiUsageWindows(body, now)
+	if errParse != nil {
+		t.Fatalf("parseKimiUsageWindows() error = %v", errParse)
+	}
+	expiresAt := now.Add(30 * time.Minute)
+	if _, errWrite := repo.UpsertQuotaSnapshot(context.Background(), cluster.QuotaSnapshotWrite{
+		CredentialID: "kimi-primary", QuotaStatus: "healthy", CollectionStatus: "success", Source: "active_probe",
+		ObservedAt: &now, ExpiresAt: &expiresAt, LastSuccessAt: &now, NextProbeAt: &expiresAt,
+		ReplaceWindows: true, Windows: windows,
+	}); errWrite != nil {
+		t.Fatalf("UpsertQuotaSnapshot() error = %v", errWrite)
+	}
+
+	result, errList := repo.ListQuotaCredentials(context.Background(), cluster.QuotaListQuery{
+		Limit: 50, IDs: map[string]struct{}{"kimi-primary": {}}, Sort: "risk_desc", Now: now.Add(time.Minute),
+	})
+	if errList != nil {
+		t.Fatalf("ListQuotaCredentials() error = %v", errList)
+	}
+	if len(result.Items) != 1 || len(result.Items[0].PrimaryWindows) != 2 {
+		t.Fatalf("unexpected Kimi list item: %+v", result.Items)
+	}
+	primary := result.Items[0].PrimaryWindows
+	if primary[0].PeriodUnit != "week" || primary[1].PeriodUnit != "hour" || primary[1].PeriodValue == nil || *primary[1].PeriodValue != 5 {
+		t.Fatalf("Kimi primary windows lost provider limits: %+v", primary)
+	}
+	if result.Items[0].WindowCount != 3 {
+		t.Fatalf("Kimi window_count = %d, want 3", result.Items[0].WindowCount)
+	}
+}

--- a/internal/quota/providers_xai_quota_test.go
+++ b/internal/quota/providers_xai_quota_test.go
@@ -1,0 +1,177 @@
+package quota
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestParseXAIUsageWindowsWithPlanAndOnDemand(t *testing.T) {
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"config": {
+			"monthlyLimit": {"val": "150000"},
+			"used": {"val": 151200},
+			"onDemandCap": {"val": 5000},
+			"onDemandUsed": "1200",
+			"billingPeriodEnd": "2026-08-01T00:00:00Z"
+		}
+	}`)
+	windows, plan, errParse := parseXAIUsageWindows(body, now)
+	if errParse != nil {
+		t.Fatalf("parseXAIUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 2 {
+		t.Fatalf("windows = %d, want 2 (monthly + on-demand)", len(windows))
+	}
+	monthly := windows[0]
+	if monthly.ID != "xai-monthly-spend" || monthly.Limit == nil || *monthly.Limit != 1500 || monthly.Used == nil || *monthly.Used != 1500 || monthly.Remaining == nil || *monthly.Remaining != 0 {
+		t.Fatalf("unexpected monthly window: %+v", monthly)
+	}
+	onDemand := windows[1]
+	if onDemand.ID != "xai-on-demand" || onDemand.Unit != "currency" || onDemand.Limit == nil || *onDemand.Limit != 50 || onDemand.Used == nil || *onDemand.Used != 12 || onDemand.Remaining == nil || *onDemand.Remaining != 38 {
+		t.Fatalf("unexpected on-demand window: %+v", onDemand)
+	}
+	if onDemand.PeriodUnit != "month" || onDemand.PeriodValue == nil || *onDemand.PeriodValue != 1 || onDemand.ResetAt == nil {
+		t.Fatalf("unexpected on-demand period: %+v", onDemand)
+	}
+	if plan == nil || plan.Name != "SuperGrok Heavy" || !plan.Premium {
+		t.Fatalf("unexpected plan: %+v", plan)
+	}
+}
+
+func TestParseXAIUsageWindowsAcceptsSnakeCaseAndScalarValues(t *testing.T) {
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	body := []byte(`{
+		"config": {
+			"monthly_limit": 15000,
+			"used": "4200",
+			"on_demand_cap": "5000",
+			"billing_period_end": "2026-08-01T00:00:00Z"
+		}
+	}`)
+	windows, plan, errParse := parseXAIUsageWindows(body, now)
+	if errParse != nil {
+		t.Fatalf("parseXAIUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 2 || windows[0].Limit == nil || *windows[0].Limit != 150 || windows[1].Remaining == nil || *windows[1].Remaining != 50 {
+		t.Fatalf("unexpected scalar/snake_case windows: %+v", windows)
+	}
+	if plan == nil || plan.Name != "SuperGrok" || plan.Premium {
+		t.Fatalf("unexpected plan: %+v", plan)
+	}
+}
+
+func TestParseXAIUsageWindowsDoesNotRecursivelyUnwrapValues(t *testing.T) {
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	windows, plan, errParse := parseXAIUsageWindows([]byte(`{"config":{"monthlyLimit":{"val":{"val":15000}}}}`), now)
+	if errParse != nil {
+		t.Fatalf("parseXAIUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 0 || plan != nil {
+		t.Fatalf("nested value wrappers were accepted: windows=%+v plan=%+v", windows, plan)
+	}
+}
+
+func TestParseXAIUsageWindowsUnknownMonthlyLimitHasNoPlan(t *testing.T) {
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	windows, plan, errParse := parseXAIUsageWindows([]byte(`{"config":{"monthlyLimit":20000,"used":167,"onDemandCap":0}}`), now)
+	if errParse != nil {
+		t.Fatalf("parseXAIUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 1 {
+		t.Fatalf("windows = %d, want 1", len(windows))
+	}
+	if plan != nil {
+		t.Fatalf("plan = %+v, want nil for an unknown monthly limit", plan)
+	}
+}
+
+func TestParseXAIUsageWindowsDoesNotInventMissingUsage(t *testing.T) {
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	windows, plan, errParse := parseXAIUsageWindows([]byte(`{"config":{"monthlyLimit":15000,"onDemandCap":5000}}`), now)
+	if errParse != nil {
+		t.Fatalf("parseXAIUsageWindows() error = %v", errParse)
+	}
+	if len(windows) != 2 || plan == nil {
+		t.Fatalf("unexpected windows or plan: windows=%+v plan=%+v", windows, plan)
+	}
+	for _, window := range windows {
+		if window.Used != nil || window.Remaining != nil || window.UsedRatio != nil || window.RemainingRatio != nil || window.Status != "unknown" {
+			t.Fatalf("missing usage was invented for window: %+v", window)
+		}
+	}
+	if status := quotaWindowAggregateStatus(windows); status != "unknown" {
+		t.Fatalf("aggregate status = %q, want unknown when usage is missing", status)
+	}
+}
+
+func TestCollectorPersistsXAIPlanAndSendsCLIHeaders(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "xai-plan-probe", "xai", map[string]any{"type": "xai", "access_token": "xai-secret", "sub": "xai-user"})
+	requestHeaders := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requestHeaders <- request.Header.Clone()
+		_, _ = w.Write([]byte(`{"config":{"monthlyLimit":{"val":150000},"used":{"val":15000},"onDemandCap":{"val":5000},"onDemandUsed":{"val":1200},"billingPeriodEnd":"2026-08-01T00:00:00Z"}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", XAIBillingURL: server.URL, Now: func() time.Time { return now }})
+	collector.collect(context.Background())
+
+	item, errGet := repo.GetQuotaCredential(context.Background(), "xai-plan-probe", now.Add(time.Minute))
+	if errGet != nil {
+		t.Fatalf("GetQuotaCredential() error = %v", errGet)
+	}
+	if item.Plan == nil || item.Plan.Name != "SuperGrok Heavy" || !item.Plan.Premium {
+		t.Fatalf("unexpected persisted plan: %+v", item.Plan)
+	}
+	if len(item.Windows) != 2 || item.Windows[0].ID != "xai-monthly-spend" || item.Windows[1].ID != "xai-on-demand" {
+		t.Fatalf("unexpected persisted windows: %+v", item.Windows)
+	}
+
+	select {
+	case headers := <-requestHeaders:
+		if headers.Get("Authorization") != "Bearer xai-secret" || headers.Get("Accept") != "*/*" || headers.Get(xaiTokenAuthHeader) != xaiTokenAuthValue || headers.Get(xaiClientVersionHeader) != xaiClientVersionValue || headers.Get("User-Agent") != xaiGrokUserAgent || headers.Get("x-userid") != "xai-user" {
+			t.Fatalf("unexpected xAI request headers: %v", headers)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("xAI probe request was not observed")
+	}
+}
+
+func TestCollectorClearsStaleXAIPlan(t *testing.T) {
+	repo := newCollectorTestRepository(t)
+	now := time.Date(2026, 7, 16, 8, 0, 0, 0, time.UTC)
+	seedCollectorProviderAuth(t, repo, "xai-plan-clear", "xai", map[string]any{"type": "xai", "access_token": "xai-secret"})
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			_, _ = w.Write([]byte(`{"config":{"monthlyLimit":150000,"used":1000}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"config":{"monthlyLimit":20000,"used":1000}}`))
+	}))
+	defer server.Close()
+
+	collector := NewCollector(repo, Options{Owner: "home-a", XAIBillingURL: server.URL, Now: func() time.Time { return now }})
+	collector.collect(context.Background())
+	first, errFirst := repo.GetQuotaCredential(context.Background(), "xai-plan-clear", now)
+	if errFirst != nil || first.Plan == nil {
+		t.Fatalf("initial plan = %+v, error = %v", first, errFirst)
+	}
+
+	now = now.Add(31 * time.Minute)
+	collector.collect(context.Background())
+	second, errSecond := repo.GetQuotaCredential(context.Background(), "xai-plan-clear", now)
+	if errSecond != nil {
+		t.Fatalf("GetQuotaCredential() after plan change error = %v", errSecond)
+	}
+	if second.Plan != nil {
+		t.Fatalf("stale plan was retained: %+v", second.Plan)
+	}
+}


### PR DESCRIPTION
## Summary

- expose `quota_recollect` and `POST /quota/collect` for asynchronous, filtered quota recollection
- force manual probes past snapshot freshness and quota backoff while still respecting disabled credentials, execution cooldowns, and active DB leases
- deduplicate local on-demand jobs and share provider concurrency across scheduled and manual collection rounds
- align xAI/Grok billing probes with the current CLI headers and response fields, including inferred plan and on-demand windows with stale-plan cleanup
- prioritize Kimi provider limits in `primary_windows`, add targeted `ids` loading, and accept `grok` as an `xai` collection alias
- document the Management API contract in English and Chinese and verify xAI websocket field mutation

Supports https://github.com/router-for-me/Home-Management-Center/issues/70

## Compatibility

- Management API changes are additive
- quota runtime state remains database-backed
- the browser continues to read Home snapshots and never probes upstream providers directly
- existing provider and credential resources remain separate

## Validation

- `gofmt -w .`
- `go test ./internal/quota ./internal/cluster/management ./internal/managementhttp`
- `go test -run Quota ./internal/cluster`
- `go test -race ./internal/quota`
- `go build -o test-output ./cmd/home && rm test-output`
- `git diff --check`

## Baseline note

`go test ./internal/cluster` currently fails on `origin/dev@5739399` in `TestUserPeriodLimit1dCalendarAndRolling`. The same failure was reproduced against a clean archive of that exact `dev` commit. The quota-focused cluster tests pass, and this PR does not modify the user period-limit implementation or test.