### PR TITLE
feat: add per-model channel bindings

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3634,7 +3634,7 @@ Example request:
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `model_group_id` | integer | yes | Existing model group ID. |
-| `model_id` | string | yes | Model ID allowed by this group. |
+| `model_id` | string | yes | Canonical model ID allowed by this group. A trailing request-option suffix such as `(high)` is stripped on write and is not part of the model identity. |
 | `channels` | array of integer | no | Channel group IDs allowed to execute this model. Empty or omitted inherits the API key credential scope. |
 
 Response: `{ "model_group_detail": ... }`.

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3579,7 +3579,7 @@ Query parameters:
 | Query | Type | Description |
 | --- | --- | --- |
 | `model_group_id` | integer | Filter by model group ID. Aliases: `model-group-id`, `group_id`, `group-id`. |
-| `model_id` | string | Filter by model ID. Alias: `model-id`. |
+| `model_id` | string | Filter by canonical model ID. Alias: `model-id`. Matching is case-insensitive and ignores a trailing request-option suffix on either the query or a legacy stored record. |
 
 Example response:
 

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -2598,6 +2598,7 @@ Response fields:
 | `capabilities.oauth_usage` | boolean | Whether OAuth/file-backed credential usage attribution is reliable. |
 | `capabilities.logs` | boolean | Whether application log APIs are available. |
 | `capabilities.request_error_logs` | boolean | Whether request error log file list/download APIs are available. |
+| `capabilities.model_channel_bindings` | boolean | Whether model group details support model-specific channel group bindings through `channels`. |
 | `capabilities.topology` | boolean | Whether `GET /topology` is available for Home + CPA cluster topology. |
 | `capabilities.users` | boolean | Whether the `/users` user-management routes are available. |
 | `capabilities.access_groups` | boolean | Whether the `/channel-groups` and `/model-groups` access-scope routes are available. |
@@ -3490,6 +3491,10 @@ Response:
 
 Model groups restrict which model IDs a client API key may use. If a client API key has an empty `model_groups` array, model filtering is not applied.
 
+Each model group detail may also contain `channels`, an array of channel group IDs that limits which credentials can execute that model. Empty or omitted `channels` inherits the client API key's existing credential scope and preserves legacy behavior. A non-empty value resolves the enabled credentials in those channel groups and intersects them by auth ID with the API key's own `channels` scope. If the API key does not restrict channels, the model-specific scope applies directly. If the resulting credential set is empty, dispatch fails closed rather than falling back to unrestricted credentials.
+
+When the same model occurs in multiple model groups selected by an API key, Home unions all non-empty model-specific `channels` bindings. Duplicate details with empty `channels` do not cancel an explicit restriction. Disabled or deleted model/channel groups do not contribute eligible credentials.
+
 ### GET `/model-groups`
 
 Example response:
@@ -3585,6 +3590,7 @@ Example response:
       "id": 10,
       "model_group_id": 1,
       "model_id": "gpt-5.5",
+      "channels": [2, 3],
       "created_at": "2026-05-27T10:00:00Z",
       "updated_at": "2026-05-27T10:00:00Z",
       "deleted_at": null
@@ -3603,6 +3609,7 @@ Returns one detail row:
     "id": 10,
     "model_group_id": 1,
     "model_id": "gpt-5.5",
+    "channels": [2, 3],
     "created_at": "2026-05-27T10:00:00Z",
     "updated_at": "2026-05-27T10:00:00Z",
     "deleted_at": null
@@ -3619,7 +3626,8 @@ Example request:
 ```json
 {
   "model_group_id": 1,
-  "model_id": "gpt-5.5"
+  "model_id": "gpt-5.5",
+  "channels": [2, 3]
 }
 ```
 
@@ -3627,6 +3635,7 @@ Example request:
 | --- | --- | --- | --- |
 | `model_group_id` | integer | yes | Existing model group ID. |
 | `model_id` | string | yes | Model ID allowed by this group. |
+| `channels` | array of integer | no | Channel group IDs allowed to execute this model. Empty or omitted inherits the API key credential scope. |
 
 Response: `{ "model_group_detail": ... }`.
 
@@ -3639,11 +3648,12 @@ Example request:
 ```json
 {
   "model_group_id": 2,
-  "model_id": "gpt-5.5-mini"
+  "model_id": "gpt-5.5-mini",
+  "channels": [4]
 }
 ```
 
-All fields are optional, but a supplied `model_group_id` must be greater than `0`.
+All fields are optional, but a supplied `model_group_id` must be greater than `0`. Supplying `channels: []` removes the model-specific credential restriction and restores inherited behavior.
 
 Response: `{ "model_group_detail": ... }`.
 

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3635,7 +3635,7 @@ Example request:
 | --- | --- | --- | --- |
 | `model_group_id` | integer | yes | Existing model group ID. |
 | `model_id` | string | yes | Canonical model ID allowed by this group. A trailing request-option suffix such as `(high)` is stripped on write and is not part of the model identity. |
-| `channels` | array of integer | no | Channel group IDs allowed to execute this model. Empty or omitted inherits the API key credential scope. |
+| `channels` | array of positive integer | no | Channel group IDs allowed to execute this model. ID `0` is rejected with HTTP `400`. Empty or omitted inherits the API key credential scope. |
 
 Response: `{ "model_group_detail": ... }`.
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3549,7 +3549,7 @@ Query 参数：
 | Query | 类型 | 说明 |
 | --- | --- | --- |
 | `model_group_id` | integer | 按 model group ID 过滤；也接受 `model-group-id`、`group_id`、`group-id`。 |
-| `model_id` | string | 按 model ID 过滤；也接受 `model-id`。 |
+| `model_id` | string | 按 canonical model ID 过滤；也接受 `model-id`。匹配不区分大小写，并忽略查询值或旧存量记录末尾的请求选项 suffix。 |
 
 输出示例：
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3604,7 +3604,7 @@ Query 参数：
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `model_group_id` | integer | 是 | 已存在的 model group ID。 |
-| `model_id` | string | 是 | 该 group 允许的模型 ID。 |
+| `model_id` | string | 是 | 该 group 允许的 canonical 模型 ID。写入时会移除末尾的 `(high)` 等请求选项 suffix；suffix 不属于模型身份。 |
 | `channels` | array of integer | 否 | 允许执行该模型的 channel group IDs；为空或省略时继承 API key 的凭证范围。 |
 
 输出：`{ "model_group_detail": ... }`。

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -2598,6 +2598,7 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 | `capabilities.oauth_usage` | boolean | OAuth/file-backed credential usage 归因是否可靠。 |
 | `capabilities.logs` | boolean | 是否支持应用日志接口。 |
 | `capabilities.request_error_logs` | boolean | 是否支持 request error log file list/download。 |
+| `capabilities.model_channel_bindings` | boolean | model group detail 是否支持通过 `channels` 配置模型级 channel group 绑定。 |
 | `capabilities.topology` | boolean | 是否支持 `GET /topology` Home + CPA 集群拓扑接口。 |
 | `capabilities.users` | boolean | 是否支持 `/users` 用户管理路由。 |
 | `capabilities.access_groups` | boolean | 是否支持 `/channel-groups` 与 `/model-groups` 访问范围路由。 |
@@ -3460,6 +3461,10 @@ Query 参数：
 
 Model groups 限制某个客户端 API key 可以使用哪些模型 ID。如果客户端 API key 的 `model_groups` 是空数组，则不应用模型过滤。
 
+每条 model group detail 还可以通过 `channels` 指定允许执行该模型的 channel group IDs。`channels` 为空或省略时继承客户端 API key 原有的凭证范围，保持旧行为不变。非空时，Home 会解析这些 channel groups 中已启用的凭证，并按 auth ID 与 API key 自身的 `channels` 凭证范围取交集；如果 API key 不限制凭证，则直接应用模型级范围。最终凭证集合为空时调度会 fail closed，不会回退为无限制凭证。
+
+同一模型出现在一个 API key 选中的多个 model groups 中时，Home 会合并所有非空的模型级 `channels`；空绑定不会取消显式限制。禁用或删除的 model/channel group 不会贡献可用凭证。
+
 ### GET `/model-groups`
 
 输出示例：
@@ -3555,6 +3560,7 @@ Query 参数：
       "id": 10,
       "model_group_id": 1,
       "model_id": "gpt-5.5",
+      "channels": [2, 3],
       "created_at": "2026-05-27T10:00:00Z",
       "updated_at": "2026-05-27T10:00:00Z",
       "deleted_at": null
@@ -3573,6 +3579,7 @@ Query 参数：
     "id": 10,
     "model_group_id": 1,
     "model_id": "gpt-5.5",
+    "channels": [2, 3],
     "created_at": "2026-05-27T10:00:00Z",
     "updated_at": "2026-05-27T10:00:00Z",
     "deleted_at": null
@@ -3589,7 +3596,8 @@ Query 参数：
 ```json
 {
   "model_group_id": 1,
-  "model_id": "gpt-5.5"
+  "model_id": "gpt-5.5",
+  "channels": [2, 3]
 }
 ```
 
@@ -3597,6 +3605,7 @@ Query 参数：
 | --- | --- | --- | --- |
 | `model_group_id` | integer | 是 | 已存在的 model group ID。 |
 | `model_id` | string | 是 | 该 group 允许的模型 ID。 |
+| `channels` | array of integer | 否 | 允许执行该模型的 channel group IDs；为空或省略时继承 API key 的凭证范围。 |
 
 输出：`{ "model_group_detail": ... }`。
 
@@ -3609,11 +3618,12 @@ Query 参数：
 ```json
 {
   "model_group_id": 2,
-  "model_id": "gpt-5.5-mini"
+  "model_id": "gpt-5.5-mini",
+  "channels": [4]
 }
 ```
 
-所有字段均可选；如果传入 `model_group_id`，必须大于 `0`。
+所有字段均可选；如果传入 `model_group_id`，必须大于 `0`。传入 `channels: []` 会移除模型级凭证限制，恢复继承行为。
 
 输出：`{ "model_group_detail": ... }`。
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3605,7 +3605,7 @@ Query 参数：
 | --- | --- | --- | --- |
 | `model_group_id` | integer | 是 | 已存在的 model group ID。 |
 | `model_id` | string | 是 | 该 group 允许的 canonical 模型 ID。写入时会移除末尾的 `(high)` 等请求选项 suffix；suffix 不属于模型身份。 |
-| `channels` | array of integer | 否 | 允许执行该模型的 channel group IDs；为空或省略时继承 API key 的凭证范围。 |
+| `channels` | array of positive integer | 否 | 允许执行该模型的 channel group IDs；ID `0` 会返回 HTTP `400`；为空或省略时继承 API key 的凭证范围。 |
 
 输出：`{ "model_group_detail": ... }`。
 

