### PR TITLE
feat(resp): add CAS compare-and-swap command

### DIFF
--- a/internal/cluster/kv_store.go
+++ b/internal/cluster/kv_store.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -120,6 +121,78 @@ func (r *Repository) KVSet(ctx context.Context, key string, value []byte, ttl ti
 		}
 	})
 	return written, errTransaction
+}
+
+// KVCompareAndSwap writes a value only when the active state matches the
+// expected state, and reports whether the swap happened.
+//
+// When expectedExists is true the key must be present and active with a value
+// equal to expected. When expectedExists is false the key must be absent or
+// expired. The comparison and the write share one transaction so concurrent
+// writers cannot both observe a matching state.
+func (r *Repository) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return false, errDB
+	}
+	key, errKey := normalizeKVKey(key)
+	if errKey != nil {
+		return false, errKey
+	}
+	copiedValue := cloneKVBytes(value)
+	expectedValue := cloneKVBytes(expected)
+	expiresAt := kvExpiresAt(ttl)
+
+	ctx = contextOrBackground(ctx)
+	swapped := false
+	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		record := KVRecord{}
+		errFirst := tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where("key = ?", key).First(&record).Error
+		now := time.Now().UTC()
+		switch {
+		case errors.Is(errFirst, gorm.ErrRecordNotFound):
+			if expectedExists {
+				return nil
+			}
+			record = KVRecord{Key: key, Value: copiedValue, Version: 1, ExpiresAt: expiresAt}
+			if errCreate := tx.Create(&record).Error; errCreate != nil {
+				return errCreate
+			}
+			swapped = true
+			return nil
+		case errFirst != nil:
+			return errFirst
+		case kvRecordExpired(record, now):
+			if errDelete := deleteExpiredKVTx(tx, key, record.ExpiresAt); errDelete != nil {
+				return errDelete
+			}
+			if expectedExists {
+				return nil
+			}
+			nextVersion := record.Version + 1
+			if nextVersion <= 1 {
+				nextVersion = 1
+			}
+			record = KVRecord{Key: key, Value: copiedValue, Version: nextVersion, ExpiresAt: expiresAt}
+			if errCreate := tx.Create(&record).Error; errCreate != nil {
+				return errCreate
+			}
+			swapped = true
+			return nil
+		case !expectedExists || !bytes.Equal(record.Value, expectedValue):
+			return nil
+		default:
+			record.Value = copiedValue
+			record.ExpiresAt = expiresAt
+			record.Version++
+			if errSave := tx.Save(&record).Error; errSave != nil {
+				return errSave
+			}
+			swapped = true
+			return nil
+		}
+	})
+	return swapped, errTransaction
 }
 
 // KVDel deletes active keys and returns the active deletion count.

