### PR TITLE
Add membership takeover handling and related tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/go-webauthn/webauthn v0.17.4
+	github.com/google/uuid v1.6.0
 	github.com/refraction-networking/utls v1.8.2
 	github.com/router-for-me/CLIProxyAPI/v7 v7.2.83
 	github.com/sirupsen/logrus v1.9.3
@@ -41,7 +42,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/internal/cluster/concurrency_admission.go
+++ b/internal/cluster/concurrency_admission.go
@@ -139,7 +139,7 @@ func (r *Repository) LockActiveConcurrencyLifetimeTx(ctx context.Context, tx *go
 
 	var membership CPANodeMembershipRecord
 	errMembership := tx.WithContext(contextOrBackground(ctx)).Clauses(clause.Locking{Strength: "UPDATE"}).
-		Where("certificate_fingerprint = ? AND connected_at = ? AND state = ?", strings.TrimSpace(lifetime.Fingerprint), lifetime.ConnectedAt, MembershipStateActive).
+		Where("certificate_fingerprint = ? AND connected_at = ? AND state = ? AND home_ip = ? AND home_port = ? AND home_started_at = ?", strings.TrimSpace(lifetime.Fingerprint), lifetime.ConnectedAt, MembershipStateActive, strings.TrimSpace(lifetime.Home.IP), lifetime.Home.Port, lifetime.Home.StartedAt).
 		First(&membership).Error
 	if errMembership != nil {
 		return ErrConcurrencyNodeUnavailable

--- a/internal/cluster/concurrency_admission_test.go
+++ b/internal/cluster/concurrency_admission_test.go
@@ -255,7 +255,7 @@ func TestReadConcurrencyStateReturnsAuthoritativeCounters(t *testing.T) {
 	}
 }
 
-func TestLockActiveConcurrencyLifetimeTxUsesCurrentHomeInsteadOfSubscriptionOwner(t *testing.T) {
+func TestLockActiveConcurrencyLifetimeTxRejectsNonOwnerHome(t *testing.T) {
 	repo := newCredentialFoundationTestRepository(t)
 	seedConcurrencyAdmissionLifetime(t, repo, "fp-a", "subscription-home")
 	currentHome := HomeProcessIncarnationRecord{
@@ -272,7 +272,7 @@ func TestLockActiveConcurrencyLifetimeTxUsesCurrentHomeInsteadOfSubscriptionOwne
 			Home: HomeIncarnationID{IP: currentHome.HomeIP, Port: currentHome.HomePort, StartedAt: currentHome.StartedAt},
 		})
 	})
-	if errTransaction != nil {
-		t.Fatal(errTransaction)
+	if !errors.Is(errTransaction, ErrConcurrencyNodeUnavailable) {
+		t.Fatalf("LockActiveConcurrencyLifetimeTx() error = %v, want %v", errTransaction, ErrConcurrencyNodeUnavailable)
 	}
 }

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
 	log "github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -45,11 +46,14 @@ type Coordinator struct {
 	onMasterChanged   func(bool)
 	startupRecovery   StartupRecovery
 
-	mu              sync.RWMutex
-	isMaster        bool
-	masterKnown     bool
-	initialized     bool
-	homeIncarnation HomeIncarnationID
+	mu               sync.RWMutex
+	masterCallbackMu sync.Mutex
+	isMaster         bool
+	masterKnown      bool
+	masterLease      uint64
+	masterTimer      *time.Timer
+	initialized      bool
+	homeIncarnation  HomeIncarnationID
 }
 
 type NodeIdentity struct {
@@ -218,15 +222,15 @@ func (c *Coordinator) Start(ctx context.Context) error {
 				return nil
 			}
 			if errHeartbeat := c.heartbeatHomeIncarnation(ctx); errHeartbeat != nil {
+				c.setMaster(false)
 				if ctx.Err() != nil {
-					c.setMaster(false)
 					return nil
 				}
 				return errHeartbeat
 			}
 			if errBeat := c.heartbeatAndElect(ctx); errBeat != nil {
+				c.setMaster(false)
 				if ctx.Err() != nil {
-					c.setMaster(false)
 					return nil
 				}
 				return errBeat
@@ -346,19 +350,18 @@ func (c *Coordinator) CurrentMaster(ctx context.Context) (*ClusterNodeRecord, er
 	if errNow != nil {
 		return nil, errNow
 	}
-	cutoff := now.Add(-c.heartbeatTimeout)
-	var liveNodes []ClusterNodeRecord
-	errFind := db.WithContext(contextOrBackground(ctx)).
-		Where("last_seen_at >= ?", cutoff).
-		Find(&liveNodes).Error
-	if errFind != nil {
-		return nil, errFind
-	}
-	if len(liveNodes) == 0 {
+	record := ClusterNodeRecord{}
+	errFirst := db.WithContext(contextOrBackground(ctx)).
+		Where("is_master = ? AND last_seen_at >= ?", true, now.Add(-c.heartbeatTimeout)).
+		Order("started_at ASC, ip ASC, port ASC").
+		First(&record).Error
+	if errors.Is(errFirst, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}
-	sortClusterNodes(liveNodes)
-	return &liveNodes[0], nil
+	if errFirst != nil {
+		return nil, errFirst
+	}
+	return &record, nil
 }
 
 // heartbeatAndElect handles a heartbeat and elect.
@@ -369,45 +372,65 @@ func (c *Coordinator) heartbeatAndElect(ctx context.Context) error {
 		return errDB
 	}
 
-	now, errNow := DatabaseNow(ctx, db)
-	if errNow != nil {
-		return errNow
-	}
-	record := ClusterNodeRecord{
-		IP:          c.node.IP,
-		Port:        c.node.Port,
-		SecretHash:  nodeSecretHash(c.node.Secret),
-		IsMaster:    c.IsMaster(),
-		ClientCount: node.GlobalRegistry().TotalCount(),
-		StartedAt:   c.node.StartedAt,
-		LastSeenAt:  now,
-	}
+	var elected ClusterNodeRecord
+	var seenAt time.Time
+	errTransaction := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		gate := ClusterMasterGateRecord{ID: 1}
+		if errCreate := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&gate).Error; errCreate != nil {
+			return errCreate
+		}
+		if errLock := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&gate, "id = ?", 1).Error; errLock != nil {
+			return errLock
+		}
 
-	if errUpsert := db.WithContext(contextOrBackground(ctx)).Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "ip"}, {Name: "port"}},
-		DoUpdates: clause.Assignments(map[string]any{
-			"started_at":   record.StartedAt,
-			"last_seen_at": record.LastSeenAt,
-			"secret_hash":  record.SecretHash,
-			"client_count": record.ClientCount,
-			"is_master":    record.IsMaster,
-		}),
-	}).Create(&record).Error; errUpsert != nil {
-		return errUpsert
+		now, errNow := DatabaseNow(ctx, tx)
+		if errNow != nil {
+			return errNow
+		}
+		seenAt = now
+		record := ClusterNodeRecord{
+			IP:          c.node.IP,
+			Port:        c.node.Port,
+			SecretHash:  nodeSecretHash(c.node.Secret),
+			ClientCount: node.GlobalRegistry().TotalCount(),
+			StartedAt:   c.node.StartedAt,
+			LastSeenAt:  now,
+		}
+		if errUpsert := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "ip"}, {Name: "port"}},
+			DoUpdates: clause.Assignments(map[string]any{
+				"started_at":   record.StartedAt,
+				"last_seen_at": record.LastSeenAt,
+				"secret_hash":  record.SecretHash,
+				"client_count": record.ClientCount,
+			}),
+		}).Create(&record).Error; errUpsert != nil {
+			return errUpsert
+		}
+
+		var liveNodes []ClusterNodeRecord
+		if errFind := tx.Where("last_seen_at >= ?", now.Add(-c.heartbeatTimeout)).Find(&liveNodes).Error; errFind != nil {
+			return errFind
+		}
+		if len(liveNodes) == 0 {
+			return fmt.Errorf("cluster election found no live nodes")
+		}
+		sortClusterNodes(liveNodes)
+		elected = liveNodes[0]
+		if errClear := tx.Model(&ClusterNodeRecord{}).Where("is_master = ?", true).Update("is_master", false).Error; errClear != nil {
+			return errClear
+		}
+		return tx.Model(&ClusterNodeRecord{}).
+			Where("ip = ? AND port = ? AND started_at = ?", elected.IP, elected.Port, elected.StartedAt).
+			Update("is_master", true).Error
+	})
+	if errTransaction != nil {
+		return errTransaction
 	}
-	if errSnapshot := c.syncCPANodeSnapshot(ctx, now); errSnapshot != nil {
+	c.setMaster(clusterNodeMatches(elected, c.node.IP, c.node.Port))
+	if errSnapshot := c.syncCPANodeSnapshot(ctx, seenAt); errSnapshot != nil {
 		log.Warnf("failed to sync CPA node snapshot: %v", errSnapshot)
 	}
-
-	elected, errMaster := c.CurrentMaster(ctx)
-	if errMaster != nil {
-		return errMaster
-	}
-	if elected == nil {
-		return fmt.Errorf("cluster election found no live nodes")
-	}
-
-	c.setMaster(clusterNodeMatches(*elected, c.node.IP, c.node.Port))
 	return nil
 }
 