--- a/internal/cliproxy/auth/model_suffix_test.go
+++ b/internal/cliproxy/auth/model_suffix_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import "testing"
+
+func TestCanonicalModelID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{name: "plain", model: " gpt-5.4 ", want: "gpt-5.4"},
+		{name: "suffix", model: " gpt-5.4(high) ", want: "gpt-5.4"},
+		{name: "unterminated suffix", model: "gpt-5.4(high", want: "gpt-5.4(high"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := CanonicalModelID(test.model); got != test.want {
+				t.Fatalf("CanonicalModelID(%q) = %q, want %q", test.model, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -131,6 +131,11 @@ func authPriority(auth *Auth) int {
 	return parsed
 }
 
+// CanonicalModelID removes a request-option suffix and surrounding whitespace from a model ID.
+func CanonicalModelID(model string) string {
+	return canonicalModelKey(model)
+}
+
 // canonicalModelKey handles a canonical model key.
 func canonicalModelKey(model string) string {
 	model = strings.TrimSpace(model)

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -685,30 +685,37 @@ func (r *Repository) AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKe
 		return nil, nil, errBilling
 	}
 
-	authIDs, errAuthIDs := allowedAuthIDsForAPIKeyRecord(ctx, db, &record)
-	if errAuthIDs != nil {
-		return nil, nil, errAuthIDs
+	baseChannelIDs, errBaseChannels := apiKeyChannelsFromJSON(record.Channels)
+	if errBaseChannels != nil {
+		return nil, nil, errBaseChannels
 	}
 	modelDetails, modelGroupsRestricted, errModelDetails := allowedModelGroupDetailsForAPIKeyRecord(ctx, db, &record)
 	if errModelDetails != nil {
 		return nil, nil, errModelDetails
 	}
 	modelIDs := allowedModelIDsFromDetails(modelDetails, modelGroupsRestricted)
-	if modelID == "" {
-		return authIDs, modelIDs, nil
+	modelChannelIDs, modelChannelsRestricted, errModelChannels := modelChannelGroupIDsFromDetails(modelDetails, modelID)
+	if errModelChannels != nil {
+		return nil, nil, errModelChannels
 	}
 
-	channelIDs, restricted, errChannels := modelChannelGroupIDsFromDetails(modelDetails, modelID)
-	if errChannels != nil {
-		return nil, nil, errChannels
+	allChannelIDs := append([]uint(nil), baseChannelIDs...)
+	if modelChannelsRestricted {
+		allChannelIDs = append(allChannelIDs, modelChannelIDs...)
 	}
-	if !restricted {
+	channelDetails, errChannelDetails := channelGroupDetailsForGroups(ctx, db, allChannelIDs)
+	if errChannelDetails != nil {
+		return nil, nil, errChannelDetails
+	}
+
+	var authIDs []string
+	if len(baseChannelIDs) > 0 {
+		authIDs = allowedAuthIDsFromChannelGroupDetails(channelDetails, baseChannelIDs)
+	}
+	if !modelChannelsRestricted {
 		return authIDs, modelIDs, nil
 	}
-	modelAuthIDs, errModelAuthIDs := allowedAuthIDsForChannelGroups(ctx, db, channelIDs)
-	if errModelAuthIDs != nil {
-		return nil, nil, errModelAuthIDs
-	}
+	modelAuthIDs := allowedAuthIDsFromChannelGroupDetails(channelDetails, modelChannelIDs)
 	return intersectAllowedAuthIDs(authIDs, modelAuthIDs), modelIDs, nil
 }
 
@@ -827,12 +834,20 @@ func allowedAuthIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *API
 }
 
 func allowedAuthIDsForChannelGroups(ctx context.Context, db *gorm.DB, channelIDs []uint) ([]string, error) {
+	details, errDetails := channelGroupDetailsForGroups(ctx, db, channelIDs)
+	if errDetails != nil {
+		return nil, errDetails
+	}
+	return allowedAuthIDsFromChannelGroupDetails(details, channelIDs), nil
+}
+
+func channelGroupDetailsForGroups(ctx context.Context, db *gorm.DB, channelIDs []uint) ([]ChannelGroupDetailRecord, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database connection is nil")
 	}
 	channelIDs = normalizeChannelGroupIDs(channelIDs)
 	if len(channelIDs) == 0 {
-		return []string{}, nil
+		return []ChannelGroupDetailRecord{}, nil
 	}
 
 	var details []ChannelGroupDetailRecord
@@ -846,10 +861,22 @@ func allowedAuthIDsForChannelGroups(ctx context.Context, db *gorm.DB, channelIDs
 		Find(&details).Error; errFind != nil {
 		return nil, errFind
 	}
+	return details, nil
+}
+
+func allowedAuthIDsFromChannelGroupDetails(details []ChannelGroupDetailRecord, channelIDs []uint) []string {
+	channelIDs = normalizeChannelGroupIDs(channelIDs)
+	channelSet := make(map[uint]struct{}, len(channelIDs))
+	for _, channelID := range channelIDs {
+		channelSet[channelID] = struct{}{}
+	}
 
 	allowed := make([]string, 0, len(details))
 	seen := make(map[string]struct{}, len(details))
 	for _, detail := range details {
+		if _, ok := channelSet[detail.ChannelGroupID]; !ok {
+			continue
+		}
 		authID := strings.TrimSpace(detail.AuthID)
 		if authID == "" {
 			continue
@@ -860,7 +887,7 @@ func allowedAuthIDsForChannelGroups(ctx context.Context, db *gorm.DB, channelIDs
 		seen[authID] = struct{}{}
 		allowed = append(allowed, authID)
 	}
-	return allowed, nil
+	return allowed
 }
 
 func allowedModelIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord) ([]string, error) {

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -665,6 +665,129 @@ func ensureAPIKeyUserCreditsAvailable(ctx context.Context, db *gorm.DB, record *
 	return ensureAPIKeyUserBillingAllowed(ctx, db, record)
 }
 
+// AllowedDispatchIDsForAPIKeyModel returns auth and model IDs after applying model-specific channel bindings.
+func (r *Repository) AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKey string, modelID string) ([]string, []string, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, nil, errDB
+	}
+	apiKey = strings.TrimSpace(apiKey)
+	modelID = strings.TrimSpace(modelID)
+	if apiKey == "" {
+		return nil, nil, nil
+	}
+
+	record := APIKeyRecord{}
+	if errFirst := db.WithContext(contextOrBackground(ctx)).Where("api_key = ?", apiKey).First(&record).Error; errFirst != nil {
+		return nil, nil, errFirst
+	}
+	if errBilling := ensureAPIKeyUserBillingAllowed(ctx, db, &record); errBilling != nil {
+		return nil, nil, errBilling
+	}
+
+	authIDs, errAuthIDs := allowedAuthIDsForAPIKeyRecord(ctx, db, &record)
+	if errAuthIDs != nil {
+		return nil, nil, errAuthIDs
+	}
+	modelIDs, errModelIDs := allowedModelIDsForAPIKeyRecord(ctx, db, &record)
+	if errModelIDs != nil {
+		return nil, nil, errModelIDs
+	}
+	if modelID == "" {
+		return authIDs, modelIDs, nil
+	}
+
+	channelIDs, restricted, errChannels := modelChannelGroupIDsForAPIKeyRecord(ctx, db, &record, modelID)
+	if errChannels != nil {
+		return nil, nil, errChannels
+	}
+	if !restricted {
+		return authIDs, modelIDs, nil
+	}
+	modelAuthIDs, errModelAuthIDs := allowedAuthIDsForChannelGroups(ctx, db, channelIDs)
+	if errModelAuthIDs != nil {
+		return nil, nil, errModelAuthIDs
+	}
+	return intersectAllowedAuthIDs(authIDs, modelAuthIDs), modelIDs, nil
+}
+
+func modelChannelGroupIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord, modelID string) ([]uint, bool, error) {
+	if db == nil {
+		return nil, false, fmt.Errorf("database connection is nil")
+	}
+	if record == nil {
+		return nil, false, fmt.Errorf("api key record is nil")
+	}
+	modelGroupIDs, errModelGroups := apiKeyModelGroupsFromJSON(record.ModelGroups)
+	if errModelGroups != nil {
+		return nil, false, errModelGroups
+	}
+	modelID = strings.ToLower(strings.TrimSpace(modelID))
+	if len(modelGroupIDs) == 0 || modelID == "" {
+		return nil, false, nil
+	}
+
+	var details []ModelGroupDetailRecord
+	if errFind := db.WithContext(contextOrBackground(ctx)).
+		Model(&ModelGroupDetailRecord{}).
+		Joins("JOIN model_group ON model_group.id = model_group_detail.model_group_id").
+		Where("model_group.deleted_at IS NULL").
+		Where("model_group.disabled = ?", false).
+		Where("model_group_detail.model_group_id IN ?", modelGroupIDs).
+		Where("LOWER(model_group_detail.model_id) = ?", modelID).
+		Order("model_group_detail.model_group_id ASC, model_group_detail.id ASC").
+		Find(&details).Error; errFind != nil {
+		return nil, false, errFind
+	}
+
+	channelIDs := make([]uint, 0)
+	restricted := false
+	for i := range details {
+		detailChannels, errDetailChannels := ModelGroupDetailChannelIDs(&details[i])
+		if errDetailChannels != nil {
+			return nil, false, errDetailChannels
+		}
+		if len(detailChannels) == 0 {
+			continue
+		}
+		restricted = true
+		channelIDs = append(channelIDs, detailChannels...)
+	}
+	return normalizeChannelGroupIDs(channelIDs), restricted, nil
+}
+
+func intersectAllowedAuthIDs(base []string, modelSpecific []string) []string {
+	if base == nil {
+		allowed := make([]string, len(modelSpecific))
+		copy(allowed, modelSpecific)
+		return allowed
+	}
+	modelSet := make(map[string]struct{}, len(modelSpecific))
+	for _, authID := range modelSpecific {
+		authID = strings.TrimSpace(authID)
+		if authID != "" {
+			modelSet[authID] = struct{}{}
+		}
+	}
+	allowed := make([]string, 0, len(base))
+	seen := make(map[string]struct{}, len(base))
+	for _, authID := range base {
+		authID = strings.TrimSpace(authID)
+		if authID == "" {
+			continue
+		}
+		if _, ok := modelSet[authID]; !ok {
+			continue
+		}
+		if _, ok := seen[authID]; ok {
+			continue
+		}
+		seen[authID] = struct{}{}
+		allowed = append(allowed, authID)
+	}
+	return allowed
+}
+
 // AllowedAuthIDsForAPIKey returns auth IDs allowed by the API key channel bindings.
 func (r *Repository) AllowedAuthIDsForAPIKey(ctx context.Context, apiKey string) ([]string, error) {
 	db, errDB := r.database()
@@ -718,6 +841,17 @@ func allowedAuthIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *API
 	}
 	if len(channelIDs) == 0 {
 		return nil, nil
+	}
+	return allowedAuthIDsForChannelGroups(ctx, db, channelIDs)
+}
+
+func allowedAuthIDsForChannelGroups(ctx context.Context, db *gorm.DB, channelIDs []uint) ([]string, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is nil")
+	}
+	channelIDs = normalizeChannelGroupIDs(channelIDs)
+	if len(channelIDs) == 0 {
+		return []string{}, nil
 	}
 
 	var details []ChannelGroupDetailRecord

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -689,15 +689,16 @@ func (r *Repository) AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKe
 	if errAuthIDs != nil {
 		return nil, nil, errAuthIDs
 	}
-	modelIDs, errModelIDs := allowedModelIDsForAPIKeyRecord(ctx, db, &record)
-	if errModelIDs != nil {
-		return nil, nil, errModelIDs
+	modelDetails, modelGroupsRestricted, errModelDetails := allowedModelGroupDetailsForAPIKeyRecord(ctx, db, &record)
+	if errModelDetails != nil {
+		return nil, nil, errModelDetails
 	}
+	modelIDs := allowedModelIDsFromDetails(modelDetails, modelGroupsRestricted)
 	if modelID == "" {
 		return authIDs, modelIDs, nil
 	}
 
-	channelIDs, restricted, errChannels := modelChannelGroupIDsForAPIKeyRecord(ctx, db, &record, modelID)
+	channelIDs, restricted, errChannels := modelChannelGroupIDsFromDetails(modelDetails, modelID)
 	if errChannels != nil {
 		return nil, nil, errChannels
 	}
@@ -711,38 +712,18 @@ func (r *Repository) AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKe
 	return intersectAllowedAuthIDs(authIDs, modelAuthIDs), modelIDs, nil
 }
 
-func modelChannelGroupIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord, modelID string) ([]uint, bool, error) {
-	if db == nil {
-		return nil, false, fmt.Errorf("database connection is nil")
-	}
-	if record == nil {
-		return nil, false, fmt.Errorf("api key record is nil")
-	}
-	modelGroupIDs, errModelGroups := apiKeyModelGroupsFromJSON(record.ModelGroups)
-	if errModelGroups != nil {
-		return nil, false, errModelGroups
-	}
-	modelID = strings.ToLower(strings.TrimSpace(modelID))
-	if len(modelGroupIDs) == 0 || modelID == "" {
+func modelChannelGroupIDsFromDetails(details []ModelGroupDetailRecord, modelID string) ([]uint, bool, error) {
+	modelKey := strings.ToLower(canonicalModelGroupModelID(modelID))
+	if modelKey == "" {
 		return nil, false, nil
-	}
-
-	var details []ModelGroupDetailRecord
-	if errFind := db.WithContext(contextOrBackground(ctx)).
-		Model(&ModelGroupDetailRecord{}).
-		Joins("JOIN model_group ON model_group.id = model_group_detail.model_group_id").
-		Where("model_group.deleted_at IS NULL").
-		Where("model_group.disabled = ?", false).
-		Where("model_group_detail.model_group_id IN ?", modelGroupIDs).
-		Where("LOWER(model_group_detail.model_id) = ?", modelID).
-		Order("model_group_detail.model_group_id ASC, model_group_detail.id ASC").
-		Find(&details).Error; errFind != nil {
-		return nil, false, errFind
 	}
 
 	channelIDs := make([]uint, 0)
 	restricted := false
 	for i := range details {
+		if strings.ToLower(canonicalModelGroupModelID(details[i].ModelID)) != modelKey {
+			continue
+		}
 		detailChannels, errDetailChannels := ModelGroupDetailChannelIDs(&details[i])
 		if errDetailChannels != nil {
 			return nil, false, errDetailChannels
@@ -883,18 +864,26 @@ func allowedAuthIDsForChannelGroups(ctx context.Context, db *gorm.DB, channelIDs
 }
 
 func allowedModelIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord) ([]string, error) {
+	details, restricted, errDetails := allowedModelGroupDetailsForAPIKeyRecord(ctx, db, record)
+	if errDetails != nil {
+		return nil, errDetails
+	}
+	return allowedModelIDsFromDetails(details, restricted), nil
+}
+
+func allowedModelGroupDetailsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord) ([]ModelGroupDetailRecord, bool, error) {
 	if db == nil {
-		return nil, fmt.Errorf("database connection is nil")
+		return nil, false, fmt.Errorf("database connection is nil")
 	}
 	if record == nil {
-		return nil, fmt.Errorf("api key record is nil")
+		return nil, false, fmt.Errorf("api key record is nil")
 	}
 	modelGroupIDs, errModelGroups := apiKeyModelGroupsFromJSON(record.ModelGroups)
 	if errModelGroups != nil {
-		return nil, errModelGroups
+		return nil, false, errModelGroups
 	}
 	if len(modelGroupIDs) == 0 {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	var details []ModelGroupDetailRecord
@@ -906,13 +895,19 @@ func allowedModelIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *AP
 		Where("model_group_detail.model_group_id IN ?", modelGroupIDs).
 		Order("model_group_detail.model_group_id ASC, model_group_detail.id ASC").
 		Find(&details).Error; errFind != nil {
-		return nil, errFind
+		return nil, false, errFind
 	}
+	return details, true, nil
+}
 
+func allowedModelIDsFromDetails(details []ModelGroupDetailRecord, restricted bool) []string {
+	if !restricted {
+		return nil
+	}
 	allowed := make([]string, 0, len(details))
 	seen := make(map[string]struct{}, len(details))
-	for _, detail := range details {
-		modelID := strings.TrimSpace(detail.ModelID)
+	for i := range details {
+		modelID := canonicalModelGroupModelID(details[i].ModelID)
 		if modelID == "" {
 			continue
 		}
@@ -923,7 +918,7 @@ func allowedModelIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *AP
 		seen[modelKey] = struct{}{}
 		allowed = append(allowed, modelID)
 	}
-	return allowed, nil
+	return allowed
 }
 
 func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries []APIKeyEntryUpdate) (APIKeyUpsertStats, error) {

--- a/internal/cluster/channel_groups.go
+++ b/internal/cluster/channel_groups.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type ChannelGroupUpdate struct {
@@ -306,7 +307,11 @@ func ensureAuthExists(ctx context.Context, tx *gorm.DB, authID string) error {
 	}
 	record := AuthRecord{}
 	errFirst := tx.WithContext(contextOrBackground(ctx)).
-		Where("uuid = ? OR id = ? OR index = ?", authID, authID, authID).
+		Where(clause.Or(
+			clause.Eq{Column: clause.Column{Name: "uuid"}, Value: authID},
+			clause.Eq{Column: clause.Column{Name: "id"}, Value: authID},
+			clause.Eq{Column: clause.Column{Name: "index"}, Value: authID},
+		)).
 		First(&record).Error
 	if errors.Is(errFirst, gorm.ErrRecordNotFound) {
 		return fmt.Errorf("auth not found: %w", errFirst)

--- a/internal/cluster/channel_groups_test.go
+++ b/internal/cluster/channel_groups_test.go
@@ -1,0 +1,44 @@
+package cluster
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+)
+
+func TestCreateChannelGroupDetailFindsAuthByQuotedIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}()
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+
+	repo := NewRepository(db)
+	authID := "auth-a"
+	if _, errUpsert := repo.UpsertAuth(ctx, &coreauth.Auth{ID: authID, Index: authID, Provider: "codex"}, "test"); errUpsert != nil {
+		t.Fatalf("UpsertAuth() error = %v", errUpsert)
+	}
+	group, errGroup := repo.CreateChannelGroup(ctx, "codex", false)
+	if errGroup != nil {
+		t.Fatalf("CreateChannelGroup() error = %v", errGroup)
+	}
+	if _, errDetail := repo.CreateChannelGroupDetail(ctx, group.ID, authID); errDetail != nil {
+		t.Fatalf("CreateChannelGroupDetail() error = %v", errDetail)
+	}
+}

--- a/internal/cluster/db.go
+++ b/internal/cluster/db.go
@@ -141,6 +141,9 @@ func autoMigrate(db *gorm.DB) error {
 	if errMigrate := migrateAPIKeyModelGroups(db); errMigrate != nil {
 		return errMigrate
 	}
+	if errMigrate := migrateModelGroupDetailChannels(db); errMigrate != nil {
+		return errMigrate
+	}
 	if errMigrate := migrateUserUniqueUsername(db); errMigrate != nil {
 		return errMigrate
 	}

--- a/internal/cluster/management/model_groups.go
+++ b/internal/cluster/management/model_groups.go
@@ -327,6 +327,10 @@ func modelGroupDetailFilterFromRequest(c *gin.Context) (cluster.ModelGroupDetail
 }
 
 func respondModelRecordError(c *gin.Context, code string, err error) {
+	if errors.Is(err, cluster.ErrInvalidModelChannelGroupID) {
+		respondError(c, http.StatusBadRequest, "invalid body", err)
+		return
+	}
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		respondError(c, http.StatusNotFound, "not_found", err)
 		return

--- a/internal/cluster/management/model_groups.go
+++ b/internal/cluster/management/model_groups.go
@@ -20,6 +20,7 @@ type modelGroupWriteRequest struct {
 type modelGroupDetailWriteRequest struct {
 	ModelGroupID *uint   `json:"model_group_id"`
 	ModelID      *string `json:"model_id"`
+	Channels     *[]uint `json:"channels"`
 }
 
 // ListModelGroups returns model groups.
@@ -151,7 +152,12 @@ func (h *Handler) ListModelGroupDetails(c *gin.Context) {
 	}
 	items := make([]gin.H, 0, len(records))
 	for _, record := range records {
-		items = append(items, modelGroupDetailRecordToMap(&record))
+		item, errItem := modelGroupDetailRecordToMap(&record)
+		if errItem != nil {
+			respondError(c, http.StatusInternalServerError, "model_group_detail_load_failed", errItem)
+			return
+		}
+		items = append(items, item)
 	}
 	c.JSON(http.StatusOK, gin.H{"model_group_details": items})
 }
@@ -170,7 +176,12 @@ func (h *Handler) GetModelGroupDetail(c *gin.Context) {
 		respondModelRecordError(c, "model_group_detail_load_failed", errRecord)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"model_group_detail": modelGroupDetailRecordToMap(record)})
+	item, errItem := modelGroupDetailRecordToMap(record)
+	if errItem != nil {
+		respondError(c, http.StatusInternalServerError, "model_group_detail_load_failed", errItem)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"model_group_detail": item})
 }
 
 // CreateModelGroupDetail creates a model group detail.
@@ -195,12 +206,21 @@ func (h *Handler) CreateModelGroupDetail(c *gin.Context) {
 
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
-	record, errCreate := h.repo.CreateModelGroupDetail(ctx, *body.ModelGroupID, modelID)
+	channels := []uint(nil)
+	if body.Channels != nil {
+		channels = *body.Channels
+	}
+	record, errCreate := h.repo.CreateModelGroupDetail(ctx, *body.ModelGroupID, modelID, channels)
 	if errCreate != nil {
 		respondModelRecordError(c, "model_group_detail_create_failed", errCreate)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"model_group_detail": modelGroupDetailRecordToMap(record)})
+	item, errItem := modelGroupDetailRecordToMap(record)
+	if errItem != nil {
+		respondError(c, http.StatusInternalServerError, "model_group_detail_create_failed", errItem)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"model_group_detail": item})
 }
 
 // UpdateModelGroupDetail updates a model group detail.
@@ -216,6 +236,7 @@ func (h *Handler) UpdateModelGroupDetail(c *gin.Context) {
 	}
 	update := cluster.ModelGroupDetailUpdate{
 		ModelGroupID: body.ModelGroupID,
+		Channels:     body.Channels,
 	}
 	if body.ModelID != nil {
 		modelID := strings.TrimSpace(*body.ModelID)
@@ -229,7 +250,12 @@ func (h *Handler) UpdateModelGroupDetail(c *gin.Context) {
 		respondModelRecordError(c, "model_group_detail_update_failed", errUpdate)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"model_group_detail": modelGroupDetailRecordToMap(record)})
+	item, errItem := modelGroupDetailRecordToMap(record)
+	if errItem != nil {
+		respondError(c, http.StatusInternalServerError, "model_group_detail_update_failed", errItem)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"model_group_detail": item})
 }
 
 // DeleteModelGroupDetail deletes a model group detail.
@@ -322,16 +348,24 @@ func modelGroupRecordToMap(record *cluster.ModelGroupRecord) gin.H {
 	}
 }
 