--- a/internal/cluster/kv_store_test.go
+++ b/internal/cluster/kv_store_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -93,6 +95,133 @@ func TestKVSetModes(t *testing.T) {
 	}
 	if written, errSet := repo.KVSet(ctx, "created-by-nx", []byte("value"), 0, KVSetModeNX); errSet != nil || !written {
 		t.Fatalf("KVSet(nx missing) = %v, %v, want true, nil", written, errSet)
+	}
+}
+
+func TestKVCompareAndSwapReservesAbsentKeyOnce(t *testing.T) {
+	t.Parallel()
+
+	repo, ctx := newTestKVRepository(t)
+	swapped, errFirst := repo.KVCompareAndSwap(ctx, "reserve", nil, false, []byte("reservation"), 0)
+	if errFirst != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap(absent) = %v, %v, want true, nil", swapped, errFirst)
+	}
+	got, found, errGet := repo.KVGet(ctx, "reserve")
+	if errGet != nil || !found || string(got) != "reservation" {
+		t.Fatalf("KVGet() = %q, %v, %v, want reservation, true, nil", got, found, errGet)
+	}
+	swappedAgain, errSecond := repo.KVCompareAndSwap(ctx, "reserve", nil, false, []byte("second"), 0)
+	if errSecond != nil || swappedAgain {
+		t.Fatalf("KVCompareAndSwap(present, expecting absent) = %v, %v, want false, nil", swappedAgain, errSecond)
+	}
+	unchanged, foundUnchanged, errGetUnchanged := repo.KVGet(ctx, "reserve")
+	if errGetUnchanged != nil || !foundUnchanged || string(unchanged) != "reservation" {
+		t.Fatalf("KVGet() = %q, %v, %v, want reservation, true, nil", unchanged, foundUnchanged, errGetUnchanged)
+	}
+}
+
+func TestKVCompareAndSwapReplacesOnlyMatchingValue(t *testing.T) {
+	t.Parallel()
+
+	repo, ctx := newTestKVRepository(t)
+	if written, errSet := repo.KVSet(ctx, "chain", []byte("first"), 0, KVSetModeAlways); errSet != nil || !written {
+		t.Fatalf("KVSet() = %v, %v, want true, nil", written, errSet)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "chain", []byte("stale"), true, []byte("second"), 0); errCAS != nil || swapped {
+		t.Fatalf("KVCompareAndSwap(mismatch) = %v, %v, want false, nil", swapped, errCAS)
+	}
+	got, found, errGet := repo.KVGet(ctx, "chain")
+	if errGet != nil || !found || string(got) != "first" {
+		t.Fatalf("KVGet() after mismatch = %q, %v, %v, want first, true, nil", got, found, errGet)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "chain", []byte("first"), true, []byte("second"), 0); errCAS != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap(match) = %v, %v, want true, nil", swapped, errCAS)
+	}
+	replaced, foundReplaced, errGetReplaced := repo.KVGet(ctx, "chain")
+	if errGetReplaced != nil || !foundReplaced || string(replaced) != "second" {
+		t.Fatalf("KVGet() after match = %q, %v, %v, want second, true, nil", replaced, foundReplaced, errGetReplaced)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "missing", []byte("first"), true, []byte("value"), 0); errCAS != nil || swapped {
+		t.Fatalf("KVCompareAndSwap(absent, expecting present) = %v, %v, want false, nil", swapped, errCAS)
+	}
+}
+
+func TestKVCompareAndSwapAppliesTTL(t *testing.T) {
+	t.Parallel()
+
+	repo, ctx := newTestKVRepository(t)
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "ttl", nil, false, []byte("value"), time.Hour); errCAS != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap(create with ttl) = %v, %v, want true, nil", swapped, errCAS)
+	}
+	ttl, errTTL := repo.KVTTL(ctx, "ttl")
+	if errTTL != nil || ttl <= 0 {
+		t.Fatalf("KVTTL() = %d, %v, want positive, nil", ttl, errTTL)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "ttl", []byte("value"), true, []byte("next"), 0); errCAS != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap(replace without ttl) = %v, %v, want true, nil", swapped, errCAS)
+	}
+	clearedTTL, errClearedTTL := repo.KVTTL(ctx, "ttl")
+	if errClearedTTL != nil || clearedTTL != -1 {
+		t.Fatalf("KVTTL() = %d, %v, want -1, nil", clearedTTL, errClearedTTL)
+	}
+}
+
+func TestKVCompareAndSwapTreatsExpiredRowAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	repo, ctx := newTestKVRepository(t)
+	past := time.Now().UTC().Add(-time.Minute)
+	if errCreate := repo.db.Create(&KVRecord{Key: "expired", Value: []byte("old"), Version: 4, ExpiresAt: &past}).Error; errCreate != nil {
+		t.Fatalf("create expired record: %v", errCreate)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "expired", []byte("old"), true, []byte("value"), 0); errCAS != nil || swapped {
+		t.Fatalf("KVCompareAndSwap(expired, expecting present) = %v, %v, want false, nil", swapped, errCAS)
+	}
+	if swapped, errCAS := repo.KVCompareAndSwap(ctx, "expired", nil, false, []byte("value"), 0); errCAS != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap(expired, expecting absent) = %v, %v, want true, nil", swapped, errCAS)
+	}
+	got, found, errGet := repo.KVGet(ctx, "expired")
+	if errGet != nil || !found || string(got) != "value" {
+		t.Fatalf("KVGet() = %q, %v, %v, want value, true, nil", got, found, errGet)
+	}
+}
+
+func TestKVCompareAndSwapConcurrentReservationHasOneWinner(t *testing.T) {
+	t.Parallel()
+
+	repo, ctx := newTestKVRepository(t)
+	const writers = 8
+	var wg sync.WaitGroup
+	results := make([]bool, writers)
+	errs := make([]error, writers)
+	wg.Add(writers)
+	for index := 0; index < writers; index++ {
+		go func(slot int) {
+			defer wg.Done()
+			results[slot], errs[slot] = repo.KVCompareAndSwap(ctx, "race", nil, false, []byte(strconv.Itoa(slot)), time.Hour)
+		}(index)
+	}
+	wg.Wait()
+
+	winners := 0
+	for index := 0; index < writers; index++ {
+		if errs[index] != nil {
+			t.Fatalf("KVCompareAndSwap() error = %v", errs[index])
+		}
+		if results[index] {
+			winners++
+		}
+	}
+	if winners != 1 {
+		t.Fatalf("winners = %d, want 1", winners)
+	}
+	got, found, errGet := repo.KVGet(ctx, "race")
+	if errGet != nil || !found {
+		t.Fatalf("KVGet() = %q, %v, %v, want a stored value", got, found, errGet)
+	}
+	slot, errParse := strconv.Atoi(string(got))
+	if errParse != nil || slot < 0 || slot >= writers || !results[slot] {
+		t.Fatalf("stored value %q does not match the single winner", got)
 	}
 }
 