@@ -455,11 +478,50 @@ func (c *Coordinator) setMaster(next bool) {
 	changed := !c.masterKnown || c.isMaster != next
 	c.isMaster = next
 	c.masterKnown = true
-	callback := c.onMasterChanged
+	c.masterLease++
+	lease := c.masterLease
+	if c.masterTimer != nil {
+		c.masterTimer.Stop()
+		c.masterTimer = nil
+	}
+	if next {
+		c.masterTimer = time.AfterFunc(c.heartbeatTimeout, func() {
+			c.expireMasterLease(lease)
+		})
+	}
 	c.mu.Unlock()
 
-	if changed && callback != nil {
-		callback(next)
+	if changed {
+		c.notifyMasterChanged(next)
+	}
+}
+
+func (c *Coordinator) expireMasterLease(lease uint64) {
+	c.mu.Lock()
+	if c.masterLease != lease || !c.isMaster {
+		c.mu.Unlock()
+		return
+	}
+	c.isMaster = false
+	c.masterKnown = true
+	c.masterTimer = nil
+	c.mu.Unlock()
+	c.notifyMasterChanged(false)
+}
+
+func (c *Coordinator) notifyMasterChanged(master bool) {
+	c.masterCallbackMu.Lock()
+	defer c.masterCallbackMu.Unlock()
+
+	c.mu.RLock()
+	if c.isMaster != master {
+		c.mu.RUnlock()
+		return
+	}
+	callback := c.onMasterChanged
+	c.mu.RUnlock()
+	if callback != nil {
+		callback(master)
 	}
 }
 

--- a/internal/cluster/coordinator_test.go
+++ b/internal/cluster/coordinator_test.go
@@ -1,0 +1,202 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestHeartbeatElectionPersistsExactlyOneLiveMaster(t *testing.T) {
+	ctx := context.Background()
+	repo := newCredentialFoundationTestRepository(t)
+	now := time.Now().UTC()
+	older := NewCoordinator(repo, NodeIdentity{IP: "10.0.0.1", Port: 8317, StartedAt: now.Add(-time.Minute)}, CoordinatorOptions{HeartbeatTimeout: 20 * time.Second})
+	newer := NewCoordinator(repo, NodeIdentity{IP: "10.0.0.2", Port: 8317, StartedAt: now}, CoordinatorOptions{HeartbeatTimeout: 20 * time.Second})
+
+	if errBeat := older.heartbeatAndElect(ctx); errBeat != nil {
+		t.Fatal(errBeat)
+	}
+	if errBeat := newer.heartbeatAndElect(ctx); errBeat != nil {
+		t.Fatal(errBeat)
+	}
+
+	var masterCount int64
+	if errCount := repo.db.Model(&ClusterNodeRecord{}).Where("is_master = ?", true).Count(&masterCount).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if masterCount != 1 {
+		t.Fatalf("persisted master count = %d, want 1", masterCount)
+	}
+	master, errMaster := newer.CurrentMaster(ctx)
+	if errMaster != nil {
+		t.Fatal(errMaster)
+	}
+	if master == nil || master.IP != older.node.IP || master.Port != older.node.Port {
+		t.Fatalf("master = %#v, want older node", master)
+	}
+	if !older.IsMaster() || newer.IsMaster() {
+		t.Fatalf("local master state older=%t newer=%t", older.IsMaster(), newer.IsMaster())
+	}
+}
+
+func TestCurrentMasterRejectsExpiredPersistedMaster(t *testing.T) {
+	ctx := context.Background()
+	repo := newCredentialFoundationTestRepository(t)
+	coordinator := NewCoordinator(repo, NodeIdentity{IP: "10.0.0.1", Port: 8317}, CoordinatorOptions{HeartbeatTimeout: time.Second})
+	stale := time.Now().UTC().Add(-2 * time.Second)
+	if errCreate := repo.db.Create(&ClusterNodeRecord{IP: coordinator.node.IP, Port: coordinator.node.Port, IsMaster: true, StartedAt: stale, LastSeenAt: stale}).Error; errCreate != nil {
+		t.Fatal(errCreate)
+	}
+	master, errMaster := coordinator.CurrentMaster(ctx)
+	if errMaster != nil {
+		t.Fatal(errMaster)
+	}
+	if master != nil {
+		t.Fatalf("CurrentMaster() = %#v, want nil", master)
+	}
+}
+
+func TestLocalMasterLeaseExpiresWithoutHeartbeatRenewal(t *testing.T) {
+	coordinator := NewCoordinator(&Repository{}, NodeIdentity{IP: "10.0.0.1", Port: 8317}, CoordinatorOptions{HeartbeatTimeout: 20 * time.Millisecond})
+	demoted := make(chan struct{})
+	coordinator.SetOnMasterChanged(func(master bool) {
+		if !master {
+			close(demoted)
+		}
+	})
+	coordinator.setMaster(true)
+	select {
+	case <-demoted:
+	case <-time.After(time.Second):
+		t.Fatal("local master lease did not expire")
+	}
+	if coordinator.IsMaster() {
+		t.Fatal("coordinator remained master after its local lease expired")
+	}
+}
+
+func TestExpiredMasterCallbackCannotOverrideRenewedLease(t *testing.T) {
+	coordinator := NewCoordinator(&Repository{}, NodeIdentity{IP: "10.0.0.1", Port: 8317}, CoordinatorOptions{HeartbeatTimeout: time.Hour})
+	expiredStarted := make(chan struct{})
+	releaseExpired := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseExpired) }) }
+	t.Cleanup(func() {
+		release()
+		coordinator.setMaster(false)
+	})
+
+	var firstExpired sync.Once
+	var callbackMu sync.Mutex
+	callbackState := false
+	coordinator.SetOnMasterChanged(func(master bool) {
+		if !master {
+			firstExpired.Do(func() {
+				close(expiredStarted)
+				<-releaseExpired
+			})
+		}
+		callbackMu.Lock()
+		callbackState = master
+		callbackMu.Unlock()
+	})
+	coordinator.setMaster(true)
+
+	coordinator.mu.Lock()
+	lease := coordinator.masterLease
+	if coordinator.masterTimer != nil {
+		coordinator.masterTimer.Stop()
+		coordinator.masterTimer = nil
+	}
+	coordinator.mu.Unlock()
+
+	expireDone := make(chan struct{})
+	go func() {
+		coordinator.expireMasterLease(lease)
+		close(expireDone)
+	}()
+	select {
+	case <-expiredStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expired lease callback did not start")
+	}
+
+	renewDone := make(chan struct{})
+	go func() {
+		coordinator.setMaster(true)
+		close(renewDone)
+	}()
+	deadline := time.After(time.Second)
+	for !coordinator.IsMaster() {
+		select {
+		case <-deadline:
+			t.Fatal("master lease was not renewed")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	release()
+	for name, done := range map[string]<-chan struct{}{"expiry": expireDone, "renewal": renewDone} {
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("%s callback did not complete", name)
+		}
+	}
+	callbackMu.Lock()
+	gotState := callbackState
+	callbackMu.Unlock()
+	if !gotState {
+		t.Fatal("stale expiry callback overrode the renewed master callback")
+	}
+}
+
+func TestRepeatedDemotionCannotSuppressLeaseExpiryCallback(t *testing.T) {
+	coordinator := NewCoordinator(&Repository{}, NodeIdentity{IP: "10.0.0.1", Port: 8317}, CoordinatorOptions{HeartbeatTimeout: time.Hour})
+	demoted := make(chan struct{}, 1)
+	coordinator.SetOnMasterChanged(func(master bool) {
+		if !master {
+			demoted <- struct{}{}
+		}
+	})
+	coordinator.setMaster(true)
+
+	coordinator.masterCallbackMu.Lock()
+	coordinator.mu.Lock()
+	lease := coordinator.masterLease
+	if coordinator.masterTimer != nil {
+		coordinator.masterTimer.Stop()
+		coordinator.masterTimer = nil
+	}
+	coordinator.mu.Unlock()
+
+	expireDone := make(chan struct{})
+	go func() {
+		coordinator.expireMasterLease(lease)
+		close(expireDone)
+	}()
+	deadline := time.After(time.Second)
+	for coordinator.IsMaster() {
+		select {
+		case <-deadline:
+			coordinator.masterCallbackMu.Unlock()
+			t.Fatal("master lease did not expire")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	coordinator.setMaster(false)
+	coordinator.masterCallbackMu.Unlock()
+
+	select {
+	case <-demoted:
+	case <-time.After(time.Second):
+		t.Fatal("repeated demotion suppressed the lease expiry callback")
+	}
+	select {
+	case <-expireDone:
+	case <-time.After(time.Second):
+		t.Fatal("lease expiry did not complete")
+	}
+}

--- a/internal/cluster/database_models.go
+++ b/internal/cluster/database_models.go
@@ -80,6 +80,7 @@ var databaseSnapshotV1Models = []databaseModel{
 var homeDatabaseModels = currentDatabaseModels()
 
 var databaseMigrationOnlyModels = []databaseModel{
+	newDatabaseModel[ClusterMasterGateRecord]("cluster_master_gate", []string{"id"}, false, false),
 	newDatabaseModel[ManagementInFlightSnapshotCursorRecord]("management_in_flight_snapshot_cursors", []string{"cursor"}, false, false),
 	newDatabaseModel[ManagementInFlightSnapshotCursorItemRecord]("management_in_flight_snapshot_cursor_items", []string{"cursor", "ordinal"}, false, false),
 	newDatabaseModel[ManagementInFlightSnapshotCursorObservedRecord]("management_in_flight_snapshot_cursor_observed", []string{"cursor", "credential_id"}, false, false),

--- a/internal/cluster/membership.go
+++ b/internal/cluster/membership.go
@@ -18,6 +18,7 @@ var (
 	ErrConcurrencyProtocolRequired     = errors.New("credential concurrency protocol version 1 is required")
 	ErrLifecycleConfigRevisionMismatch = errors.New("lifecycle configuration revision does not match")
 	ErrMembershipNotActive             = errors.New("CPA membership is not active")
+	ErrMembershipTakeoverUnavailable   = errors.New("membership_takeover_unavailable")
 )
 
 // ConnectionLifetime identifies the membership lifetime associated with a connection.
@@ -36,6 +37,12 @@ type SubscribeMembershipRequest struct {
 	Home                    HomeIncarnationID
 	ProtocolVersion         int
 	LifecycleConfigRevision int64
+	Takeover                bool
+}
+
+func membershipOwnedByHome(member CPANodeMembershipRecord, home HomeIncarnationID) bool {
+	return strings.TrimSpace(member.HomeIP) == strings.TrimSpace(home.IP) &&
+		member.HomePort == home.Port && member.HomeStartedAt.Equal(home.StartedAt)
 }
 
 // ClassifyConnection determines whether a connection belongs to an active membership.
@@ -58,7 +65,7 @@ func (r *Repository) ClassifyConnection(ctx context.Context, fingerprint string,
 	if errFirst != nil {
 		return ConnectionLifetime{}, errFirst
 	}
-	if member.State != MembershipStateActive {
+	if member.State != MembershipStateActive || !membershipOwnedByHome(member, home) {
 		return lifetime, nil
 	}
 
@@ -119,7 +126,10 @@ func (r *Repository) SubscribeMembership(ctx context.Context, request SubscribeM
 
 		previous := CPANodeMembershipRecord{}
 		errPrevious := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("certificate_fingerprint = ?", request.Fingerprint).First(&previous).Error
-		if errPrevious == nil && previous.State != MembershipStateClosed {
+		if request.Takeover && (errors.Is(errPrevious, gorm.ErrRecordNotFound) || (errPrevious == nil && previous.State == MembershipStateClosed)) {
+			return ErrMembershipTakeoverUnavailable
+		}
+		if errPrevious == nil && previous.State != MembershipStateClosed && (!request.Takeover || previous.NodeID != request.NodeID) {
 			return ErrDuplicateCPACertificate
 		}
 		if errPrevious != nil && !errors.Is(errPrevious, gorm.ErrRecordNotFound) {
@@ -127,6 +137,25 @@ func (r *Repository) SubscribeMembership(ctx context.Context, request SubscribeM
 		}
 		if errHome := verifyActiveHomeIncarnation(tx, request.Home); errHome != nil {
 			return errHome
+		}
+		if errPrevious == nil && previous.State != MembershipStateClosed {
+			oldLifetime := "certificate_fingerprint = ? AND membership_connected_at = ?"
+			oldArgs := []any{previous.CertificateFingerprint, previous.ConnectedAt}
+			if errDelete := tx.Where(oldLifetime, oldArgs...).Delete(&CPANodeParticipationRecord{}).Error; errDelete != nil {
+				return errDelete
+			}
+			if errDelete := tx.Where(oldLifetime, oldArgs...).Delete(&CPANodeQuiescenceRecord{}).Error; errDelete != nil {
+				return errDelete
+			}
+			if errDelete := tx.Where(oldLifetime, oldArgs...).Delete(&CPAInFlightSnapshotPartRecord{}).Error; errDelete != nil {
+				return errDelete
+			}
+			if errDelete := tx.Where(oldLifetime, oldArgs...).Delete(&CPAInFlightSnapshotAttemptRecord{}).Error; errDelete != nil {
+				return errDelete
+			}
+			if errDelete := tx.Where(oldLifetime, oldArgs...).Delete(&CPAInFlightSnapshotRecord{}).Error; errDelete != nil {
+				return errDelete
+			}
 		}
 
 		now, errNow := DatabaseNow(ctx, tx)

--- a/internal/cluster/membership.go
+++ b/internal/cluster/membership.go
@@ -25,6 +25,7 @@ var (
 type ConnectionLifetime struct {
 	Fingerprint  string
 	ConnectedAt  time.Time
+	InstanceID   string
 	Home         HomeIncarnationID
 	Controlled   bool
 	Subscription bool
@@ -129,8 +130,13 @@ func (r *Repository) SubscribeMembership(ctx context.Context, request SubscribeM
 		if request.Takeover && (errors.Is(errPrevious, gorm.ErrRecordNotFound) || (errPrevious == nil && previous.State == MembershipStateClosed)) {
 			return ErrMembershipTakeoverUnavailable
 		}
-		if errPrevious == nil && previous.State != MembershipStateClosed && (!request.Takeover || previous.NodeID != request.NodeID) {
-			return ErrDuplicateCPACertificate
+		if errPrevious == nil && previous.State != MembershipStateClosed {
+			if !request.Takeover || previous.NodeID != request.NodeID {
+				return ErrDuplicateCPACertificate
+			}
+			if previous.LifecycleConfigRevision != request.LifecycleConfigRevision {
+				return ErrMembershipTakeoverUnavailable
+			}
 		}
 		if errPrevious != nil && !errors.Is(errPrevious, gorm.ErrRecordNotFound) {
 			return errPrevious

--- a/internal/cluster/membership.go
+++ b/internal/cluster/membership.go
@@ -158,12 +158,13 @@ func (r *Repository) SubscribeMembership(ctx context.Context, request SubscribeM
 			}
 		}
 
-		now, errNow := DatabaseNow(ctx, tx)
+		dbNow, errNow := DatabaseNow(ctx, tx)
 		if errNow != nil {
 			return errNow
 		}
-		if !previous.ConnectedAt.IsZero() && !now.After(previous.ConnectedAt) {
-			now = previous.ConnectedAt.Add(databaseTimestampStep(tx))
+		connectedAt := dbNow
+		if !previous.ConnectedAt.IsZero() && !connectedAt.After(previous.ConnectedAt) {
+			connectedAt = previous.ConnectedAt.Add(databaseTimestampStep(tx))
 		}
 		accepted = CPANodeMembershipRecord{
 			CertificateFingerprint:  request.Fingerprint,
@@ -173,13 +174,13 @@ func (r *Repository) SubscribeMembership(ctx context.Context, request SubscribeM
 			HomeStartedAt:           request.Home.StartedAt,
 			ProtocolVersion:         request.ProtocolVersion,
 			State:                   MembershipStateActive,
-			ConnectedAt:             now,
+			ConnectedAt:             connectedAt,
 			LifecycleConfigRevision: lifecycle.Revision,
 			CPAHeartbeatTimeout:     cfg.CPAHeartbeatTimeout,
 			CPACancelBound:          cfg.CPACancelBound,
 			ReclaimGrace:            cfg.ReclaimGrace,
-			LastSeenAt:              now,
-			UpdatedAt:               now,
+			LastSeenAt:              dbNow,
+			UpdatedAt:               dbNow,
 		}
 		return tx.Save(&accepted).Error
 	})

--- a/internal/cluster/membership_test.go
+++ b/internal/cluster/membership_test.go
@@ -10,6 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const testMembershipInstanceID = "550e8400-e29b-41d4-a716-446655440000"
+
 func TestSubscribeMembershipRejectsDifferentNodeAndAllowsSameNodeTakeover(t *testing.T) {
 	ctx := context.Background()
 	repo := newCredentialFoundationTestRepository(t)
@@ -41,6 +43,13 @@ func TestSubscribeMembershipRejectsDifferentNodeAndAllowsSameNodeTakeover(t *tes
 	}
 	if _, errDifferentNode := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-b", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true}); !errors.Is(errDifferentNode, ErrDuplicateCPACertificate) {
 		t.Fatalf("different-node takeover error = %v", errDifferentNode)
+	}
+	persistedBeforeTakeover := CPANodeMembershipRecord{}
+	if errPersisted := repo.db.First(&persistedBeforeTakeover, "certificate_fingerprint = ?", first.CertificateFingerprint).Error; errPersisted != nil {
+		t.Fatal(errPersisted)
+	}
+	if !persistedBeforeTakeover.ConnectedAt.Equal(first.ConnectedAt) {
+		t.Fatalf("failed takeover changed membership: %#v", persistedBeforeTakeover)
 	}
 	second, errSecond := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true})
 	if errSecond != nil {
@@ -106,8 +115,38 @@ func TestSubscribeMembershipRejectsDifferentNodeAndAllowsSameNodeTakeover(t *tes
 	if _, errTakeover := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-missing", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true}); !errors.Is(errTakeover, ErrMembershipTakeoverUnavailable) {
 		t.Fatalf("missing membership takeover error = %v, want %v", errTakeover, ErrMembershipTakeoverUnavailable)
 	}
-	if _, errReopen := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision}); errReopen != nil {
+	_, errReopen := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision})
+	if errReopen != nil {
 		t.Fatalf("normal closed membership reopen error = %v", errReopen)
+	}
+}
+
+func TestRESPHandlerKeepsMembershipInstanceIDRuntimeOnly(t *testing.T) {
+	ctx := context.Background()
+	repo := newCredentialFoundationTestRepository(t)
+	home, errHome := repo.RegisterHomeIncarnation(ctx, "10.0.0.1", 8317, []string{"credential_concurrency_foundation_v1"})
+	if errHome != nil {
+		t.Fatal(errHome)
+	}
+	revision, errUpdate := repo.UpdateLifecycleConfig(ctx, 20*time.Second, config.DefaultCredentialConcurrencyConfig())
+	if errUpdate != nil {
+		t.Fatal(errUpdate)
+	}
+	coordinator := NewCoordinator(repo, NodeIdentity{IP: home.IP, Port: home.Port}, CoordinatorOptions{})
+	coordinator.mu.Lock()
+	coordinator.homeIncarnation = home
+	coordinator.initialized = true
+	coordinator.mu.Unlock()
+
+	lifetime, errSubscribe := NewRESPHandler(coordinator, nil, repo).SubscribeMembership(ctx, "fp-runtime", "cpa-runtime", 1, revision, false, testMembershipInstanceID)
+	if errSubscribe != nil {
+		t.Fatal(errSubscribe)
+	}
+	if lifetime.InstanceID != testMembershipInstanceID {
+		t.Fatalf("runtime instance ID = %q, want %q", lifetime.InstanceID, testMembershipInstanceID)
+	}
+	if repo.db.Migrator().HasColumn(&CPANodeMembershipRecord{}, "instance_id") {
+		t.Fatal("membership instance ID was persisted as a database column")
 	}
 }
 

--- a/internal/cluster/membership_test.go
+++ b/internal/cluster/membership_test.go
@@ -10,7 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestSubscribeMembershipRejectsDuplicateOwnerAndReopensOnlyClosed(t *testing.T) {
+func TestSubscribeMembershipRejectsDifferentNodeAndAllowsSameNodeTakeover(t *testing.T) {
 	ctx := context.Background()
 	repo := newCredentialFoundationTestRepository(t)
 	homeA, errHomeA := repo.RegisterHomeIncarnation(ctx, "10.0.0.1", 8317, []string{"credential_concurrency_foundation_v1"})
@@ -29,22 +29,89 @@ func TestSubscribeMembershipRejectsDuplicateOwnerAndReopensOnlyClosed(t *testing
 	if errFirst != nil {
 		t.Fatal(errFirst)
 	}
-	if _, errDuplicate := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision}); !errors.Is(errDuplicate, ErrDuplicateCPACertificate) {
+	counter := CredentialConcurrencyCounterRecord{CredentialID: "cred-a", Model: "model-a", CertificateFingerprint: first.CertificateFingerprint, ActiveCount: 1, UpdatedAt: time.Now().UTC()}
+	if errCreate := repo.db.Create(&counter).Error; errCreate != nil {
+		t.Fatal(errCreate)
+	}
+	if _, errDuplicate := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-b", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision}); !errors.Is(errDuplicate, ErrDuplicateCPACertificate) {
 		t.Fatalf("duplicate error = %v", errDuplicate)
 	}
-	if errClose := repo.db.WithContext(ctx).Model(&CPANodeMembershipRecord{}).Where("certificate_fingerprint = ?", "fp-a").Update("state", MembershipStateClosed).Error; errClose != nil {
-		t.Fatal(errClose)
+	if _, errNoTakeover := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision}); !errors.Is(errNoTakeover, ErrDuplicateCPACertificate) {
+		t.Fatalf("same-node request without takeover error = %v", errNoTakeover)
 	}
-	second, errSecond := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision})
+	if _, errDifferentNode := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-b", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true}); !errors.Is(errDifferentNode, ErrDuplicateCPACertificate) {
+		t.Fatalf("different-node takeover error = %v", errDifferentNode)
+	}
+	second, errSecond := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true})
 	if errSecond != nil {
 		t.Fatal(errSecond)
 	}
 	if !second.ConnectedAt.After(first.ConnectedAt) {
 		t.Fatalf("connected_at did not increase: first=%s second=%s", first.ConnectedAt, second.ConnectedAt)
 	}
+	if second.HomeIP != homeB.IP || second.HomePort != homeB.Port || !second.HomeStartedAt.Equal(homeB.StartedAt) {
+		t.Fatalf("takeover owner = %s:%d %s, want %#v", second.HomeIP, second.HomePort, second.HomeStartedAt, homeB)
+	}
+	oldLifetime := ConnectionLifetime{Fingerprint: first.CertificateFingerprint, ConnectedAt: first.ConnectedAt, Home: homeA, Controlled: true}
+	newLifetime := ConnectionLifetime{Fingerprint: second.CertificateFingerprint, ConnectedAt: second.ConnectedAt, Home: homeB, Controlled: true}
+	if _, errCancel := repo.BeginFingerprintCancellationForLifetime(ctx, oldLifetime); !errors.Is(errCancel, ErrMembershipNotActive) {
+		t.Fatalf("stale lifetime cancellation error = %v, want %v", errCancel, ErrMembershipNotActive)
+	}
+	var counterCount int64
+	if errCount := repo.db.Model(&CredentialConcurrencyCounterRecord{}).Where("certificate_fingerprint = ?", first.CertificateFingerprint).Count(&counterCount).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if counterCount != 1 {
+		t.Fatalf("counter count after takeover = %d, want 1", counterCount)
+	}
+	errOld := withConcurrencyTransaction(ctx, repo.db, func(tx *gorm.DB) error {
+		return repo.LockActiveConcurrencyLifetimeTx(ctx, tx, oldLifetime)
+	})
+	if !errors.Is(errOld, ErrConcurrencyNodeUnavailable) {
+		t.Fatalf("old lifetime error = %v, want %v", errOld, ErrConcurrencyNodeUnavailable)
+	}
+	if errNew := withConcurrencyTransaction(ctx, repo.db, func(tx *gorm.DB) error {
+		return repo.LockActiveConcurrencyLifetimeTx(ctx, tx, newLifetime)
+	}); errNew != nil {
+		t.Fatalf("new lifetime error = %v", errNew)
+	}
+	oldClassified, errClassify := repo.ClassifyConnection(ctx, first.CertificateFingerprint, homeA)
+	if errClassify != nil {
+		t.Fatal(errClassify)
+	}
+	newClassified, errClassify := repo.ClassifyConnection(ctx, second.CertificateFingerprint, homeB)
+	if errClassify != nil {
+		t.Fatal(errClassify)
+	}
+	if oldClassified.Controlled || !newClassified.Controlled || !newClassified.ConnectedAt.Equal(second.ConnectedAt) {
+		t.Fatalf("classified lifetimes old=%#v new=%#v", oldClassified, newClassified)
+	}
+	var activeCount int64
+	if errCount := repo.db.Model(&CPANodeMembershipRecord{}).Where("certificate_fingerprint = ? AND state = ?", first.CertificateFingerprint, MembershipStateActive).Count(&activeCount).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if activeCount != 1 {
+		t.Fatalf("active membership count = %d, want 1", activeCount)
+	}
+	if _, errCancel := repo.BeginFingerprintCancellationForLifetime(ctx, newLifetime); errCancel != nil {
+		t.Fatalf("current lifetime cancellation error = %v", errCancel)
+	}
+	assertMembershipState(t, repo, second.CertificateFingerprint, MembershipStateCanceling)
+	if errClose := repo.db.Model(&CPANodeMembershipRecord{}).Where("certificate_fingerprint = ?", second.CertificateFingerprint).Update("state", MembershipStateClosed).Error; errClose != nil {
+		t.Fatal(errClose)
+	}
+	if _, errTakeover := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true}); !errors.Is(errTakeover, ErrMembershipTakeoverUnavailable) {
+		t.Fatalf("closed membership takeover error = %v, want %v", errTakeover, ErrMembershipTakeoverUnavailable)
+	}
+	if _, errTakeover := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-missing", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true}); !errors.Is(errTakeover, ErrMembershipTakeoverUnavailable) {
+		t.Fatalf("missing membership takeover error = %v, want %v", errTakeover, ErrMembershipTakeoverUnavailable)
+	}
+	if _, errReopen := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: homeB, ProtocolVersion: 1, LifecycleConfigRevision: revision}); errReopen != nil {
+		t.Fatalf("normal closed membership reopen error = %v", errReopen)
+	}
 }
 