-func modelGroupDetailRecordToMap(record *cluster.ModelGroupDetailRecord) gin.H {
+func modelGroupDetailRecordToMap(record *cluster.ModelGroupDetailRecord) (gin.H, error) {
 	if record == nil {
-		return gin.H{}
+		return gin.H{}, nil
+	}
+	channels, errChannels := cluster.ModelGroupDetailChannelIDs(record)
+	if errChannels != nil {
+		return nil, errChannels
+	}
+	if channels == nil {
+		channels = []uint{}
 	}
 	return gin.H{
 		"id":             record.ID,
 		"model_group_id": record.ModelGroupID,
 		"model_id":       record.ModelID,
+		"channels":       channels,
 		"created_at":     record.CreatedAt,
 		"updated_at":     record.UpdatedAt,
 		"deleted_at":     deletedAtValue(record.DeletedAt),
-	}
+	}, nil
 }

--- a/internal/cluster/management/model_groups.go
+++ b/internal/cluster/management/model_groups.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"gorm.io/gorm"
 )
@@ -362,7 +363,7 @@ func modelGroupDetailRecordToMap(record *cluster.ModelGroupDetailRecord) (gin.H,
 	return gin.H{
 		"id":             record.ID,
 		"model_group_id": record.ModelGroupID,
-		"model_id":       record.ModelID,
+		"model_id":       coreauth.CanonicalModelID(record.ModelID),
 		"channels":       channels,
 		"created_at":     record.CreatedAt,
 		"updated_at":     record.UpdatedAt,

--- a/internal/cluster/management/model_groups_test.go
+++ b/internal/cluster/management/model_groups_test.go
@@ -1,0 +1,29 @@
+package management
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+func TestModelGroupDetailRecordToMapIncludesChannels(t *testing.T) {
+	t.Parallel()
+
+	item, errItem := modelGroupDetailRecordToMap(&cluster.ModelGroupDetailRecord{
+		ID:           10,
+		ModelGroupID: 2,
+		ModelID:      "gpt-5.4",
+		Channels:     cluster.JSONB(`[4,2,4]`),
+	})
+	if errItem != nil {
+		t.Fatalf("modelGroupDetailRecordToMap() error = %v", errItem)
+	}
+	channels, ok := item["channels"].([]uint)
+	if !ok {
+		t.Fatalf("channels = %T, want []uint", item["channels"])
+	}
+	if want := []uint{2, 4}; !reflect.DeepEqual(channels, want) {
+		t.Fatalf("channels = %v, want %v", channels, want)
+	}
+}

--- a/internal/cluster/management/model_groups_test.go
+++ b/internal/cluster/management/model_groups_test.go
@@ -32,6 +32,22 @@ func TestModelGroupDetailRoutesCreateAndClearChannels(t *testing.T) {
 	engine.POST("/model-group-details", handler.CreateModelGroupDetail)
 	engine.PATCH("/model-group-details/:id", handler.UpdateModelGroupDetail)
 
+	invalidBody, errInvalidBody := json.Marshal(map[string]any{
+		"model_group_id": modelGroup.ID,
+		"model_id":       "gpt-invalid",
+		"channels":       []uint{channel.ID, 0},
+	})
+	if errInvalidBody != nil {
+		t.Fatalf("marshal invalid body: %v", errInvalidBody)
+	}
+	invalidResponse := httptest.NewRecorder()
+	invalidRequest := httptest.NewRequest(http.MethodPost, "/model-group-details", bytes.NewReader(invalidBody))
+	invalidRequest.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(invalidResponse, invalidRequest)
+	if invalidResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid status = %d body=%s, want %d", invalidResponse.Code, invalidResponse.Body.String(), http.StatusBadRequest)
+	}
+
 	createBody, errCreateBody := json.Marshal(map[string]any{
 		"model_group_id": modelGroup.ID,
 		"model_id":       "gpt-5.4",
@@ -58,6 +74,14 @@ func TestModelGroupDetailRoutesCreateAndClearChannels(t *testing.T) {
 	}
 	if createPayload.Detail.ID == 0 || !reflect.DeepEqual(createPayload.Detail.Channels, []uint{channel.ID}) {
 		t.Fatalf("created detail = %#v", createPayload.Detail)
+	}
+
+	invalidPatchResponse := httptest.NewRecorder()
+	invalidPatchRequest := httptest.NewRequest(http.MethodPatch, "/model-group-details/"+modelRecordID(createPayload.Detail.ID), bytes.NewBufferString(`{"channels":[0]}`))
+	invalidPatchRequest.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(invalidPatchResponse, invalidPatchRequest)
+	if invalidPatchResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid patch status = %d body=%s, want %d", invalidPatchResponse.Code, invalidPatchResponse.Body.String(), http.StatusBadRequest)
 	}
 
 	patchResponse := httptest.NewRecorder()

--- a/internal/cluster/management/model_groups_test.go
+++ b/internal/cluster/management/model_groups_test.go
@@ -1,11 +1,88 @@
 package management
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 )
+
+func TestModelGroupDetailRoutesCreateAndClearChannels(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+
+	ctx := t.Context()
+	channel, errChannel := handler.repo.CreateChannelGroup(ctx, "codex-subset", false)
+	if errChannel != nil {
+		t.Fatalf("CreateChannelGroup() error = %v", errChannel)
+	}
+	modelGroup, errModelGroup := handler.repo.CreateModelGroup(ctx, "codex-models", false)
+	if errModelGroup != nil {
+		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
+	}
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.POST("/model-group-details", handler.CreateModelGroupDetail)
+	engine.PATCH("/model-group-details/:id", handler.UpdateModelGroupDetail)
+
+	createBody, errCreateBody := json.Marshal(map[string]any{
+		"model_group_id": modelGroup.ID,
+		"model_id":       "gpt-5.4",
+		"channels":       []uint{channel.ID},
+	})
+	if errCreateBody != nil {
+		t.Fatalf("marshal create body: %v", errCreateBody)
+	}
+	createResponse := httptest.NewRecorder()
+	createRequest := httptest.NewRequest(http.MethodPost, "/model-group-details", bytes.NewReader(createBody))
+	createRequest.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(createResponse, createRequest)
+	if createResponse.Code != http.StatusOK {
+		t.Fatalf("create status = %d body=%s", createResponse.Code, createResponse.Body.String())
+	}
+	var createPayload struct {
+		Detail struct {
+			ID       uint   `json:"id"`
+			Channels []uint `json:"channels"`
+		} `json:"model_group_detail"`
+	}
+	if errDecode := json.Unmarshal(createResponse.Body.Bytes(), &createPayload); errDecode != nil {
+		t.Fatalf("decode create response: %v", errDecode)
+	}
+	if createPayload.Detail.ID == 0 || !reflect.DeepEqual(createPayload.Detail.Channels, []uint{channel.ID}) {
+		t.Fatalf("created detail = %#v", createPayload.Detail)
+	}
+
+	patchResponse := httptest.NewRecorder()
+	patchRequest := httptest.NewRequest(http.MethodPatch, "/model-group-details/"+modelRecordID(createPayload.Detail.ID), bytes.NewBufferString(`{"channels":[]}`))
+	patchRequest.Header.Set("Content-Type", "application/json")
+	engine.ServeHTTP(patchResponse, patchRequest)
+	if patchResponse.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s", patchResponse.Code, patchResponse.Body.String())
+	}
+	var patchPayload struct {
+		Detail struct {
+			Channels []uint `json:"channels"`
+		} `json:"model_group_detail"`
+	}
+	if errDecode := json.Unmarshal(patchResponse.Body.Bytes(), &patchPayload); errDecode != nil {
+		t.Fatalf("decode patch response: %v", errDecode)
+	}
+	if patchPayload.Detail.Channels == nil || len(patchPayload.Detail.Channels) != 0 {
+		t.Fatalf("patched channels = %#v, want empty array", patchPayload.Detail.Channels)
+	}
+}
+
+func modelRecordID(id uint) string {
+	return strconv.FormatUint(uint64(id), 10)
+}
 
 func TestModelGroupDetailRecordToMapIncludesChannels(t *testing.T) {
 	t.Parallel()

--- a/internal/cluster/management/model_groups_test.go
+++ b/internal/cluster/management/model_groups_test.go
@@ -29,6 +29,7 @@ func TestModelGroupDetailRoutesCreateAndClearChannels(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	engine := gin.New()
+	engine.GET("/model-group-details", handler.ListModelGroupDetails)
 	engine.POST("/model-group-details", handler.CreateModelGroupDetail)
 	engine.PATCH("/model-group-details/:id", handler.UpdateModelGroupDetail)
 
@@ -74,6 +75,25 @@ func TestModelGroupDetailRoutesCreateAndClearChannels(t *testing.T) {
 	}
 	if createPayload.Detail.ID == 0 || !reflect.DeepEqual(createPayload.Detail.Channels, []uint{channel.ID}) {
 		t.Fatalf("created detail = %#v", createPayload.Detail)
+	}
+
+	filterResponse := httptest.NewRecorder()
+	filterRequest := httptest.NewRequest(http.MethodGet, "/model-group-details?model_id=gpt-5.4(high)", nil)
+	engine.ServeHTTP(filterResponse, filterRequest)
+	if filterResponse.Code != http.StatusOK {
+		t.Fatalf("filter status = %d body=%s", filterResponse.Code, filterResponse.Body.String())
+	}
+	var filterPayload struct {
+		Details []struct {
+			ID      uint   `json:"id"`
+			ModelID string `json:"model_id"`
+		} `json:"model_group_details"`
+	}
+	if errDecode := json.Unmarshal(filterResponse.Body.Bytes(), &filterPayload); errDecode != nil {
+		t.Fatalf("decode filter response: %v", errDecode)
+	}
+	if len(filterPayload.Details) != 1 || filterPayload.Details[0].ID != createPayload.Detail.ID || filterPayload.Details[0].ModelID != "gpt-5.4" {
+		t.Fatalf("filtered details = %#v, want canonical created detail", filterPayload.Details)
 	}
 
 	invalidPatchResponse := httptest.NewRecorder()

--- a/internal/cluster/management/model_groups_test.go
+++ b/internal/cluster/management/model_groups_test.go
@@ -90,11 +90,14 @@ func TestModelGroupDetailRecordToMapIncludesChannels(t *testing.T) {
 	item, errItem := modelGroupDetailRecordToMap(&cluster.ModelGroupDetailRecord{
 		ID:           10,
 		ModelGroupID: 2,
-		ModelID:      "gpt-5.4",
+		ModelID:      "gpt-5.4(high)",
 		Channels:     cluster.JSONB(`[4,2,4]`),
 	})
 	if errItem != nil {
 		t.Fatalf("modelGroupDetailRecordToMap() error = %v", errItem)
+	}
+	if item["model_id"] != "gpt-5.4" {
+		t.Fatalf("model_id = %v, want canonical gpt-5.4", item["model_id"])
 	}
 	channels, ok := item["channels"].([]uint)
 	if !ok {

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -56,6 +56,7 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 			"oauth_usage":             true,
 			"logs":                    true,
 			"request_error_logs":      true,
+			"model_channel_bindings":  true,
 			"topology":                true,
 			"users":                   true,
 			"access_groups":           true,

--- a/internal/cluster/management/usage_observability_test.go
+++ b/internal/cluster/management/usage_observability_test.go
@@ -118,7 +118,7 @@ func TestGetCapabilitiesReturnsUsageObservabilityFlags(t *testing.T) {
 	if !ok {
 		t.Fatalf("capabilities = %T, want object", payload["capabilities"])
 	}
-	for _, key := range []string{"quota_snapshots", "quota_snapshot_details", "usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "request_log_index", "request_events", "request_event_details", "request_event_export", "request_event_filters", "request_events_details", "request_events_export", "request_events_filters", "requestEvents", "requestEventDetails", "requestEventExport", "requestEventFilters", "requestEventsDetails", "requestEventsExport", "requestEventsFilters", "oauth_usage", "logs", "request_error_logs", "topology"} {
+	for _, key := range []string{"quota_snapshots", "quota_snapshot_details", "usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "request_log_index", "request_events", "request_event_details", "request_event_export", "request_event_filters", "request_events_details", "request_events_export", "request_events_filters", "requestEvents", "requestEventDetails", "requestEventExport", "requestEventFilters", "requestEventsDetails", "requestEventsExport", "requestEventsFilters", "oauth_usage", "logs", "request_error_logs", "model_channel_bindings", "topology"} {
 		if capabilities[key] != true {
 			t.Fatalf("capabilities[%s] = %v, want true", key, capabilities[key])
 		}

--- a/internal/cluster/model_groups.go
+++ b/internal/cluster/model_groups.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
 	"gorm.io/gorm"
 )
 
@@ -180,7 +181,7 @@ func (r *Repository) CreateModelGroupDetail(ctx context.Context, modelGroupID ui
 	if errDB != nil {
 		return nil, errDB
 	}
-	modelID = strings.TrimSpace(modelID)
+	modelID = canonicalModelGroupModelID(modelID)
 	if modelGroupID == 0 {
 		return nil, fmt.Errorf("model group id is required")
 	}
@@ -239,7 +240,7 @@ func (r *Repository) UpdateModelGroupDetail(ctx context.Context, id uint, update
 			record.ModelGroupID = *update.ModelGroupID
 		}
 		if update.ModelID != nil {
-			modelID := strings.TrimSpace(*update.ModelID)
+			modelID := canonicalModelGroupModelID(*update.ModelID)
 			if modelID == "" {
 				return fmt.Errorf("model id is required")
 			}
@@ -295,6 +296,10 @@ func ParseModelRecordID(value string) (uint, error) {
 		return 0, fmt.Errorf("record id is required")
 	}
 	return uint(parsed), nil
+}
+
+func canonicalModelGroupModelID(modelID string) string {
+	return coreauth.CanonicalModelID(modelID)
 }
 
 func ensureModelGroupExists(ctx context.Context, tx *gorm.DB, id uint) error {

--- a/internal/cluster/model_groups.go
+++ b/internal/cluster/model_groups.go
@@ -18,6 +18,7 @@ type ModelGroupUpdate struct {
 type ModelGroupDetailUpdate struct {
 	ModelGroupID *uint
 	ModelID      *string
+	Channels     *[]uint
 }
 
 type ModelGroupDetailFilter struct {
@@ -174,7 +175,7 @@ func (r *Repository) GetModelGroupDetail(ctx context.Context, id uint) (*ModelGr
 }
 
 // CreateModelGroupDetail creates a model group detail.
-func (r *Repository) CreateModelGroupDetail(ctx context.Context, modelGroupID uint, modelID string) (*ModelGroupDetailRecord, error) {
+func (r *Repository) CreateModelGroupDetail(ctx context.Context, modelGroupID uint, modelID string, channels []uint) (*ModelGroupDetailRecord, error) {
 	db, errDB := r.database()
 	if errDB != nil {
 		return nil, errDB
@@ -186,15 +187,23 @@ func (r *Repository) CreateModelGroupDetail(ctx context.Context, modelGroupID ui
 	if modelID == "" {
 		return nil, fmt.Errorf("model id is required")
 	}
+	channelsJSON, errChannels := modelGroupDetailChannelsJSON(channels)
+	if errChannels != nil {
+		return nil, errChannels
+	}
 
 	record := &ModelGroupDetailRecord{
 		ModelGroupID: modelGroupID,
 		ModelID:      modelID,
+		Channels:     channelsJSON,
 	}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if errGroup := ensureModelGroupExists(ctx, tx, modelGroupID); errGroup != nil {
 			return errGroup
+		}
+		if errChannelGroups := ensureChannelGroupsExist(ctx, tx, channels); errChannelGroups != nil {
+			return errChannelGroups
 		}
 		return tx.Create(record).Error
 	})
@@ -235,6 +244,16 @@ func (r *Repository) UpdateModelGroupDetail(ctx context.Context, id uint, update
 				return fmt.Errorf("model id is required")
 			}
 			record.ModelID = modelID
+		}
+		if update.Channels != nil {
+			if errChannelGroups := ensureChannelGroupsExist(ctx, tx, *update.Channels); errChannelGroups != nil {
+				return errChannelGroups
+			}
+			channelsJSON, errChannels := modelGroupDetailChannelsJSON(*update.Channels)
+			if errChannels != nil {
+				return errChannels
+			}
+			record.Channels = channelsJSON
 		}
 		return tx.Save(record).Error
 	})
@@ -288,4 +307,38 @@ func ensureModelGroupExists(ctx context.Context, tx *gorm.DB, id uint) error {
 		return fmt.Errorf("model group not found: %w", errFirst)
 	}
 	return errFirst
+}
+
+func ensureChannelGroupsExist(ctx context.Context, tx *gorm.DB, ids []uint) error {
+	for _, id := range normalizeChannelGroupIDs(ids) {
+		if errGroup := ensureChannelGroupExists(ctx, tx, id); errGroup != nil {
+			return errGroup
+		}
+	}
+	return nil
+}
+
+func modelGroupDetailChannelsJSON(channels []uint) (JSONB, error) {
+	return apiKeyChannelsJSON(channels)
+}
+
+func modelGroupDetailChannelsFromJSON(raw JSONB) ([]uint, error) {
+	return apiKeyChannelsFromJSON(raw)
+}
+
+// ModelGroupDetailChannelIDs returns the channel group IDs bound to a model detail.
+func ModelGroupDetailChannelIDs(record *ModelGroupDetailRecord) ([]uint, error) {
+	if record == nil {
+		return nil, fmt.Errorf("model group detail record is nil")
+	}
+	return modelGroupDetailChannelsFromJSON(record.Channels)
+}
+
+func migrateModelGroupDetailChannels(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	return db.Model(&ModelGroupDetailRecord{}).
+		Where("channels IS NULL").
+		Update("channels", emptyAPIKeyChannelsJSON()).Error
 }

--- a/internal/cluster/model_groups.go
+++ b/internal/cluster/model_groups.go
@@ -11,6 +11,9 @@ import (
 	"gorm.io/gorm"
 )
 
+// ErrInvalidModelChannelGroupID indicates that a model detail channel binding contains ID zero.
+var ErrInvalidModelChannelGroupID = errors.New("model channel group id must be greater than zero")
+
 type ModelGroupUpdate struct {
 	GroupName *string
 	Disabled  *bool
@@ -188,6 +191,9 @@ func (r *Repository) CreateModelGroupDetail(ctx context.Context, modelGroupID ui
 	if modelID == "" {
 		return nil, fmt.Errorf("model id is required")
 	}
+	if errChannels := validateModelGroupDetailChannelIDs(channels); errChannels != nil {
+		return nil, errChannels
+	}
 	channelsJSON, errChannels := modelGroupDetailChannelsJSON(channels)
 	if errChannels != nil {
 		return nil, errChannels
@@ -314,7 +320,19 @@ func ensureModelGroupExists(ctx context.Context, tx *gorm.DB, id uint) error {
 	return errFirst
 }
 
+func validateModelGroupDetailChannelIDs(ids []uint) error {
+	for _, id := range ids {
+		if id == 0 {
+			return ErrInvalidModelChannelGroupID
+		}
+	}
+	return nil
+}
+
 func ensureChannelGroupsExist(ctx context.Context, tx *gorm.DB, ids []uint) error {
+	if errIDs := validateModelGroupDetailChannelIDs(ids); errIDs != nil {
+		return errIDs
+	}
 	for _, id := range normalizeChannelGroupIDs(ids) {
 		if errGroup := ensureChannelGroupExists(ctx, tx, id); errGroup != nil {
 			return errGroup

--- a/internal/cluster/model_groups.go
+++ b/internal/cluster/model_groups.go
@@ -150,15 +150,26 @@ func (r *Repository) ListModelGroupDetails(ctx context.Context, filter ModelGrou
 	if filter.ModelGroupID != nil {
 		query = query.Where("model_group_id = ?", *filter.ModelGroupID)
 	}
-	if modelID := strings.TrimSpace(filter.ModelID); modelID != "" {
-		query = query.Where("model_id = ?", modelID)
-	}
 
 	var records []ModelGroupDetailRecord
 	if errFind := query.Find(&records).Error; errFind != nil {
 		return nil, errFind
 	}
-	return records, nil
+	rawModelID := strings.TrimSpace(filter.ModelID)
+	if rawModelID == "" {
+		return records, nil
+	}
+	modelID := canonicalModelGroupModelID(rawModelID)
+	if modelID == "" {
+		return []ModelGroupDetailRecord{}, nil
+	}
+	filtered := make([]ModelGroupDetailRecord, 0, len(records))
+	for i := range records {
+		if strings.EqualFold(canonicalModelGroupModelID(records[i].ModelID), modelID) {
+			filtered = append(filtered, records[i])
+		}
+	}
+	return filtered, nil
 }
 
 // GetModelGroupDetail returns a model group detail by ID.

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
 	"gorm.io/gorm"
 )
 
@@ -86,6 +87,138 @@ func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 	}
 	if !reflect.DeepEqual(channels, updatedChannels) {
 		t.Fatalf("channels after rejected update = %v, want %v", channels, updatedChannels)
+	}
+}
+
+func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}()
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+
+	repo := NewRepository(db)
+	for _, authID := range []string{"auth-a", "auth-b", "auth-c"} {
+		auth := &coreauth.Auth{ID: authID, Index: authID, Provider: "codex"}
+		if _, errUpsert := repo.UpsertAuth(ctx, auth, "test"); errUpsert != nil {
+			t.Fatalf("UpsertAuth(%s) error = %v", authID, errUpsert)
+		}
+	}
+	allChannel, errAllChannel := repo.CreateChannelGroup(ctx, "codex-all", false)
+	if errAllChannel != nil {
+		t.Fatalf("CreateChannelGroup(all) error = %v", errAllChannel)
+	}
+	subsetChannel, errSubsetChannel := repo.CreateChannelGroup(ctx, "codex-subset", false)
+	if errSubsetChannel != nil {
+		t.Fatalf("CreateChannelGroup(subset) error = %v", errSubsetChannel)
+	}
+	emptyChannel, errEmptyChannel := repo.CreateChannelGroup(ctx, "codex-empty", false)
+	if errEmptyChannel != nil {
+		t.Fatalf("CreateChannelGroup(empty) error = %v", errEmptyChannel)
+	}
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		if _, errDetail := repo.CreateChannelGroupDetail(ctx, allChannel.ID, authID); errDetail != nil {
+			t.Fatalf("CreateChannelGroupDetail(all, %s) error = %v", authID, errDetail)
+		}
+	}
+	for _, authID := range []string{"auth-b", "auth-c"} {
+		if _, errDetail := repo.CreateChannelGroupDetail(ctx, subsetChannel.ID, authID); errDetail != nil {
+			t.Fatalf("CreateChannelGroupDetail(subset, %s) error = %v", authID, errDetail)
+		}
+	}
+
+	explicitGroup, errExplicitGroup := repo.CreateModelGroup(ctx, "explicit", false)
+	if errExplicitGroup != nil {
+		t.Fatalf("CreateModelGroup(explicit) error = %v", errExplicitGroup)
+	}
+	inheritedGroup, errInheritedGroup := repo.CreateModelGroup(ctx, "inherited", false)
+	if errInheritedGroup != nil {
+		t.Fatalf("CreateModelGroup(inherited) error = %v", errInheritedGroup)
+	}
+	if _, errDetail := repo.CreateModelGroupDetail(ctx, explicitGroup.ID, "gpt-5.4", []uint{subsetChannel.ID}); errDetail != nil {
+		t.Fatalf("CreateModelGroupDetail(explicit) error = %v", errDetail)
+	}
+	if _, errDetail := repo.CreateModelGroupDetail(ctx, inheritedGroup.ID, "gpt-5.4", nil); errDetail != nil {
+		t.Fatalf("CreateModelGroupDetail(inherited duplicate) error = %v", errDetail)
+	}
+	if _, errDetail := repo.CreateModelGroupDetail(ctx, inheritedGroup.ID, "gpt-5.5", nil); errDetail != nil {
+		t.Fatalf("CreateModelGroupDetail(inherited model) error = %v", errDetail)
+	}
+	if _, errDetail := repo.CreateModelGroupDetail(ctx, explicitGroup.ID, "gpt-empty", []uint{emptyChannel.ID}); errDetail != nil {
+		t.Fatalf("CreateModelGroupDetail(empty) error = %v", errDetail)
+	}
+
+	clientKey := "client-key"
+	keyChannels := []uint{allChannel.ID}
+	keyModelGroups := []uint{explicitGroup.ID, inheritedGroup.ID}
+	if _, errCreateKey := repo.CreateAPIKey(ctx, APIKeyEntryUpdate{APIKey: clientKey, Channels: &keyChannels, ModelGroups: &keyModelGroups}); errCreateKey != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreateKey)
+	}
+
+	authIDs, modelIDs, errAllowed := repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "GPT-5.4")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(explicit) error = %v", errAllowed)
+	}
+	if want := []string{"auth-b"}; !reflect.DeepEqual(authIDs, want) {
+		t.Fatalf("explicit auth IDs = %v, want %v", authIDs, want)
+	}
+	if want := []string{"gpt-5.4", "gpt-empty", "gpt-5.5"}; !reflect.DeepEqual(modelIDs, want) {
+		t.Fatalf("model IDs = %v, want %v", modelIDs, want)
+	}
+
+	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "gpt-5.5")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(inherited) error = %v", errAllowed)
+	}
+	if want := []string{"auth-a", "auth-b"}; !reflect.DeepEqual(authIDs, want) {
+		t.Fatalf("inherited auth IDs = %v, want %v", authIDs, want)
+	}
+
+	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "gpt-empty")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(empty) error = %v", errAllowed)
+	}
+	if authIDs == nil || len(authIDs) != 0 {
+		t.Fatalf("empty explicit auth IDs = %#v, want non-nil empty list", authIDs)
+	}
+
+	unrestrictedKey := "unrestricted-client-key"
+	unrestrictedModelGroups := []uint{explicitGroup.ID}
+	if _, errCreateKey := repo.CreateAPIKey(ctx, APIKeyEntryUpdate{APIKey: unrestrictedKey, ModelGroups: &unrestrictedModelGroups}); errCreateKey != nil {
+		t.Fatalf("CreateAPIKey(unrestricted channels) error = %v", errCreateKey)
+	}
+	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, unrestrictedKey, "gpt-5.4")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(unrestricted channels) error = %v", errAllowed)
+	}
+	if want := []string{"auth-b", "auth-c"}; !reflect.DeepEqual(authIDs, want) {
+		t.Fatalf("unrestricted base auth IDs = %v, want %v", authIDs, want)
+	}
+
+	disabled := true
+	if _, errDisable := repo.UpdateChannelGroup(ctx, subsetChannel.ID, ChannelGroupUpdate{Disabled: &disabled}); errDisable != nil {
+		t.Fatalf("UpdateChannelGroup(disable) error = %v", errDisable)
+	}
+	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, unrestrictedKey, "gpt-5.4")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(disabled channel) error = %v", errAllowed)
+	}
+	if authIDs == nil || len(authIDs) != 0 {
+		t.Fatalf("disabled model channel auth IDs = %#v, want non-nil empty list", authIDs)
 	}
 }
 

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -200,6 +200,15 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 	if errCreateLegacy := db.Create(legacyDetail).Error; errCreateLegacy != nil {
 		t.Fatalf("create legacy suffixed detail: %v", errCreateLegacy)
 	}