--- a/internal/cluster/runtime.go
+++ b/internal/cluster/runtime.go
@@ -146,6 +146,14 @@ func (a *RuntimeAdapter) KVSet(ctx context.Context, key string, value []byte, tt
 	return a.repo.KVSet(ctx, key, value, ttl, KVSetMode(strings.ToLower(strings.TrimSpace(mode))))
 }
 
+// KVCompareAndSwap writes a KV value only when the active state matches the expected state.
+func (a *RuntimeAdapter) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	if !a.Enabled() {
+		return false, fmt.Errorf("cluster runtime adapter is disabled")
+	}
+	return a.repo.KVCompareAndSwap(ctx, key, expected, expectedExists, value, ttl)
+}
+
 // KVDel deletes active KV values.
 func (a *RuntimeAdapter) KVDel(ctx context.Context, keys []string) (int64, error) {
 	if !a.Enabled() {

--- a/internal/home/kv_store_test.go
+++ b/internal/home/kv_store_test.go
@@ -3,6 +3,7 @@ package home
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -52,6 +53,11 @@ func (a *runtimeKVTestAdapter) KVGet(ctx context.Context, key string) ([]byte, b
 
 func (a *runtimeKVTestAdapter) KVSet(ctx context.Context, key string, value []byte, ttl time.Duration, mode string) (bool, error) {
 	a.record("KVSet:" + key + ":" + string(value) + ":" + mode)
+	return true, nil
+}
+
+func (a *runtimeKVTestAdapter) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	a.record("KVCompareAndSwap:" + key + ":" + string(expected) + ":" + strconv.FormatBool(expectedExists) + ":" + string(value))
 	return true, nil
 }
 
@@ -132,6 +138,9 @@ func TestRuntimeKVUnavailable(t *testing.T) {
 	if _, errSet := runtime.KVSet(context.Background(), "key", []byte("value"), 0, ""); errSet == nil || !strings.Contains(errSet.Error(), "kv store unavailable") {
 		t.Fatalf("KVSet() error = %v, want kv store unavailable", errSet)
 	}
+	if _, errCAS := runtime.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("value"), 0); errCAS == nil || !strings.Contains(errCAS.Error(), "kv store unavailable") {
+		t.Fatalf("KVCompareAndSwap() error = %v, want kv store unavailable", errCAS)
+	}
 
 	runtime.SetClusterAdapter(&runtimeKVTestAdapter{enabled: false})
 	_, errDel := runtime.KVDel(context.Background(), []string{"key"})
@@ -152,6 +161,9 @@ func TestRuntimeKVDelegatesToAdapter(t *testing.T) {
 	}
 	if written, errSet := runtime.KVSet(ctx, "key", []byte("next"), time.Minute, "nx"); errSet != nil || !written {
 		t.Fatalf("KVSet() = %v, %v, want true, nil", written, errSet)
+	}
+	if swapped, errCAS := runtime.KVCompareAndSwap(ctx, "key", []byte("value"), true, []byte("next"), time.Minute); errCAS != nil || !swapped {
+		t.Fatalf("KVCompareAndSwap() = %v, %v, want true, nil", swapped, errCAS)
 	}
 	if deleted, errDel := runtime.KVDel(ctx, []string{"a", "b"}); errDel != nil || deleted != 2 {
 		t.Fatalf("KVDel() = %d, %v, want 2, nil", deleted, errDel)
@@ -176,7 +188,7 @@ func TestRuntimeKVDelegatesToAdapter(t *testing.T) {
 		t.Fatalf("KVMSet() error = %v", errMSet)
 	}
 
-	for _, prefix := range []string{"KVGet:key", "KVSet:key", "KVDel:a,b", "KVExpire:key", "KVTTL:key", "KVIncrBy:counter", "KVMGet:a,b", "KVMSet"} {
+	for _, prefix := range []string{"KVGet:key", "KVSet:key", "KVCompareAndSwap:key:value:true:next", "KVDel:a,b", "KVExpire:key", "KVTTL:key", "KVIncrBy:counter", "KVMGet:a,b", "KVMSet"} {
 		if !adapter.hasCall(prefix) {
 			t.Fatalf("adapter call %q was not recorded", prefix)
 		}

--- a/internal/home/runtime.go
+++ b/internal/home/runtime.go
@@ -176,6 +176,7 @@ type KVGetResult struct {
 type kvStore interface {
 	KVGet(ctx context.Context, key string) ([]byte, bool, error)
 	KVSet(ctx context.Context, key string, value []byte, ttl time.Duration, mode string) (bool, error)
+	KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error)
 	KVDel(ctx context.Context, keys []string) (int64, error)
 	KVExpire(ctx context.Context, key string, ttl time.Duration) (bool, error)
 	KVTTL(ctx context.Context, key string) (int64, error)
@@ -513,6 +514,16 @@ func (r *Runtime) KVSet(ctx context.Context, key string, value []byte, ttl time.
 		return false, errStore
 	}
 	return store.KVSet(ctx, key, value, ttl, mode)
+}
+
+// KVCompareAndSwap writes a KV value to the cluster store only when the active
+// state matches the expected state.
+func (r *Runtime) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	store, errStore := r.kvStore()
+	if errStore != nil {
+		return false, errStore
+	}
+	return store.KVCompareAndSwap(ctx, key, expected, expectedExists, value, ttl)
 }
 
 // KVDel deletes active KV values from the cluster store.

--- a/internal/respserver/dispatch/registry.go
+++ b/internal/respserver/dispatch/registry.go
@@ -394,7 +394,7 @@ func commandRequiresControlledLifetime(args []string) bool {
 		return false
 	}
 	switch strings.ToUpper(strings.TrimSpace(args[0])) {
-	case "RPOP", "LPUSH", "RPUSH", "SET", "DEL", "MSET", "INCRBY", "EXPIRE":
+	case "RPOP", "LPUSH", "RPUSH", "SET", "CAS", "DEL", "MSET", "INCRBY", "EXPIRE":
 		return true
 	default:
 		return false

--- a/internal/respserver/kv/handlers.go
+++ b/internal/respserver/kv/handlers.go
@@ -57,6 +57,52 @@ func handleSetNX(ctx context.Context, env dispatch.Env, args []string) dispatch.
 	return dispatch.Integer(0)
 }
 
+// handleCAS handles the Home-specific compare-and-swap command:
+//
+//	CAS <key> <expected-exists 0|1> <expected-value> <new-value> [PX <ttl-ms>]
+//
+// When the expected-exists flag is 1 the key must be present with a value equal
+// to expected-value; when it is 0 the key must be absent. The reply is integer 1
+// when the swap happened and integer 0 when the state did not match. Omitting PX
+// stores the new value without a TTL.
+//
+// CPA needs this primitive for its reasoning replay caches. It exists instead of
+// EVAL so Home does not have to expose general-purpose Lua execution.
+func handleCAS(ctx context.Context, env dispatch.Env, args []string) dispatch.Reply {
+	if env.Runtime == nil {
+		return dispatch.Err("runtime not ready")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(args) != 5 && len(args) != 7 {
+		return wrongArgs("cas")
+	}
+	expectedExists, errFlag := parseCASExpectedExists(args[2])
+	if errFlag != nil {
+		return dispatch.Err(errFlag.Error())
+	}
+	var ttl time.Duration
+	if len(args) == 7 {
+		if !strings.EqualFold(strings.TrimSpace(args[5]), "PX") {
+			return dispatch.Err(fmt.Sprintf("unsupported cas option %q", args[5]))
+		}
+		milliseconds, errParse := parsePositiveInt(args[6], "px value")
+		if errParse != nil {
+			return dispatch.Err(errParse.Error())
+		}
+		ttl = time.Duration(milliseconds) * time.Millisecond
+	}
+	swapped, errCAS := env.Runtime.KVCompareAndSwap(ctx, args[1], []byte(args[3]), expectedExists, []byte(args[4]), ttl)
+	if errCAS != nil {
+		return dispatch.Err(errCAS.Error())
+	}
+	if swapped {
+		return dispatch.Integer(1)
+	}
+	return dispatch.Integer(0)
+}
+
 // handleDel handles Redis-compatible DEL.
 func handleDel(ctx context.Context, env dispatch.Env, args []string) dispatch.Reply {
 	if env.Runtime == nil {
@@ -226,6 +272,17 @@ func parseSetOptions(args []string) (time.Duration, string, error) {
 		}
 	}
 	return ttl, mode, nil
+}
+
+func parseCASExpectedExists(value string) (bool, error) {
+	switch strings.TrimSpace(value) {
+	case "0":
+		return false, nil
+	case "1":
+		return true, nil
+	default:
+		return false, fmt.Errorf("cas expected-exists flag must be 0 or 1")
+	}
 }
 
 func parsePositiveInt(value string, label string) (int64, error) {

--- a/internal/respserver/kv/handlers_test.go
+++ b/internal/respserver/kv/handlers_test.go
@@ -136,7 +136,57 @@ func TestKVCommandErrors(t *testing.T) {
 		{"SET", "key", "value", "EX", "bad"},
 		{"MSET", "key", "value", "dangling"},
 		{"INCRBY", "key", "bad"},
+		{"CAS", "key", "0", "", "value", "PX"},
+		{"CAS", "key", "0", ""},
+		{"CAS", "key", "2", "", "value"},
+		{"CAS", "key", "0", "", "value", "EX", "10"},
+		{"CAS", "key", "0", "", "value", "PX", "0"},
+		{"CAS", "key", "0", "", "value", "PX", "bad"},
 	} {
 		requireRedisError(t, executeKVCommand(t, rt, args...))
+	}
+}
+
+func TestKVCompareAndSwapCommand(t *testing.T) {
+	rt := newKVHandlerTestRuntime(t)
+
+	// Reserving an absent key succeeds once, mirroring the CPA replay-cache fence.
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "replay", "0", "", "reservation", "PX", "1500"), 1)
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "replay", "0", "", "other", "PX", "1500"), 0)
+
+	// A matching expected value swaps; a stale one is a no-op.
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "replay", "1", "stale", "chain", "PX", "1500"), 0)
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "replay", "1", "reservation", "chain", "PX", "1500"), 1)
+	value, found, errGet := rt.KVGet(context.Background(), "replay")
+	if errGet != nil || !found || string(value) != "chain" {
+		t.Fatalf("KVGet(replay) = %q, %v, %v, want chain, true, nil", value, found, errGet)
+	}
+	ttlReply := executeKVCommand(t, rt, "TTL", "replay")
+	if ttlReply.Kind != dispatch.ReplyKindInteger || ttlReply.Integer < 0 {
+		t.Fatalf("TTL(replay) = %#v, want non-negative integer", ttlReply)
+	}
+
+	// Omitting PX stores the value without a TTL.
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "replay", "1", "chain", "tombstone"), 1)
+	requireInteger(t, executeKVCommand(t, rt, "TTL", "replay"), -1)
+
+	// Binary values round-trip through the comparison.
+	binary := string([]byte{0x00, 0xff, 0x10})
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "binary", "0", "", binary), 1)
+	requireInteger(t, executeKVCommand(t, rt, "CAS", "binary", "1", binary, "next"), 1)
+}
+
+func TestKVCompareAndSwapRequiresControlledLifetime(t *testing.T) {
+	rt := newKVHandlerTestRuntime(t)
+
+	reg := dispatch.NewRegistry()
+	Register(reg)
+	reply := reg.Execute(context.Background(), dispatch.Env{
+		Runtime:            rt,
+		ConnectionLifetime: cluster.ConnectionLifetime{Controlled: false},
+	}, []string{"CAS", "replay", "0", "", "reservation"})
+	requireRedisError(t, reply)
+	if _, found, errGet := rt.KVGet(context.Background(), "replay"); errGet != nil || found {
+		t.Fatalf("KVGet(replay) = %v, %v, want not found, nil", found, errGet)
 	}
 }