-func TestClassifyConnectionRecordsParticipationForCurrentCommandHome(t *testing.T) {
+func TestClassifyConnectionOnlyControlsMembershipOwnerHome(t *testing.T) {
 	ctx := context.Background()
 	repo := newCredentialFoundationTestRepository(t)
 	owner, errOwner := repo.RegisterHomeIncarnation(ctx, "10.0.0.1", 8317, []string{"credential_concurrency_foundation_v1"})
@@ -68,12 +135,23 @@ func TestClassifyConnectionRecordsParticipationForCurrentCommandHome(t *testing.
 	if errClassify != nil {
 		t.Fatal(errClassify)
 	}
-	if !lifetime.Controlled || lifetime.Home != commandHome || !lifetime.ConnectedAt.Equal(member.ConnectedAt) {
+	if lifetime.Controlled || lifetime.Home != commandHome || !lifetime.ConnectedAt.IsZero() {
 		t.Fatalf("lifetime = %#v", lifetime)
 	}
-	var participation CPANodeParticipationRecord
-	if errFind := repo.db.Where("certificate_fingerprint = ? AND membership_connected_at = ? AND home_ip = ? AND home_port = ? AND home_started_at = ?", "fp-a", member.ConnectedAt, commandHome.IP, commandHome.Port, commandHome.StartedAt).First(&participation).Error; errFind != nil {
-		t.Fatal(errFind)
+	var participationCount int64
+	if errCount := repo.db.Model(&CPANodeParticipationRecord{}).Where("certificate_fingerprint = ? AND membership_connected_at = ? AND home_ip = ? AND home_port = ? AND home_started_at = ?", "fp-a", member.ConnectedAt, commandHome.IP, commandHome.Port, commandHome.StartedAt).Count(&participationCount).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if participationCount != 0 {
+		t.Fatalf("non-owner participation count = %d, want 0", participationCount)
+	}
+
+	lifetime, errClassify = repo.ClassifyConnection(ctx, "fp-a", owner)
+	if errClassify != nil {
+		t.Fatal(errClassify)
+	}
+	if !lifetime.Controlled || lifetime.Home != owner || !lifetime.ConnectedAt.Equal(member.ConnectedAt) {
+		t.Fatalf("owner lifetime = %#v", lifetime)
 	}
 }
 

--- a/internal/cluster/membership_test.go
+++ b/internal/cluster/membership_test.go
@@ -111,6 +111,60 @@ func TestSubscribeMembershipRejectsDifferentNodeAndAllowsSameNodeTakeover(t *tes
 	}
 }
 
+func TestSubscribeMembershipKeepsTakeoverLivenessAtDatabaseTime(t *testing.T) {
+	ctx := context.Background()
+	repo := newCredentialFoundationTestRepository(t)
+	home, errHome := repo.RegisterHomeIncarnation(ctx, "10.0.0.1", 8317, []string{"credential_concurrency_foundation_v1"})
+	if errHome != nil {
+		t.Fatal(errHome)
+	}
+	revision, errUpdate := repo.UpdateLifecycleConfig(ctx, 20*time.Second, config.DefaultCredentialConcurrencyConfig())
+	if errUpdate != nil {
+		t.Fatal(errUpdate)
+	}
+	first, errFirst := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: home, ProtocolVersion: 1, LifecycleConfigRevision: revision})
+	if errFirst != nil {
+		t.Fatal(errFirst)
+	}
+
+	futureConnectedAt := first.ConnectedAt.Add(10 * time.Minute)
+	if errFuture := repo.db.Model(&CPANodeMembershipRecord{}).
+		Where("certificate_fingerprint = ?", first.CertificateFingerprint).
+		Update("connected_at", futureConnectedAt).Error; errFuture != nil {
+		t.Fatal(errFuture)
+	}
+	dbNowBefore, errNow := DatabaseNow(ctx, repo.db)
+	if errNow != nil {
+		t.Fatal(errNow)
+	}
+
+	takenOver, errTakeover := repo.SubscribeMembership(ctx, SubscribeMembershipRequest{Fingerprint: "fp-a", NodeID: "cpa-a", Home: home, ProtocolVersion: 1, LifecycleConfigRevision: revision, Takeover: true})
+	if errTakeover != nil {
+		t.Fatal(errTakeover)
+	}
+	dbNowAfter, errNow := DatabaseNow(ctx, repo.db)
+	if errNow != nil {
+		t.Fatal(errNow)
+	}
+	persisted := CPANodeMembershipRecord{}
+	if errPersisted := repo.db.First(&persisted, "certificate_fingerprint = ?", takenOver.CertificateFingerprint).Error; errPersisted != nil {
+		t.Fatal(errPersisted)
+	}
+
+	if !takenOver.ConnectedAt.After(futureConnectedAt) {
+		t.Fatalf("takeover connected_at = %s, want after %s", takenOver.ConnectedAt, futureConnectedAt)
+	}
+	if !persisted.ConnectedAt.Equal(takenOver.ConnectedAt) {
+		t.Fatalf("persisted connected_at = %s, want %s", persisted.ConnectedAt, takenOver.ConnectedAt)
+	}
+	if persisted.LastSeenAt.Before(dbNowBefore) || persisted.LastSeenAt.After(dbNowAfter) {
+		t.Fatalf("persisted last_seen_at = %s, want database time between %s and %s", persisted.LastSeenAt, dbNowBefore, dbNowAfter)
+	}
+	if !persisted.LastSeenAt.Before(persisted.ConnectedAt) {
+		t.Fatalf("takeover liveness time %s was advanced to lifetime identity %s", persisted.LastSeenAt, persisted.ConnectedAt)
+	}
+}
+
 func TestClassifyConnectionOnlyControlsMembershipOwnerHome(t *testing.T) {
 	ctx := context.Background()
 	repo := newCredentialFoundationTestRepository(t)

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -154,6 +154,15 @@ func (ConcurrencyActivationGateRecord) TableName() string {
 	return "concurrency_activation_gate"
 }
 
+// ClusterMasterGateRecord serializes the single persisted Home master selection.
+type ClusterMasterGateRecord struct {
+	ID int `gorm:"column:id;primaryKey"`
+}
+
+func (ClusterMasterGateRecord) TableName() string {
+	return "cluster_master_gate"
+}
+
 // HomeProcessIncarnationRecord stores an append-only Home process incarnation.
 type HomeProcessIncarnationRecord struct {
 	HomeIP       string     `gorm:"column:home_ip;primaryKey"`

--- a/internal/cluster/quiescence.go
+++ b/internal/cluster/quiescence.go
@@ -54,6 +54,39 @@ func (r *Repository) BeginFingerprintCancellation(ctx context.Context, fingerpri
 	return revision, errTransaction
 }
 
+// BeginFingerprintCancellationForLifetime starts cancellation only when the exact connection lifetime is still active.
+func (r *Repository) BeginFingerprintCancellationForLifetime(ctx context.Context, lifetime ConnectionLifetime) (int64, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return 0, errDB
+	}
+	lifetime.Fingerprint = strings.TrimSpace(lifetime.Fingerprint)
+	lifetime.Home.IP = strings.TrimSpace(lifetime.Home.IP)
+	if !lifetime.Controlled || lifetime.Fingerprint == "" || lifetime.ConnectedAt.IsZero() || lifetime.Home.IP == "" || lifetime.Home.Port <= 0 || lifetime.Home.StartedAt.IsZero() {
+		return 0, ErrMembershipNotActive
+	}
+
+	var revision int64
+	errTransaction := db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		membership := CPANodeMembershipRecord{}
+		errLock := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("certificate_fingerprint = ?", lifetime.Fingerprint).First(&membership).Error
+		if errors.Is(errLock, gorm.ErrRecordNotFound) {
+			return ErrMembershipNotActive
+		}
+		if errLock != nil {
+			return errLock
+		}
+		recordQuiescenceLock(ctx, "membership")
+		if membership.State != MembershipStateActive || !membership.ConnectedAt.Equal(lifetime.ConnectedAt) || !membershipOwnedByHome(membership, lifetime.Home) {
+			return ErrMembershipNotActive
+		}
+		var errBegin error
+		revision, errBegin = beginFingerprintCancellationForMembershipTx(ctx, tx, &membership, time.Time{})
+		return errBegin
+	})
+	return revision, errTransaction
+}
+
 func beginFingerprintCancellationTx(ctx context.Context, tx *gorm.DB, fingerprint string, now time.Time) (int64, error) {
 	membership := CPANodeMembershipRecord{}
 	if errLock := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("certificate_fingerprint = ?", fingerprint).First(&membership).Error; errLock != nil {
@@ -355,7 +388,7 @@ func (r *Repository) RefreshCPALiveness(ctx context.Context, lifetime Connection
 		if errMember != nil {
 			return errMember
 		}
-		if membership.State != MembershipStateActive || !membership.ConnectedAt.Equal(lifetime.ConnectedAt) {
+		if membership.State != MembershipStateActive || !membership.ConnectedAt.Equal(lifetime.ConnectedAt) || !membershipOwnedByHome(membership, lifetime.Home) {
 			return ErrMembershipNotActive
 		}
 		if errHome := verifyActiveHomeIncarnation(tx, lifetime.Home); errHome != nil {

--- a/internal/cluster/refresh.go
+++ b/internal/cluster/refresh.go
@@ -67,7 +67,11 @@ func (c *RefreshController) RefreshNow(ctx context.Context, authIndex string) ([
 	if c.coordinator == nil || c.repo == nil {
 		return c.runtime.RefreshNowLocal(ctx, authIndex)
 	}
-	if c.coordinator.IsMaster() {
+	master, errMaster := c.coordinator.CurrentMaster(ctx)
+	if errMaster != nil {
+		return nil, fmt.Errorf("cluster refresh master lookup: %w", errMaster)
+	}
+	if c.isSelf(master) {
 		return c.refreshLocalWithLock(ctx, authIndex)
 	}
 
@@ -77,15 +81,10 @@ func (c *RefreshController) RefreshNow(ctx context.Context, authIndex string) ([
 			forwardAuthUUID = targetUUID
 		}
 	}
-	master, errMaster := c.coordinator.CurrentMaster(ctx)
-	if errMaster == nil && master != nil && strings.TrimSpace(master.IP) != "" && master.Port > 0 {
-		if c.isSelf(master) {
-			return c.refreshLocalWithLock(ctx, authIndex)
-		}
+	if master != nil && strings.TrimSpace(master.IP) != "" && master.Port > 0 {
 		nodeSecret := c.coordinator.NodeSecret()
 		if strings.TrimSpace(nodeSecret) == "" {
-			log.Warnf("cluster refresh node secret missing, falling back to local refresh")
-			return c.refreshLocalWithLock(ctx, authIndex)
+			return nil, fmt.Errorf("cluster refresh node secret is unavailable")
 		}
 		forwardRefresh := c.forwardRefresh
 		if forwardRefresh == nil {
@@ -106,15 +105,12 @@ func (c *RefreshController) RefreshNow(ctx context.Context, authIndex string) ([
 				}
 				return nil, errForward
 			}
-			log.Warn("cluster refresh forward failed, falling back to local refresh")
+			return nil, fmt.Errorf("cluster refresh forward to master: %w", errForward)
 		}
-	} else if errMaster != nil {
-		log.Warnf("cluster refresh master lookup failed, falling back to local refresh: %v", errMaster)
 	} else {
-		log.Warnf("cluster refresh master unavailable, falling back to local refresh")
+		return nil, fmt.Errorf("cluster refresh master is unavailable")
 	}
-
-	return c.refreshLocalWithLock(ctx, authIndex)
+	return nil, fmt.Errorf("cluster refresh master is unavailable")
 }
 
 // syncForwardedAuth applies the state already persisted by the master without

--- a/internal/cluster/refresh_test.go
+++ b/internal/cluster/refresh_test.go
@@ -17,6 +17,24 @@ import (
 	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
 )
 
+func markRefreshTestMaster(t *testing.T, repo *Repository, coordinator *Coordinator) {
+	t.Helper()
+	if repo == nil || coordinator == nil {
+		t.Fatal("refresh test master is unavailable")
+	}
+	now := time.Now().UTC()
+	if errCreate := repo.db.Create(&ClusterNodeRecord{
+		IP:         coordinator.node.IP,
+		Port:       coordinator.node.Port,
+		IsMaster:   true,
+		StartedAt:  coordinator.node.StartedAt,
+		LastSeenAt: now,
+	}).Error; errCreate != nil {
+		t.Fatalf("create refresh test master: %v", errCreate)
+	}
+	coordinator.setMaster(true)
+}
+
 func TestNewRefreshControllerStoresForwardTLSConfig(t *testing.T) {
 	t.Parallel()
 
@@ -209,7 +227,7 @@ func TestRefreshControllerMasterFailureFailsClosedWhenIndexSyncFails(t *testing.
 	t.Cleanup(runtime.Stop)
 
 	coordinator := NewCoordinator(repo, NodeIdentity{IP: "127.0.0.1", Port: 9300, Secret: "master-secret"}, CoordinatorOptions{})
-	coordinator.setMaster(true)
+	markRefreshTestMaster(t, repo, coordinator)
 	controller := NewRefreshController(coordinator, runtime, repo, nil)
 
 	_, errRefresh := controller.RefreshNow(ctx, authID)
@@ -233,7 +251,7 @@ func TestRefreshControllerMasterInvalidGrantPersistsDisabledAuth(t *testing.T) {
 	transport := &refreshTestRoundTripper{body: `{"error":"invalid_grant","error_description":"Token has been expired or revoked.","access_token":"response-access-secret"}`}
 	runtime := newRefreshTestRuntime(t, repo, auth, transport)
 	coordinator := NewCoordinator(repo, NodeIdentity{IP: "127.0.0.1", Port: 9301, Secret: "master-secret"}, CoordinatorOptions{})
-	coordinator.setMaster(true)
+	markRefreshTestMaster(t, repo, coordinator)
 	controller := NewRefreshController(coordinator, runtime, repo, nil)
 
 	_, errRefresh := controller.RefreshNow(ctx, authID)
@@ -295,22 +313,8 @@ func TestRefreshControllerStandbyPreservesTerminalMasterError(t *testing.T) {
 
 	masterIdentity := NodeIdentity{IP: "127.0.0.1", Port: 9401, Secret: "master-secret", StartedAt: time.Now().UTC().Add(-time.Minute)}
 	masterCoordinator := NewCoordinator(repo, masterIdentity, CoordinatorOptions{})
-	masterCoordinator.setMaster(true)
+	markRefreshTestMaster(t, repo, masterCoordinator)
 	masterController := NewRefreshController(masterCoordinator, masterRuntime, repo, nil)
-
-	db, errDB := repo.database()
-	if errDB != nil {
-		t.Fatalf("repository database: %v", errDB)
-	}
-	if errCreate := db.Create(&ClusterNodeRecord{
-		IP:         masterIdentity.IP,
-		Port:       masterIdentity.Port,
-		IsMaster:   true,
-		StartedAt:  masterIdentity.StartedAt,
-		LastSeenAt: time.Now().UTC(),
-	}).Error; errCreate != nil {
-		t.Fatalf("create master node: %v", errCreate)
-	}
 
 	standbyCoordinator := NewCoordinator(repo, NodeIdentity{IP: "127.0.0.2", Port: 9402, Secret: "standby-secret"}, CoordinatorOptions{})
 	standbyCoordinator.setMaster(false)

--- a/internal/cluster/resp.go
+++ b/internal/cluster/resp.go
@@ -89,7 +89,7 @@ func (h *RESPHandler) RefreshCPALiveness(ctx context.Context, lifetime Connectio
 }
 
 // SubscribeMembership creates a membership owned by this Home incarnation.
-func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint string, nodeID string, protocolVersion int, lifecycleConfigRevision int64, takeover bool) (ConnectionLifetime, error) {
+func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint string, nodeID string, protocolVersion int, lifecycleConfigRevision int64, takeover bool, instanceID string) (ConnectionLifetime, error) {
 	if h == nil || h.repo == nil || h.coordinator == nil {
 		return ConnectionLifetime{}, fmt.Errorf("cluster resp: membership handler is not ready")
 	}
@@ -111,6 +111,7 @@ func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint strin
 	return ConnectionLifetime{
 		Fingerprint:  member.CertificateFingerprint,
 		ConnectedAt:  member.ConnectedAt,
+		InstanceID:   strings.TrimSpace(instanceID),
 		Home:         home,
 		Subscription: true,
 	}, nil

--- a/internal/cluster/resp.go
+++ b/internal/cluster/resp.go
@@ -44,15 +44,15 @@ func NewRESPHandler(coordinator *Coordinator, refresh *RefreshController, repo *
 	}
 }
 
-// UpdateClientCount stores the current active CPA client count for this node.
-// BeginFingerprintCancellation starts distributed cancellation for an ambiguous dispatch delivery.
-func (h *RESPHandler) BeginFingerprintCancellation(ctx context.Context, fingerprint string) (int64, error) {
+// BeginFingerprintCancellationForLifetime starts distributed cancellation for an ambiguous dispatch delivery.
+func (h *RESPHandler) BeginFingerprintCancellationForLifetime(ctx context.Context, lifetime ConnectionLifetime) (int64, error) {
 	if h == nil || h.repo == nil {
 		return 0, fmt.Errorf("cluster resp: membership handler is not ready")
 	}
-	return h.repo.BeginFingerprintCancellation(ctx, fingerprint)
+	return h.repo.BeginFingerprintCancellationForLifetime(ctx, lifetime)
 }
 
+// UpdateClientCount stores the current active CPA client count for this node.
 func (h *RESPHandler) UpdateClientCount(ctx context.Context, clientCount int) error {
 	if h == nil || h.coordinator == nil {
 		return nil
@@ -89,7 +89,7 @@ func (h *RESPHandler) RefreshCPALiveness(ctx context.Context, lifetime Connectio
 }
 
 // SubscribeMembership creates a membership owned by this Home incarnation.
-func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint string, nodeID string, protocolVersion int, lifecycleConfigRevision int64) (ConnectionLifetime, error) {
+func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint string, nodeID string, protocolVersion int, lifecycleConfigRevision int64, takeover bool) (ConnectionLifetime, error) {
 	if h == nil || h.repo == nil || h.coordinator == nil {
 		return ConnectionLifetime{}, fmt.Errorf("cluster resp: membership handler is not ready")
 	}
@@ -103,6 +103,7 @@ func (h *RESPHandler) SubscribeMembership(ctx context.Context, fingerprint strin
 		Home:                    home,
 		ProtocolVersion:         protocolVersion,
 		LifecycleConfigRevision: lifecycleConfigRevision,
+		Takeover:                takeover,
 	})
 	if errSubscribe != nil {
 		return ConnectionLifetime{}, errSubscribe

--- a/internal/respserver/dispatch/registry.go
+++ b/internal/respserver/dispatch/registry.go
@@ -54,7 +54,7 @@ type ConnEnv struct {
 	SubscribeConfigYAML            func() (int64, error)
 	UnsubscribeConfigYAML          func() (int64, error)
 	IsSubscribed                   func() bool
-	SubscribeMembership            func(context.Context, int, int64, bool) (cluster.ConnectionLifetime, error)
+	SubscribeMembership            func(context.Context, int, int64, bool, string) (cluster.ConnectionLifetime, error)
 	AttachSubscriptionLifetimeFunc func(cluster.ConnectionLifetime) error
 	FenceFingerprint               func(context.Context, string) error
 	CloseLocalFingerprint          func()

--- a/internal/respserver/dispatch/registry.go
+++ b/internal/respserver/dispatch/registry.go
@@ -54,7 +54,7 @@ type ConnEnv struct {
 	SubscribeConfigYAML            func() (int64, error)
 	UnsubscribeConfigYAML          func() (int64, error)
 	IsSubscribed                   func() bool
-	SubscribeMembership            func(context.Context, int, int64) (cluster.ConnectionLifetime, error)
+	SubscribeMembership            func(context.Context, int, int64, bool) (cluster.ConnectionLifetime, error)
 	AttachSubscriptionLifetimeFunc func(cluster.ConnectionLifetime) error
 	FenceFingerprint               func(context.Context, string) error
 	CloseLocalFingerprint          func()

--- a/internal/respserver/fingerprint_registry_test.go
+++ b/internal/respserver/fingerprint_registry_test.go
@@ -249,7 +249,7 @@ func (h *blockingClusterHandler) ClassifyConnection(context.Context, string) (cl
 	return h.lifetime, nil
 }
 
-func (h *blockingClusterHandler) SubscribeMembership(context.Context, string, string, int, int64, bool) (cluster.ConnectionLifetime, error) {
+func (h *blockingClusterHandler) SubscribeMembership(context.Context, string, string, int, int64, bool, string) (cluster.ConnectionLifetime, error) {
 	return h.lifetime, nil
 }
 

--- a/internal/respserver/fingerprint_registry_test.go
+++ b/internal/respserver/fingerprint_registry_test.go
@@ -249,7 +249,7 @@ func (h *blockingClusterHandler) ClassifyConnection(context.Context, string) (cl
 	return h.lifetime, nil
 }
 
-func (h *blockingClusterHandler) SubscribeMembership(context.Context, string, string, int, int64) (cluster.ConnectionLifetime, error) {
+func (h *blockingClusterHandler) SubscribeMembership(context.Context, string, string, int, int64, bool) (cluster.ConnectionLifetime, error) {
 	return h.lifetime, nil
 }
 

--- a/internal/respserver/server.go
+++ b/internal/respserver/server.go
@@ -30,7 +30,7 @@ type fingerprintCancellationStarter interface {
 
 type clusterHandler interface {
 	ClassifyConnection(context.Context, string) (cluster.ConnectionLifetime, error)
-	SubscribeMembership(context.Context, string, string, int, int64, bool) (cluster.ConnectionLifetime, error)
+	SubscribeMembership(context.Context, string, string, int, int64, bool, string) (cluster.ConnectionLifetime, error)
 	RefreshCPALiveness(context.Context, cluster.ConnectionLifetime) error
 	UpdateClientCount(context.Context, int) error
 	Handle(context.Context, []string, string) ([]byte, error)
@@ -484,8 +484,8 @@ func (s *Server) HandleConn(ctx context.Context, conn net.Conn) {
 		},
 	}
 	if s.cluster != nil && clientCertificateFingerprint != "" {
-		connEnv.SubscribeMembership = func(subscriptionCtx context.Context, protocolVersion int, lifecycleConfigRevision int64, takeover bool) (cluster.ConnectionLifetime, error) {
-			return s.cluster.SubscribeMembership(subscriptionCtx, clientCertificateFingerprint, clientNodeID, protocolVersion, lifecycleConfigRevision, takeover)
+		connEnv.SubscribeMembership = func(subscriptionCtx context.Context, protocolVersion int, lifecycleConfigRevision int64, takeover bool, instanceID string) (cluster.ConnectionLifetime, error) {
+			return s.cluster.SubscribeMembership(subscriptionCtx, clientCertificateFingerprint, clientNodeID, protocolVersion, lifecycleConfigRevision, takeover, instanceID)
 		}
 	}
 

--- a/internal/respserver/server.go
+++ b/internal/respserver/server.go
@@ -25,12 +25,12 @@ import (
 )
 
 type fingerprintCancellationStarter interface {
-	BeginFingerprintCancellation(context.Context, string) (int64, error)
+	BeginFingerprintCancellationForLifetime(context.Context, cluster.ConnectionLifetime) (int64, error)
 }
 
 type clusterHandler interface {
 	ClassifyConnection(context.Context, string) (cluster.ConnectionLifetime, error)
-	SubscribeMembership(context.Context, string, string, int, int64) (cluster.ConnectionLifetime, error)
+	SubscribeMembership(context.Context, string, string, int, int64, bool) (cluster.ConnectionLifetime, error)
 	RefreshCPALiveness(context.Context, cluster.ConnectionLifetime) error
 	UpdateClientCount(context.Context, int) error
 	Handle(context.Context, []string, string) ([]byte, error)
@@ -423,7 +423,7 @@ func (s *Server) HandleConn(ctx context.Context, conn net.Conn) {
 			if !ok || starter == nil {
 				return fmt.Errorf("cluster fingerprint cancellation is unavailable")
 			}
-			_, errBegin := starter.BeginFingerprintCancellation(fenceCtx, connectionLifetime.Fingerprint)
+			_, errBegin := starter.BeginFingerprintCancellationForLifetime(fenceCtx, connectionLifetime)
 			return errBegin
 		},
 		CloseLocalFingerprint: func() {
@@ -484,8 +484,8 @@ func (s *Server) HandleConn(ctx context.Context, conn net.Conn) {
 		},
 	}
 	if s.cluster != nil && clientCertificateFingerprint != "" {
-		connEnv.SubscribeMembership = func(subscriptionCtx context.Context, protocolVersion int, lifecycleConfigRevision int64) (cluster.ConnectionLifetime, error) {
-			return s.cluster.SubscribeMembership(subscriptionCtx, clientCertificateFingerprint, clientNodeID, protocolVersion, lifecycleConfigRevision)
+		connEnv.SubscribeMembership = func(subscriptionCtx context.Context, protocolVersion int, lifecycleConfigRevision int64, takeover bool) (cluster.ConnectionLifetime, error) {
+			return s.cluster.SubscribeMembership(subscriptionCtx, clientCertificateFingerprint, clientNodeID, protocolVersion, lifecycleConfigRevision, takeover)
 		}
 	}
 

--- a/internal/respserver/subscribe/config.go
+++ b/internal/respserver/subscribe/config.go
@@ -5,13 +5,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/respserver/dispatch"
 )
 
 // handleConfig handles a config.
 func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch.Reply {
-	if len(args) < 2 || len(args) > 4 {
+	if len(args) < 2 || len(args) > 5 {
 		return dispatch.Err("wrong number of arguments for 'subscribe' command")
 	}
 
@@ -22,6 +23,7 @@ func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch
 	protocolVersion := 0
 	lifecycleConfigRevision := int64(0)
 	takeover := false
+	instanceID := ""
 	if len(args) >= 3 {
 		parsedRevision, errParse := strconv.ParseInt(strings.TrimSpace(args[2]), 10, 64)
 		if errParse != nil || parsedRevision < 1 {
@@ -31,10 +33,25 @@ func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch
 		lifecycleConfigRevision = parsedRevision
 	}
 	if len(args) == 4 {
+		instanceID = strings.TrimSpace(args[3])
+	}
+	if len(args) == 5 {
 		if !strings.EqualFold(strings.TrimSpace(args[3]), "takeover") {
 			return dispatch.Err("invalid membership takeover mode")
 		}
 		takeover = true
+		instanceID = strings.TrimSpace(args[4])
+	}
+	if instanceID != "" {
+		if len(instanceID) > 64 {
+			return dispatch.Err("invalid membership instance ID")
+		}
+		parsedInstanceID, errParse := uuid.Parse(instanceID)
+		if errParse != nil || parsedInstanceID.String() != strings.ToLower(instanceID) {
+			return dispatch.Err("invalid membership instance ID")
+		}
+	} else if len(args) >= 4 {
+		return dispatch.Err("invalid membership instance ID")
 	}
 
 	var lifetimeMetadata *cluster.ConnectionLifetime
@@ -43,7 +60,7 @@ func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch
 			lifetimeMetadata = &lifetime
 		}
 	} else if env.Conn.SubscribeMembership != nil {
-		lifetime, errMembership := env.Conn.SubscribeMembership(ctx, protocolVersion, lifecycleConfigRevision, takeover)
+		lifetime, errMembership := env.Conn.SubscribeMembership(ctx, protocolVersion, lifecycleConfigRevision, takeover, instanceID)
 		if errMembership != nil {
 			return dispatch.Err(errMembership.Error())
 		}

--- a/internal/respserver/subscribe/config.go
+++ b/internal/respserver/subscribe/config.go
@@ -11,7 +11,7 @@ import (
 
 // handleConfig handles a config.
 func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch.Reply {
-	if len(args) != 2 && len(args) != 3 {
+	if len(args) < 2 || len(args) > 4 {
 		return dispatch.Err("wrong number of arguments for 'subscribe' command")
 	}
 
@@ -21,13 +21,20 @@ func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch
 
 	protocolVersion := 0
 	lifecycleConfigRevision := int64(0)
-	if len(args) == 3 {
+	takeover := false
+	if len(args) >= 3 {
 		parsedRevision, errParse := strconv.ParseInt(strings.TrimSpace(args[2]), 10, 64)
 		if errParse != nil || parsedRevision < 1 {
 			return dispatch.Err("invalid lifecycle configuration revision")
 		}
 		protocolVersion = 1
 		lifecycleConfigRevision = parsedRevision
+	}
+	if len(args) == 4 {
+		if !strings.EqualFold(strings.TrimSpace(args[3]), "takeover") {
+			return dispatch.Err("invalid membership takeover mode")
+		}
+		takeover = true
 	}
 
 	var lifetimeMetadata *cluster.ConnectionLifetime
@@ -36,7 +43,7 @@ func handleConfig(ctx context.Context, env dispatch.Env, args []string) dispatch
 			lifetimeMetadata = &lifetime
 		}
 	} else if env.Conn.SubscribeMembership != nil {
-		lifetime, errMembership := env.Conn.SubscribeMembership(ctx, protocolVersion, lifecycleConfigRevision)
+		lifetime, errMembership := env.Conn.SubscribeMembership(ctx, protocolVersion, lifecycleConfigRevision, takeover)
 		if errMembership != nil {
 			return dispatch.Err(errMembership.Error())
 		}

--- a/internal/respserver/subscribe/config_test.go
+++ b/internal/respserver/subscribe/config_test.go
@@ -2,6 +2,7 @@ package subscribe
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ func TestConfigSubscribeUsesProtocolOneRevisionAndReturnsLifetime(t *testing.T) 
 	var gotRevision int64
 	var gotTakeover bool
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(_ context.Context, protocol int, revision int64, takeover bool) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(_ context.Context, protocol int, revision int64, takeover bool, _ string) (cluster.ConnectionLifetime, error) {
 			gotProtocol = protocol
 			gotRevision = revision
 			gotTakeover = takeover
@@ -41,7 +42,7 @@ func TestConfigSubscribeUsesProtocolZeroWithoutRevision(t *testing.T) {
 	var gotProtocol int
 	called := false
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(_ context.Context, protocol int, _ int64, takeover bool) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(_ context.Context, protocol int, _ int64, takeover bool, _ string) (cluster.ConnectionLifetime, error) {
 			called = true
 			gotProtocol = protocol
 			if takeover {
@@ -62,23 +63,25 @@ func TestConfigSubscribeUsesProtocolZeroWithoutRevision(t *testing.T) {
 
 func TestConfigSubscribePassesTakeover(t *testing.T) {
 	var gotTakeover bool
+	var gotInstanceID string
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(_ context.Context, _ int, _ int64, takeover bool) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(_ context.Context, _ int, _ int64, takeover bool, instanceID string) (cluster.ConnectionLifetime, error) {
 			gotTakeover = takeover
+			gotInstanceID = instanceID
 			return cluster.ConnectionLifetime{}, nil
 		},
 		SubscribeConfigYAML: func() (int64, error) { return 1, nil },
-	}}, []string{"SUBSCRIBE", "config", "17", "takeover"})
+	}}, []string{"SUBSCRIBE", "config", "17", "takeover", "550e8400-e29b-41d4-a716-446655440000"})
 
-	if !gotTakeover || reply.Kind != dispatch.ReplyKindArray {
-		t.Fatalf("takeover = %t reply = %#v", gotTakeover, reply)
+	if !gotTakeover || gotInstanceID != "550e8400-e29b-41d4-a716-446655440000" || reply.Kind != dispatch.ReplyKindArray {
+		t.Fatalf("takeover = %t instance ID = %q reply = %#v", gotTakeover, gotInstanceID, reply)
 	}
 }
 
 func TestConfigSubscribeRejectsInvalidFourthArgument(t *testing.T) {
 	called := false
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(context.Context, int, int64, bool) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(context.Context, int, int64, bool, string) (cluster.ConnectionLifetime, error) {
 			called = true
 			return cluster.ConnectionLifetime{}, nil
 		},
@@ -87,5 +90,58 @@ func TestConfigSubscribeRejectsInvalidFourthArgument(t *testing.T) {
 
 	if called || reply.Kind != dispatch.ReplyKindRedisError {
 		t.Fatalf("called = %t reply = %#v", called, reply)
+	}
+}
+
+func TestConfigSubscribeMembershipProtocolArguments(t *testing.T) {
+	const instanceID = "550e8400-e29b-41d4-a716-446655440000"
+	tests := []struct {
+		name         string
+		args         []string
+		wantProtocol int
+		wantRevision int64
+		wantTakeover bool
+		wantInstance string
+		wantError    string
+	}{
+		{name: "protocol zero", args: []string{"SUBSCRIBE", "config"}},
+		{name: "legacy normal", args: []string{"SUBSCRIBE", "config", "7"}, wantProtocol: 1, wantRevision: 7},
+		{name: "secure normal", args: []string{"SUBSCRIBE", "config", "7", instanceID}, wantProtocol: 1, wantRevision: 7, wantInstance: instanceID},
+		{name: "secure takeover", args: []string{"SUBSCRIBE", "config", "7", "takeover", instanceID}, wantProtocol: 1, wantRevision: 7, wantTakeover: true, wantInstance: instanceID},
+		{name: "invalid revision", args: []string{"SUBSCRIBE", "config", "0"}, wantError: "ERR invalid lifecycle configuration revision"},
+		{name: "empty instance", args: []string{"SUBSCRIBE", "config", "7", ""}, wantError: "ERR invalid membership instance ID"},
+		{name: "invalid instance", args: []string{"SUBSCRIBE", "config", "7", "not-a-uuid"}, wantError: "ERR invalid membership instance ID"},
+		{name: "long instance", args: []string{"SUBSCRIBE", "config", "7", strings.Repeat("a", 65)}, wantError: "ERR invalid membership instance ID"},
+		{name: "bare takeover", args: []string{"SUBSCRIBE", "config", "7", "takeover"}, wantError: "ERR invalid membership instance ID"},
+		{name: "invalid takeover mode", args: []string{"SUBSCRIBE", "config", "7", "replace", instanceID}, wantError: "ERR invalid membership takeover mode"},
+		{name: "too few", args: []string{"SUBSCRIBE"}, wantError: "ERR wrong number of arguments for 'subscribe' command"},
+		{name: "too many", args: []string{"SUBSCRIBE", "config", "7", "takeover", instanceID, "extra"}, wantError: "ERR wrong number of arguments for 'subscribe' command"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			called := false
+			var gotProtocol int
+			var gotRevision int64
+			var gotTakeover bool
+			var gotInstance string
+			reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
+				SubscribeMembership: func(_ context.Context, protocol int, revision int64, takeover bool, instance string) (cluster.ConnectionLifetime, error) {
+					called = true
+					gotProtocol, gotRevision, gotTakeover, gotInstance = protocol, revision, takeover, instance
+					return cluster.ConnectionLifetime{}, nil
+				},
+				SubscribeConfigYAML: func() (int64, error) { return 1, nil },
+			}}, testCase.args)
+			if testCase.wantError != "" {
+				if called || reply.Kind != dispatch.ReplyKindRedisError || reply.RedisError != testCase.wantError {
+					t.Fatalf("called = %t reply = %#v", called, reply)
+				}
+				return
+			}
+			if !called || reply.Kind != dispatch.ReplyKindArray || gotProtocol != testCase.wantProtocol || gotRevision != testCase.wantRevision || gotTakeover != testCase.wantTakeover || gotInstance != testCase.wantInstance {
+				t.Fatalf("called = %t reply = %#v membership = (%d, %d, %t, %q)", called, reply, gotProtocol, gotRevision, gotTakeover, gotInstance)
+			}
+		})
 	}
 }

--- a/internal/respserver/subscribe/config_test.go
+++ b/internal/respserver/subscribe/config_test.go
@@ -18,17 +18,19 @@ func TestConfigSubscribeUsesProtocolOneRevisionAndReturnsLifetime(t *testing.T) 
 	}
 	var gotProtocol int
 	var gotRevision int64
+	var gotTakeover bool
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(_ context.Context, protocol int, revision int64) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(_ context.Context, protocol int, revision int64, takeover bool) (cluster.ConnectionLifetime, error) {
 			gotProtocol = protocol
 			gotRevision = revision
+			gotTakeover = takeover
 			return lifetime, nil
 		},
 		SubscribeConfigYAML: func() (int64, error) { return 1, nil },
 	}}, []string{"SUBSCRIBE", "config", "17"})
 
-	if gotProtocol != 1 || gotRevision != 17 {
-		t.Fatalf("membership request = protocol %d revision %d", gotProtocol, gotRevision)
+	if gotProtocol != 1 || gotRevision != 17 || gotTakeover {
+		t.Fatalf("membership request = protocol %d revision %d takeover %t", gotProtocol, gotRevision, gotTakeover)
 	}
 	if reply.SubscriptionLifetime == nil || *reply.SubscriptionLifetime != lifetime {
 		t.Fatalf("reply subscription lifetime = %#v", reply.SubscriptionLifetime)
@@ -39,9 +41,12 @@ func TestConfigSubscribeUsesProtocolZeroWithoutRevision(t *testing.T) {
 	var gotProtocol int
 	called := false
 	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
-		SubscribeMembership: func(_ context.Context, protocol int, _ int64) (cluster.ConnectionLifetime, error) {
+		SubscribeMembership: func(_ context.Context, protocol int, _ int64, takeover bool) (cluster.ConnectionLifetime, error) {
 			called = true
 			gotProtocol = protocol
+			if takeover {
+				t.Fatal("protocol zero subscription requested takeover")
+			}
 			return cluster.ConnectionLifetime{}, nil
 		},
 		SubscribeConfigYAML: func() (int64, error) { return 1, nil },
@@ -52,5 +57,35 @@ func TestConfigSubscribeUsesProtocolZeroWithoutRevision(t *testing.T) {
 	}
 	if reply.Kind != dispatch.ReplyKindArray {
 		t.Fatalf("reply = %#v", reply)
+	}
+}
+
+func TestConfigSubscribePassesTakeover(t *testing.T) {
+	var gotTakeover bool
+	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
+		SubscribeMembership: func(_ context.Context, _ int, _ int64, takeover bool) (cluster.ConnectionLifetime, error) {
+			gotTakeover = takeover
+			return cluster.ConnectionLifetime{}, nil
+		},
+		SubscribeConfigYAML: func() (int64, error) { return 1, nil },
+	}}, []string{"SUBSCRIBE", "config", "17", "takeover"})
+
+	if !gotTakeover || reply.Kind != dispatch.ReplyKindArray {
+		t.Fatalf("takeover = %t reply = %#v", gotTakeover, reply)
+	}
+}
+
+func TestConfigSubscribeRejectsInvalidFourthArgument(t *testing.T) {
+	called := false
+	reply := handleConfig(context.Background(), dispatch.Env{Conn: &dispatch.ConnEnv{
+		SubscribeMembership: func(context.Context, int, int64, bool) (cluster.ConnectionLifetime, error) {
+			called = true
+			return cluster.ConnectionLifetime{}, nil
+		},
+		SubscribeConfigYAML: func() (int64, error) { return 1, nil },
+	}}, []string{"SUBSCRIBE", "config", "17", "invalid"})
+
+	if called || reply.Kind != dispatch.ReplyKindRedisError {
+		t.Fatalf("called = %t reply = %#v", called, reply)
 	}
 }


### PR DESCRIPTION
Introduce handling for membership takeover in the cluster, including updates to the subscription method and database migration. Add tests to ensure liveness during takeover scenarios. Enhance error handling and validation for instance IDs in the subscription process.