+	for _, filterModelID := range []string{"gpt-legacy", "gpt-legacy(high)"} {
+		filteredDetails, errFilteredDetails := repo.ListModelGroupDetails(ctx, ModelGroupDetailFilter{ModelID: filterModelID})
+		if errFilteredDetails != nil {
+			t.Fatalf("ListModelGroupDetails(%q) error = %v", filterModelID, errFilteredDetails)
+		}
+		if len(filteredDetails) != 1 || filteredDetails[0].ID != legacyDetail.ID {
+			t.Fatalf("ListModelGroupDetails(%q) = %#v, want legacy detail %d", filterModelID, filteredDetails, legacyDetail.ID)
+		}
+	}
 
 	clientKey := "client-key"
 	keyChannels := []uint{allChannel.ID}

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -49,6 +49,18 @@ func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
 	}
 
+	_, errZeroCreate := repo.CreateModelGroupDetail(ctx, modelGroup.ID, "gpt-invalid", []uint{firstChannel.ID, 0})
+	if !errors.Is(errZeroCreate, ErrInvalidModelChannelGroupID) {
+		t.Fatalf("CreateModelGroupDetail(zero channel) error = %v, want ErrInvalidModelChannelGroupID", errZeroCreate)
+	}
+	invalidDetails, errInvalidDetails := repo.ListModelGroupDetails(ctx, ModelGroupDetailFilter{ModelID: "gpt-invalid"})
+	if errInvalidDetails != nil {
+		t.Fatalf("ListModelGroupDetails(invalid) error = %v", errInvalidDetails)
+	}
+	if len(invalidDetails) != 0 {
+		t.Fatalf("invalid model details = %#v, want none", invalidDetails)
+	}
+
 	detail, errCreate := repo.CreateModelGroupDetail(ctx, modelGroup.ID, "gpt-5.4(high)", []uint{secondChannel.ID, firstChannel.ID, secondChannel.ID})
 	if errCreate != nil {
 		t.Fatalf("CreateModelGroupDetail() error = %v", errCreate)
@@ -85,6 +97,11 @@ func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 	_, errMissing := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{Channels: &missingChannels})
 	if !errors.Is(errMissing, gorm.ErrRecordNotFound) {
 		t.Fatalf("UpdateModelGroupDetail(missing channel) error = %v, want record not found", errMissing)
+	}
+	zeroChannels := []uint{secondChannel.ID, 0}
+	_, errZeroUpdate := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{Channels: &zeroChannels})
+	if !errors.Is(errZeroUpdate, ErrInvalidModelChannelGroupID) {
+		t.Fatalf("UpdateModelGroupDetail(zero channel) error = %v, want ErrInvalidModelChannelGroupID", errZeroUpdate)
 	}
 
 	reloaded, errReload := repo.GetModelGroupDetail(ctx, detail.ID)

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -49,9 +49,12 @@ func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
 	}
 