--- a/internal/respserver/kv/register.go
+++ b/internal/respserver/kv/register.go
@@ -9,6 +9,7 @@ func Register(reg *dispatch.Registry) {
 	}
 	_ = reg.SetDirectDefault("SET", handleSet)
 	_ = reg.SetDirectDefault("SETNX", handleSetNX)
+	_ = reg.SetDirectDefault("CAS", handleCAS)
 	_ = reg.SetDirectDefault("DEL", handleDel)
 	_ = reg.SetDirectDefault("EXPIRE", handleExpire)
 	_ = reg.SetDirectDefault("TTL", handleTTL)


### PR DESCRIPTION
Fixes the Home half of #79.

## Problem

CPA implements `Client.KVCompareAndSwap` by sending Redis `EVAL` with a Lua script. Home's RESP subset does not register `EVAL`, so unknown-command fallthrough returns:

```
ERR unknown command 'eval'
```

This breaks the Antigravity and Codex reasoning replay caches in Home mode. On the CPA side the error is recorded into the credential's per-model state (`status: error`, `unavailable: true`), and once every high-priority credential for a model is marked unavailable, alias resolution returns `auth_not_found: no execution models available` / HTTP 503.

## Approach

A dedicated, bounded compare-and-swap command rather than general-purpose Lua execution, as suggested in the issue:

```
CAS <key> <expected-exists 0|1> <expected-value> <new-value> [PX <ttl-ms>]
→ :1 swapped, :0 state did not match
```

Semantics match CPA's existing Lua script argument for argument, so CPA only has to change its transport — `KVCompareAndSwap`'s signature and all its callers stay as they are:

| CPA `EVAL` arg | `CAS` arg | Behavior |
|---|---|---|
| `ARGV[1]` expectedFlag | `expected-exists` | `1` → key must be present and byte-equal; `0` → key must be absent |
| `ARGV[2]` expected | `expected-value` | ignored when the flag is `0` (send empty) |
| `ARGV[3]` value | `new-value` | binary-safe |
| `ARGV[4]` ttl ms | `PX <ttl-ms>` | omit PX when `ttl <= 0`, matching the script's `SET`-without-`PX` branch, which clears the TTL |

Expired rows count as absent on both sides, matching Redis.

## Implementation

`Repository.KVCompareAndSwap` compares and writes inside a single transaction holding `SELECT ... FOR UPDATE` on the row, reusing the existing `KVSet` branch structure and helpers (`kvExpiresAt`, `kvRecordExpired`, `deleteExpiredKVTx`, `cloneKVBytes`). Because it goes through gorm, PostgreSQL and SQLite share one implementation with no dialect-specific SQL.