-	detail, errCreate := repo.CreateModelGroupDetail(ctx, modelGroup.ID, "gpt-5.4", []uint{secondChannel.ID, firstChannel.ID, secondChannel.ID})
+	detail, errCreate := repo.CreateModelGroupDetail(ctx, modelGroup.ID, "gpt-5.4(high)", []uint{secondChannel.ID, firstChannel.ID, secondChannel.ID})
 	if errCreate != nil {
 		t.Fatalf("CreateModelGroupDetail() error = %v", errCreate)
+	}
+	if detail.ModelID != "gpt-5.4" {
+		t.Fatalf("created model ID = %q, want canonical gpt-5.4", detail.ModelID)
 	}
 	channels, errChannels := ModelGroupDetailChannelIDs(detail)
 	if errChannels != nil {
@@ -62,9 +65,13 @@ func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 	}
 
 	updatedChannels := []uint{secondChannel.ID}
-	updated, errUpdate := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{Channels: &updatedChannels})
+	updatedModelID := "gpt-5.5(low)"
+	updated, errUpdate := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{ModelID: &updatedModelID, Channels: &updatedChannels})
 	if errUpdate != nil {
 		t.Fatalf("UpdateModelGroupDetail() error = %v", errUpdate)
+	}
+	if updated.ModelID != "gpt-5.5" {
+		t.Fatalf("updated model ID = %q, want canonical gpt-5.5", updated.ModelID)
 	}
 	channels, errChannels = ModelGroupDetailChannelIDs(updated)
 	if errChannels != nil {
@@ -164,6 +171,14 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 	if _, errDetail := repo.CreateModelGroupDetail(ctx, explicitGroup.ID, "gpt-empty", []uint{emptyChannel.ID}); errDetail != nil {
 		t.Fatalf("CreateModelGroupDetail(empty) error = %v", errDetail)
 	}
+	legacyChannels, errLegacyChannels := modelGroupDetailChannelsJSON([]uint{subsetChannel.ID})
+	if errLegacyChannels != nil {
+		t.Fatalf("modelGroupDetailChannelsJSON(legacy) error = %v", errLegacyChannels)
+	}
+	legacyDetail := &ModelGroupDetailRecord{ModelGroupID: explicitGroup.ID, ModelID: "gpt-legacy(high)", Channels: legacyChannels}
+	if errCreateLegacy := db.Create(legacyDetail).Error; errCreateLegacy != nil {
+		t.Fatalf("create legacy suffixed detail: %v", errCreateLegacy)
+	}
 
 	clientKey := "client-key"
 	keyChannels := []uint{allChannel.ID}
@@ -172,15 +187,38 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 		t.Fatalf("CreateAPIKey() error = %v", errCreateKey)
 	}
 
+	modelDetailQueries := 0
+	callbackName := "test:count-model-group-detail-queries"
+	if errCallback := db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
+		if tx != nil && tx.Statement != nil && tx.Statement.Table == "model_group_detail" {
+			modelDetailQueries++
+		}
+	}); errCallback != nil {
+		t.Fatalf("register query callback: %v", errCallback)
+	}
 	authIDs, modelIDs, errAllowed := repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "GPT-5.4")
+	if errRemove := db.Callback().Query().Remove(callbackName); errRemove != nil {
+		t.Fatalf("remove query callback: %v", errRemove)
+	}
 	if errAllowed != nil {
 		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(explicit) error = %v", errAllowed)
+	}
+	if modelDetailQueries != 1 {
+		t.Fatalf("model detail query count = %d, want one coherent load", modelDetailQueries)
 	}
 	if want := []string{"auth-b"}; !reflect.DeepEqual(authIDs, want) {
 		t.Fatalf("explicit auth IDs = %v, want %v", authIDs, want)
 	}
-	if want := []string{"gpt-5.4", "gpt-empty", "gpt-5.5"}; !reflect.DeepEqual(modelIDs, want) {
+	if want := []string{"gpt-5.4", "gpt-empty", "gpt-legacy", "gpt-5.5"}; !reflect.DeepEqual(modelIDs, want) {
 		t.Fatalf("model IDs = %v, want %v", modelIDs, want)
+	}
+
+	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "gpt-legacy")
+	if errAllowed != nil {
+		t.Fatalf("AllowedDispatchIDsForAPIKeyModel(legacy suffix) error = %v", errAllowed)
+	}
+	if want := []string{"auth-b"}; !reflect.DeepEqual(authIDs, want) {
+		t.Fatalf("legacy suffix auth IDs = %v, want %v", authIDs, want)
 	}
 
 	authIDs, _, errAllowed = repo.AllowedDispatchIDsForAPIKeyModel(ctx, clientKey, "gpt-5.5")

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -14,6 +14,10 @@ import (
 	"gorm.io/gorm"
 )
 