`CAS` joins `SET` in `commandRequiresControlledLifetime` since it mutates shared state.

## Why not `EVAL`

Beyond the execution surface: Redis gets script atomicity from single-threaded execution, but Home is database-backed. Making an arbitrary script's multiple `redis.call`s atomic would mean wrapping the whole script in a transaction, and you cannot determine which rows to lock without knowing the script. A fixed-semantics command has a determinate lock scope, which is what makes the single-transaction implementation possible.

## Tests

Absent-key reservation succeeds once; matching value replaces; stale value is a no-op; expected-present against an absent or expired key fails; PX applied and omitted-PX clears the TTL; concurrent writers yield exactly one winner; binary values round-trip; malformed arity/flag/option rejected; an uncontrolled connection is rejected and leaves no row.

One caveat worth stating: `OpenSQLite` sets `MaxOpenConns(1)`, so the concurrency test serializes at the pool and does not exercise row locking. The single-winner property rests on `FOR UPDATE` and is only genuinely exercised on PostgreSQL.

`gofmt` clean, build passes, `go vet ./...` clean apart from the pre-existing `refresh.go:113` unreachable-code warning.

## Rollout ordering

**This PR must merge and ship a tag before the CPA-side change goes out.** CPA still sends `EVAL` today, so Home shipping `CAS` alone changes nothing; CPA switching alone would break against every deployed Home. The CPA PR detects `CAS` support by probing and latching on `unknown command`, so a new CPA against an old Home degrades rather than failing hard — but the ordering still matters for the fix to actually take effect.