+var _ interface {
+	AllowedDispatchIDsForAPIKeyModel(context.Context, string, string) ([]string, []string, error)
+} = (*RuntimeAdapter)(nil)
+
 func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -296,8 +300,8 @@ func TestRuntimeAdapterEnforcesModelChannelBindingsInHomeDispatch(t *testing.T) 
 
 	modelID := "adapter-model"
 	auths := []*coreauth.Auth{
-		{ID: "adapter-auth-wide", Index: "adapter-auth-wide", Provider: "codex", Status: coreauth.StatusActive},
-		{ID: "adapter-auth-subset", Index: "adapter-auth-subset", Provider: "codex", Status: coreauth.StatusActive},
+		{ID: "adapter-auth-a-wide", Index: "adapter-auth-a-wide", Provider: "codex", Status: coreauth.StatusActive},
+		{ID: "adapter-auth-z-subset", Index: "adapter-auth-z-subset", Provider: "codex", Status: coreauth.StatusActive},
 	}
 	for _, auth := range auths {
 		if _, errUpsert := repo.UpsertAuth(ctx, auth, "test"); errUpsert != nil {
@@ -353,12 +357,14 @@ func TestRuntimeAdapterEnforcesModelChannelBindingsInHomeDispatch(t *testing.T) 
 		})
 	}
 
-	result, errDispatch := runtime.DispatchForAPIKey(ctx, modelID, nil, clientKey)
-	if errDispatch != nil {
-		t.Fatalf("DispatchForAPIKey() error = %v", errDispatch)
-	}
-	if result == nil || result.AuthID != auths[1].ID {
-		t.Fatalf("DispatchForAPIKey() result = %#v, want auth %q", result, auths[1].ID)
+	for attempt := 1; attempt <= 2; attempt++ {
+		result, errDispatch := runtime.DispatchForAPIKey(ctx, modelID, nil, clientKey)
+		if errDispatch != nil {
+			t.Fatalf("DispatchForAPIKey(attempt %d) error = %v", attempt, errDispatch)
+		}
+		if result == nil || result.AuthID != auths[1].ID {
+			t.Fatalf("DispatchForAPIKey(attempt %d) result = %#v, want auth %q", attempt, result, auths[1].ID)
+		}
 	}
 }
 

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -1,0 +1,136 @@
+package cluster
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestModelGroupDetailChannelsCreateAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}()
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+
+	repo := NewRepository(db)
+	firstChannel, errFirstChannel := repo.CreateChannelGroup(ctx, "codex-all", false)
+	if errFirstChannel != nil {
+		t.Fatalf("CreateChannelGroup(first) error = %v", errFirstChannel)
+	}
+	secondChannel, errSecondChannel := repo.CreateChannelGroup(ctx, "codex-subset", false)
+	if errSecondChannel != nil {
+		t.Fatalf("CreateChannelGroup(second) error = %v", errSecondChannel)
+	}
+	modelGroup, errModelGroup := repo.CreateModelGroup(ctx, "codex-models", false)
+	if errModelGroup != nil {
+		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
+	}
+
+	detail, errCreate := repo.CreateModelGroupDetail(ctx, modelGroup.ID, "gpt-5.4", []uint{secondChannel.ID, firstChannel.ID, secondChannel.ID})
+	if errCreate != nil {
+		t.Fatalf("CreateModelGroupDetail() error = %v", errCreate)
+	}
+	channels, errChannels := ModelGroupDetailChannelIDs(detail)
+	if errChannels != nil {
+		t.Fatalf("ModelGroupDetailChannelIDs(create) error = %v", errChannels)
+	}
+	if want := []uint{firstChannel.ID, secondChannel.ID}; !reflect.DeepEqual(channels, want) {
+		t.Fatalf("created channels = %v, want %v", channels, want)
+	}
+
+	updatedChannels := []uint{secondChannel.ID}
+	updated, errUpdate := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{Channels: &updatedChannels})
+	if errUpdate != nil {
+		t.Fatalf("UpdateModelGroupDetail() error = %v", errUpdate)
+	}
+	channels, errChannels = ModelGroupDetailChannelIDs(updated)
+	if errChannels != nil {
+		t.Fatalf("ModelGroupDetailChannelIDs(update) error = %v", errChannels)
+	}
+	if !reflect.DeepEqual(channels, updatedChannels) {
+		t.Fatalf("updated channels = %v, want %v", channels, updatedChannels)
+	}
+
+	missingChannels := []uint{secondChannel.ID + 1000}
+	_, errMissing := repo.UpdateModelGroupDetail(ctx, detail.ID, ModelGroupDetailUpdate{Channels: &missingChannels})
+	if !errors.Is(errMissing, gorm.ErrRecordNotFound) {
+		t.Fatalf("UpdateModelGroupDetail(missing channel) error = %v, want record not found", errMissing)
+	}
+
+	reloaded, errReload := repo.GetModelGroupDetail(ctx, detail.ID)
+	if errReload != nil {
+		t.Fatalf("GetModelGroupDetail() error = %v", errReload)
+	}
+	channels, errChannels = ModelGroupDetailChannelIDs(reloaded)
+	if errChannels != nil {
+		t.Fatalf("ModelGroupDetailChannelIDs(reload) error = %v", errChannels)
+	}
+	if !reflect.DeepEqual(channels, updatedChannels) {
+		t.Fatalf("channels after rejected update = %v, want %v", channels, updatedChannels)
+	}
+}
+
+func TestMigrateModelGroupDetailChannelsBackfillsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}()
+	if errMigrate := db.AutoMigrate(&ModelGroupRecord{}, &ModelGroupDetailRecord{}); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+
+	group := ModelGroupRecord{GroupName: "legacy"}
+	if errCreateGroup := db.Create(&group).Error; errCreateGroup != nil {
+		t.Fatalf("create model group: %v", errCreateGroup)
+	}
+	detail := ModelGroupDetailRecord{ModelGroupID: group.ID, ModelID: "legacy-model"}
+	if errCreateDetail := db.Create(&detail).Error; errCreateDetail != nil {
+		t.Fatalf("create model group detail: %v", errCreateDetail)
+	}
+	if errMigrate := migrateModelGroupDetailChannels(db); errMigrate != nil {
+		t.Fatalf("migrateModelGroupDetailChannels() error = %v", errMigrate)
+	}
+
+	var reloaded ModelGroupDetailRecord
+	if errFirst := db.First(&reloaded, detail.ID).Error; errFirst != nil {
+		t.Fatalf("reload model group detail: %v", errFirst)
+	}
+	channels, errChannels := ModelGroupDetailChannelIDs(&reloaded)
+	if errChannels != nil {
+		t.Fatalf("ModelGroupDetailChannelIDs() error = %v", errChannels)
+	}
+	if len(channels) != 0 || string(reloaded.Channels) != "[]" {
+		t.Fatalf("migrated channels = %v raw=%q, want []", channels, string(reloaded.Channels))
+	}
+}

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
 	"gorm.io/gorm"
 )
 
@@ -219,6 +222,78 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 	}
 	if authIDs == nil || len(authIDs) != 0 {
 		t.Fatalf("disabled model channel auth IDs = %#v, want non-nil empty list", authIDs)
+	}
+}
+
+func TestRuntimeAdapterEnforcesModelChannelBindingsInHomeDispatch(t *testing.T) {
+	ctx := context.Background()
+	repo := newRefreshTestRepository(t)
+
+	modelID := "adapter-model"
+	auths := []*coreauth.Auth{
+		{ID: "adapter-auth-wide", Index: "adapter-auth-wide", Provider: "codex", Status: coreauth.StatusActive},
+		{ID: "adapter-auth-subset", Index: "adapter-auth-subset", Provider: "codex", Status: coreauth.StatusActive},
+	}
+	for _, auth := range auths {
+		if _, errUpsert := repo.UpsertAuth(ctx, auth, "test"); errUpsert != nil {
+			t.Fatalf("UpsertAuth(%s) error = %v", auth.ID, errUpsert)
+		}
+	}
+
+	allChannel, errAllChannel := repo.CreateChannelGroup(ctx, "adapter-all", false)
+	if errAllChannel != nil {
+		t.Fatalf("CreateChannelGroup(all) error = %v", errAllChannel)
+	}
+	subsetChannel, errSubsetChannel := repo.CreateChannelGroup(ctx, "adapter-subset", false)
+	if errSubsetChannel != nil {
+		t.Fatalf("CreateChannelGroup(subset) error = %v", errSubsetChannel)
+	}
+	for _, auth := range auths {
+		if _, errDetail := repo.CreateChannelGroupDetail(ctx, allChannel.ID, auth.ID); errDetail != nil {
+			t.Fatalf("CreateChannelGroupDetail(all, %s) error = %v", auth.ID, errDetail)
+		}
+	}
+	if _, errDetail := repo.CreateChannelGroupDetail(ctx, subsetChannel.ID, auths[1].ID); errDetail != nil {
+		t.Fatalf("CreateChannelGroupDetail(subset) error = %v", errDetail)
+	}
+
+	modelGroup, errModelGroup := repo.CreateModelGroup(ctx, "adapter-models", false)
+	if errModelGroup != nil {
+		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
+	}
+	if _, errDetail := repo.CreateModelGroupDetail(ctx, modelGroup.ID, modelID, []uint{subsetChannel.ID}); errDetail != nil {
+		t.Fatalf("CreateModelGroupDetail() error = %v", errDetail)
+	}
+	clientKey := "adapter-client-key"
+	keyChannels := []uint{allChannel.ID}
+	keyModelGroups := []uint{modelGroup.ID}
+	if _, errKey := repo.CreateAPIKey(ctx, APIKeyEntryUpdate{APIKey: clientKey, Channels: &keyChannels, ModelGroups: &keyModelGroups}); errKey != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errKey)
+	}
+
+	runtime, errRuntime := home.NewRuntime(&config.Config{})
+	if errRuntime != nil {
+		t.Fatalf("home.NewRuntime() error = %v", errRuntime)
+	}
+	runtime.SetClusterAdapter(NewRuntimeAdapter(repo, ""))
+	t.Cleanup(runtime.Stop)
+	for _, auth := range auths {
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: modelID, Object: "model", Type: "openai"}})
+		if _, errRegister := runtime.CoreManager().Register(coreauth.WithSkipPersist(ctx), auth.Clone()); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, errRegister)
+		}
+		authID := auth.ID
+		t.Cleanup(func() {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		})
+	}
+
+	result, errDispatch := runtime.DispatchForAPIKey(ctx, modelID, nil, clientKey)
+	if errDispatch != nil {
+		t.Fatalf("DispatchForAPIKey() error = %v", errDispatch)
+	}
+	if result == nil || result.AuthID != auths[1].ID {
+		t.Fatalf("DispatchForAPIKey() result = %#v, want auth %q", result, auths[1].ID)
 	}
 }
 

--- a/internal/cluster/model_groups_test.go
+++ b/internal/cluster/model_groups_test.go
@@ -205,10 +205,17 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 	}
 
 	modelDetailQueries := 0
-	callbackName := "test:count-model-group-detail-queries"
+	channelDetailQueries := 0
+	callbackName := "test:count-policy-detail-queries"
 	if errCallback := db.Callback().Query().Before("gorm:query").Register(callbackName, func(tx *gorm.DB) {
-		if tx != nil && tx.Statement != nil && tx.Statement.Table == "model_group_detail" {
+		if tx == nil || tx.Statement == nil {
+			return
+		}
+		switch tx.Statement.Table {
+		case "model_group_detail":
 			modelDetailQueries++
+		case "channel_group_detail":
+			channelDetailQueries++
 		}
 	}); errCallback != nil {
 		t.Fatalf("register query callback: %v", errCallback)
@@ -222,6 +229,9 @@ func TestAllowedDispatchIDsForAPIKeyModelIntersectsModelChannels(t *testing.T) {
 	}
 	if modelDetailQueries != 1 {
 		t.Fatalf("model detail query count = %d, want one coherent load", modelDetailQueries)
+	}
+	if channelDetailQueries != 1 {
+		t.Fatalf("channel detail query count = %d, want one coherent load", channelDetailQueries)
 	}
 	if want := []string{"auth-b"}; !reflect.DeepEqual(authIDs, want) {
 		t.Fatalf("explicit auth IDs = %v, want %v", authIDs, want)

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -381,6 +381,7 @@ type ModelGroupDetailRecord struct {
 	ID           uint           `gorm:"column:id;primaryKey;autoIncrement;index:idx_model_group_detail_group_active_order,priority:3;index:idx_model_group_detail_model_active_order,priority:4;index:idx_model_group_detail_active_order,priority:3"`
 	ModelGroupID uint           `gorm:"column:model_group_id;not null;index:idx_model_group_detail_group_active_order,priority:1;index:idx_model_group_detail_model_active_order,priority:3;index:idx_model_group_detail_active_order,priority:2"`
 	ModelID      string         `gorm:"column:model_id;not null;index:idx_model_group_detail_model_active_order,priority:1"`
+	Channels     JSONB          `gorm:"column:channels"`
 	CreatedAt    time.Time      `gorm:"column:created_at"`
 	UpdatedAt    time.Time      `gorm:"column:updated_at"`
 	DeletedAt    gorm.DeletedAt `gorm:"column:deleted_at;index;index:idx_model_group_detail_group_active_order,priority:2;index:idx_model_group_detail_model_active_order,priority:2;index:idx_model_group_detail_active_order,priority:1"`

--- a/internal/cluster/runtime.go
+++ b/internal/cluster/runtime.go
@@ -242,6 +242,14 @@ func (a *RuntimeAdapter) AllowedDispatchIDsForAPIKey(ctx context.Context, apiKey
 	return a.repo.AllowedDispatchIDsForAPIKey(ctx, apiKey)
 }
 
+// AllowedDispatchIDsForAPIKeyModel returns auth and model IDs after applying model-specific channel bindings.
+func (a *RuntimeAdapter) AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKey string, modelID string) ([]string, []string, error) {
+	if !a.Enabled() {
+		return nil, nil, fmt.Errorf("cluster runtime adapter is disabled")
+	}
+	return a.repo.AllowedDispatchIDsForAPIKeyModel(ctx, apiKey, modelID)
+}
+
 // AllowedModelIDsForAPIKey returns model IDs allowed by API-key model group bindings.
 func (a *RuntimeAdapter) AllowedModelIDsForAPIKey(ctx context.Context, apiKey string) ([]string, error) {
 	if !a.Enabled() {

--- a/internal/home/model_channel_dispatch_test.go
+++ b/internal/home/model_channel_dispatch_test.go
@@ -1,0 +1,96 @@
+package home
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
+)
+
+type modelChannelDispatchTestAdapter struct {
+	allowedAuthIDs  []string
+	allowedModelIDs []string
+	requestedModel  string
+}
+
+func (a *modelChannelDispatchTestAdapter) Enabled() bool { return true }
+
+func (a *modelChannelDispatchTestAdapter) LoadAuthIndex(context.Context) error { return nil }
+
+func (a *modelChannelDispatchTestAdapter) ListMinimalAuths() []*coreauth.Auth { return nil }
+
+func (a *modelChannelDispatchTestAdapter) GetFullAuth(context.Context, string) (*coreauth.Auth, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *modelChannelDispatchTestAdapter) LoadConfigYAML(context.Context) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *modelChannelDispatchTestAdapter) AllowedDispatchIDsForAPIKeyModel(_ context.Context, _ string, modelID string) ([]string, []string, error) {
+	a.requestedModel = modelID
+	return a.allowedAuthIDs, a.allowedModelIDs, nil
+}
+
+func TestDispatchForAPIKeyAppliesModelSpecificAuthIDs(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	modelID := "gpt-test-model"
+	for _, authID := range []string{"auth-a", "auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: modelID, Object: "model", Type: "openai"}})
+		auth := &coreauth.Auth{ID: authID, Provider: "codex", Status: coreauth.StatusActive}
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", authID, errRegister)
+		}
+		t.Cleanup(func() {
+			registry.GetGlobalRegistry().UnregisterClient(authID)
+		})
+	}
+
+	adapter := &modelChannelDispatchTestAdapter{
+		allowedAuthIDs:  []string{"auth-b"},
+		allowedModelIDs: []string{modelID},
+	}
+	runtime := &Runtime{coreManager: manager, clusterAdapter: adapter}
+	result, errDispatch := runtime.DispatchForAPIKey(context.Background(), modelID+"(high)", nil, "client-key")
+	if errDispatch != nil {
+		t.Fatalf("DispatchForAPIKey() error = %v", errDispatch)
+	}
+	if result == nil || result.AuthID != "auth-b" {
+		t.Fatalf("DispatchForAPIKey() auth = %#v, want auth-b", result)
+	}
+	if adapter.requestedModel != modelID {
+		t.Fatalf("policy model = %q, want %q", adapter.requestedModel, modelID)
+	}
+	if !reflect.DeepEqual(adapter.allowedAuthIDs, []string{"auth-b"}) {
+		t.Fatalf("adapter allowed auth IDs mutated: %v", adapter.allowedAuthIDs)
+	}
+}
+
+func TestDispatchForAPIKeyFailsClosedForEmptyModelChannel(t *testing.T) {
+	manager := coreauth.NewManager(nil, nil, nil)
+	modelID := "gpt-empty-model"
+	authID := "auth-empty"
+	registry.GetGlobalRegistry().RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: modelID, Object: "model", Type: "openai"}})
+	if _, errRegister := manager.Register(context.Background(), &coreauth.Auth{ID: authID, Provider: "codex", Status: coreauth.StatusActive}); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(authID)
+	})
+
+	adapter := &modelChannelDispatchTestAdapter{
+		allowedAuthIDs:  []string{},
+		allowedModelIDs: []string{modelID},
+	}
+	runtime := &Runtime{coreManager: manager, clusterAdapter: adapter}
+	result, errDispatch := runtime.DispatchForAPIKey(context.Background(), modelID, nil, "client-key")
+	if errDispatch == nil {
+		t.Fatalf("DispatchForAPIKey() result = %#v, want error", result)
+	}
+	if result != nil {
+		t.Fatalf("DispatchForAPIKey() result = %#v, want nil", result)
+	}
+}

--- a/internal/home/runtime.go
+++ b/internal/home/runtime.go
@@ -157,6 +157,10 @@ type apiKeyScopedDispatchStore interface {
 	AllowedDispatchIDsForAPIKey(ctx context.Context, apiKey string) ([]string, []string, error)
 }
 
+type apiKeyModelScopedDispatchStore interface {
+	AllowedDispatchIDsForAPIKeyModel(ctx context.Context, apiKey string, modelID string) ([]string, []string, error)
+}
+
 // NewRuntime creates a new runtime.
 func NewRuntime(cfg *config.Config) (*Runtime, error) {
 	// Keep validation before state changes so failures leave existing data intact.
@@ -714,7 +718,7 @@ func (r *Runtime) DispatchForAPIKey(ctx context.Context, reqModel string, header
 	if headers != nil {
 		opts.Headers = headers.Clone()
 	}
-	allowedAuthIDs, allowedModelIDs, errAllowed := r.allowedDispatchIDsForAPIKey(ctx, apiKey)
+	allowedAuthIDs, allowedModelIDs, errAllowed := r.allowedDispatchIDsForAPIKey(ctx, apiKey, reqModel)
 	if errAllowed != nil {
 		return nil, errAllowed
 	}
@@ -803,10 +807,14 @@ func (r *Runtime) allowedAuthIDsForAPIKey(ctx context.Context, apiKey string) ([
 	return store.AllowedAuthIDsForAPIKey(ctx, apiKey)
 }
 
-func (r *Runtime) allowedDispatchIDsForAPIKey(ctx context.Context, apiKey string) ([]string, []string, error) {
+func (r *Runtime) allowedDispatchIDsForAPIKey(ctx context.Context, apiKey string, modelID string) ([]string, []string, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" || r == nil || r.clusterAdapter == nil {
 		return nil, nil, nil
+	}
+	modelID = strings.TrimSpace(stripModelSuffix(modelID))
+	if store, ok := r.clusterAdapter.(apiKeyModelScopedDispatchStore); ok && store != nil {
+		return store.AllowedDispatchIDsForAPIKeyModel(ctx, apiKey, modelID)
 	}
 	if store, ok := r.clusterAdapter.(apiKeyScopedDispatchStore); ok && store != nil {
 		return store.AllowedDispatchIDsForAPIKey(ctx, apiKey)

--- a/internal/home/runtime.go
+++ b/internal/home/runtime.go
@@ -812,7 +812,7 @@ func (r *Runtime) allowedDispatchIDsForAPIKey(ctx context.Context, apiKey string
 	if apiKey == "" || r == nil || r.clusterAdapter == nil {
 		return nil, nil, nil
 	}
-	modelID = strings.TrimSpace(stripModelSuffix(modelID))
+	modelID = coreauth.CanonicalModelID(modelID)
 	if store, ok := r.clusterAdapter.(apiKeyModelScopedDispatchStore); ok && store != nil {
 		return store.AllowedDispatchIDsForAPIKeyModel(ctx, apiKey, modelID)
 	}
@@ -844,23 +844,11 @@ func (r *Runtime) supportsRequestedModel(model string) bool {
 	if trimmedModel == "" {
 		return false
 	}
-	modelKey := strings.TrimSpace(stripModelSuffix(trimmedModel))
+	modelKey := coreauth.CanonicalModelID(trimmedModel)
 	if modelKey == "" {
 		modelKey = trimmedModel
 	}
 	return registry.LookupModelInfo(modelKey) != nil
-}
-
-// stripModelSuffix handles a strip model suffix.
-func stripModelSuffix(model string) string {
-	lastOpen := strings.LastIndex(model, "(")
-	if lastOpen == -1 {
-		return model
-	}
-	if !strings.HasSuffix(model, ")") {
-		return model
-	}
-	return model[:lastOpen]
 }
 
 // AddToken stores a credential JSON blob into the auth directory and schedules it for use.


### PR DESCRIPTION
## Summary

- add optional `channels` bindings to each model-group detail
- enforce the intersection of API-key channel scope, model-specific channel scope, and runtime model support during dispatch
- keep empty or omitted model channels backward-compatible by inheriting the API-key credential scope
- expose `model_channel_bindings` capability metadata and document the Management API in English and Chinese

## Safety and compatibility

- resolve base and model-specific channel membership from one database snapshot before intersecting in memory
- fail closed when an explicit model channel scope has no eligible credential
- canonicalize request-option model suffixes consistently for writes, dispatch, legacy reads, and Management API filters
- reject channel group ID `0` with HTTP 400 instead of silently converting it to inherited access
- cover the production `RuntimeAdapter` path with a real repository/runtime integration test and compile-time interface assertion

## Testing

- `go test -run 'Test(AllowedDispatchIDsForAPIKeyModelIntersectsModelChannels|RuntimeAdapterEnforcesModelChannelBindingsInHomeDispatch|ModelGroupDetailChannelsCreateAndUpdate)' ./internal/cluster`
- `go test -run TestModelGroupDetailRoutesCreateAndClearChannels ./internal/cluster/management`
- `go build -o test-output ./cmd/home && rm test-output`

Closes #45
