### PR TITLE
Use CPA membership for topology and database time for health

### DIFF
--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -595,15 +595,15 @@ Example response:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `nodes` | array | Active CPA node list aggregated from connection snapshots written by all live Home nodes into the shared database. |
+| `nodes` | array | Authoritative active CPA list. A snapshot is returned only when it has a config subscription and its certificate fingerprint and complete Home incarnation match an active `cpa_node_membership` owner. Draining and revision-only snapshots are excluded. |
 | `plugin_report_required` | boolean | Whether the current Home config expects CPA plugin reports because at least one enabled plugin has a pinned store manifest. |
 | `plugin_report_statuses` | array | Latest plugin reports stored in the shared database, grouped by reporting node and report metadata. Delete reports for one plugin can coexist with preserved status rows for other plugins. These are retained until the node reports again or is explicitly cleaned up; they do not expire by TTL and are self-reported observations, not authoritative install proof. |
 | `nodes[].node_id` | string | CPA node ID derived from the Home client certificate when available. |
 | `nodes[].ip` | string | Node IP address. |
 | `nodes[].connected_time` | string | First connection time for the active node entry. |
-| `nodes[].last_seen_at` | string | Time when the serving Home node last refreshed this CPA connection snapshot in the shared database. |
+| `nodes[].last_seen_at` | string | Time when the serving Home last refreshed the derived `cpa_node` snapshot. |
 | `nodes[].client_count` | integer | Active RESP subscription connection count from this IP. |
-| `nodes[].healthy` | boolean | Whether the node has an active RESP subscription connection. Plugin reports do not make this field unhealthy. |
+| `nodes[].healthy` | boolean | Whether the CPA membership heartbeat and its exact serving Home incarnation are both healthy. Plugin reports do not affect this field. |
 | `nodes[].home_id` | string | Home node identity serving this CPA node, formatted as `home_ip:home_port`. |
 | `nodes[].home_ip` | string | Home node IP or advertised cluster identity serving this CPA node. |
 | `nodes[].home_port` | integer | Home node RESP/cluster port serving this CPA node. |
@@ -618,7 +618,7 @@ Example response:
 
 ### GET `/topology`
 
-Returns a Home + CPA topology snapshot for the database-backed Home runtime. Unlike `GET /nodes`, this route is cluster-wide and topology-oriented: Home nodes are read from the shared cluster heartbeat table, and CPA nodes are read from the shared CPA snapshot table written by each Home process, including stale snapshots that are classified by the configured heartbeat timeout.
+Returns a Home + CPA topology snapshot for the database-backed Home runtime. Active ownership comes from `cpa_node_membership`; `cpa_node` is a derived diagnostic snapshot. Subscription snapshots that do not match the membership fingerprint and complete `(HomeIP, HomePort, HomeStartedAt)` owner are shown as `draining`, not as active CPAs.
 
 Input: none.
 
@@ -689,8 +689,9 @@ Example response:
       "connected_time": "2026-05-27T10:05:00Z",
       "last_seen_at": "2026-05-27T10:30:02Z",
       "client_count": 1,
-      "healthy": true,
+      "state": "active",
       "health": "healthy",
+      "healthy": true,
       "home_id": "10.0.0.10:8327",
       "home_ip": "10.0.0.10",
       "home_port": 8327,
@@ -707,14 +708,14 @@ Example response:
 | `summary.healthy_home_count` | integer | Home nodes whose `last_seen_at` is within `stale_after_seconds`. |
 | `summary.stale_home_count` | integer | Home nodes known to the database but past the stale cutoff. |
 | `summary.unknown_home_count` | integer | Home nodes whose health cannot be determined because required identity or heartbeat data is missing. |
-| `summary.cpa_count` | integer | Number of CPA node snapshots known to the cluster. |
-| `summary.healthy_cpa_count` | integer | CPA snapshots attached to a healthy Home and seen within the stale cutoff. |
-| `summary.stale_cpa_count` | integer | CPA snapshots whose Home or own heartbeat is stale. |
-| `summary.unknown_cpa_count` | integer | CPA snapshots whose serving Home identity or health cannot be determined. |
+| `summary.cpa_count` | integer | Logical CPA count, deduplicated by certificate fingerprint across active and draining snapshots. |
+| `summary.healthy_cpa_count` | integer | Active CPAs whose membership heartbeat and exact Home incarnation are healthy. |
+| `summary.stale_cpa_count` | integer | Active CPAs whose membership heartbeat or exact Home incarnation is stale. |
+| `summary.unknown_cpa_count` | integer | Active CPAs whose exact serving Home incarnation cannot be determined. |
 | `summary.plugin_attention_count` | integer | CPA nodes with missing, partial, or failed plugin reports when plugin reports are required. |
 | `summary.attention_count` | integer | Combined operational attention count: stale/unknown Home nodes, CPA nodes needing attention counted once each, plus missing master. |
 | `summary.missing_master` | boolean | Whether no healthy Home can currently be selected as master. |
-| `summary.stale_after_seconds` | integer | Heartbeat timeout used for topology health classification. |
+| `summary.stale_after_seconds` | integer | Home heartbeat timeout used to classify Home health and select the current master. CPA health additionally uses each membership's CPA heartbeat timeout. |
 | `summary.retention_after_seconds` | integer | Topology snapshot retention window. Records older than this are omitted from `homes[]` and `cpas[]`. |
 | `management.home_id` | string | Current Management runtime Home identity, formatted as `home_ip:home_port`. |
 | `management.home_ip` | string | Current Management runtime Home IP or advertised cluster identity. |
@@ -732,18 +733,19 @@ Example response:
 | `homes[].client_count` | integer | Total active CPA config subscriptions reported by that Home. |
 | `homes[].started_at` | string | Home process start time. |
 | `homes[].last_seen_at` | string | Last Home heartbeat stored in the shared database. |
-| `homes[].cpa_count` | integer | CPA snapshots currently associated with this Home. |
-| `homes[].healthy_cpa_count` | integer | Healthy CPA snapshots associated with this Home. |
-| `homes[].stale_cpa_count` | integer | Stale CPA snapshots associated with this Home. |
-| `homes[].unknown_cpa_count` | integer | Unknown-health CPA snapshots associated with this Home. |
-| `cpas[]` | array | CPA node snapshots with their serving Home identity. |
+| `homes[].cpa_count` | integer | Active CPA count owned by this exact Home incarnation. |
+| `homes[].healthy_cpa_count` | integer | Healthy active CPAs owned by this Home incarnation. |
+| `homes[].stale_cpa_count` | integer | Stale active CPAs owned by this Home incarnation. |
+| `homes[].unknown_cpa_count` | integer | Unknown-health active CPAs owned by this Home incarnation. |
+| `cpas[]` | array | Active and draining CPA diagnostic snapshots. Revision-only snapshots are omitted. |
 | `cpas[].node_id` | string | CPA node ID derived from the client certificate when available. |
 | `cpas[].ip` | string | CPA node IP address observed by its serving Home. |
 | `cpas[].connected_time` | string | First observed active connection time for this CPA snapshot on its serving Home. |
-| `cpas[].last_seen_at` | string | Last time the serving Home refreshed this CPA snapshot. |
+| `cpas[].last_seen_at` | string | Last time the serving Home refreshed this derived snapshot. |
 | `cpas[].client_count` | integer | Active RESP subscription count represented by this CPA snapshot. |
-| `cpas[].healthy` | boolean | Whether `cpas[].health` is `healthy`. |
+| `cpas[].state` | string | `active` when the subscription and authoritative membership owner match; otherwise `draining`. |
 | `cpas[].health` | string | `healthy`, `stale`, or `unknown`. |
+| `cpas[].healthy` | boolean | Whether `cpas[].health` is `healthy`; retained for backward compatibility. |
 | `cpas[].home_id` | string | Serving Home identity, formatted as `home_ip:home_port`. |
 | `cpas[].home_ip` | string | Serving Home IP or advertised cluster identity. |
 | `cpas[].home_port` | integer | Serving Home cluster/RESP port. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -595,15 +595,15 @@ openai-compatibility
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
-| `nodes` | array | 当前活跃 CPA 节点列表，聚合自所有 live Home 节点写入共享数据库的连接快照。 |
+| `nodes` | array | 权威活动 CPA 列表。只有存在 config subscription，且证书 fingerprint 与完整 Home incarnation 都匹配 active `cpa_node_membership` owner 的快照才会返回；draining 和 revision-only 快照不会进入此列表。 |
 | `plugin_report_required` | boolean | 当前 Home 配置是否期望 CPA 上报插件状态；至少一个已启用插件带有固定的 store manifest 时为 `true`。 |
 | `plugin_report_statuses` | array | 共享数据库中保存的最新插件上报，按上报节点和上报元数据分组；单插件删除上报可以和其他插件保留的状态行同时存在。它们会一直保留到节点再次上报或被显式清理，不按 TTL 自动过期。这是 CPA 自报告的观测信息，不是强可信安装事实。 |
 | `nodes[].node_id` | string | 从 Home 客户端证书得到的 CPA node ID。 |
 | `nodes[].ip` | string | 节点 IP 地址。 |
 | `nodes[].connected_time` | string | 当前活跃节点条目的首次连接时间。 |
-| `nodes[].last_seen_at` | string | 该 CPA 节点连接快照最近一次由对应 Home 节点刷新到共享数据库的时间。 |
+| `nodes[].last_seen_at` | string | 服务 Home 最近一次刷新派生 `cpa_node` 快照的时间。 |
 | `nodes[].client_count` | integer | 当前 IP 下活跃 RESP 订阅连接数。 |
-| `nodes[].healthy` | boolean | 节点是否存在活跃 RESP 配置订阅连接；插件上报不会直接让该字段变为不健康。 |
+| `nodes[].healthy` | boolean | CPA membership heartbeat 与精确服务 Home incarnation 是否都健康；插件上报不影响此字段。 |
 | `nodes[].home_id` | string | 当前服务此 CPA 的 Home 节点身份，格式为 `home_ip:home_port`。 |
 | `nodes[].home_ip` | string | 当前服务此 CPA 的 Home 节点 IP 或集群广播身份。 |
 | `nodes[].home_port` | integer | 当前服务此 CPA 的 Home 节点 RESP/cluster 端口。 |
@@ -618,7 +618,7 @@ openai-compatibility
 
 ### GET `/topology`
 
-返回数据库态 Home runtime 的 Home + CPA 拓扑快照。与 `GET /nodes` 不同，此接口是面向拓扑的集群视角：Home 节点来自共享 cluster heartbeat 表，CPA 节点来自每个 Home 写入共享数据库的 CPA 快照表，包括会按已配置 heartbeat timeout 分类的 stale 快照。
+返回数据库态 Home runtime 的 Home + CPA 拓扑快照。活动 owner 以 `cpa_node_membership` 为准，`cpa_node` 仅是派生诊断快照。subscription 快照若没有同时匹配 membership fingerprint 和完整 `(HomeIP, HomePort, HomeStartedAt)` owner，只会显示为 `draining`，不会计为活动 CPA。
 
 输入：无。
 
@@ -689,8 +689,9 @@ openai-compatibility
       "connected_time": "2026-05-27T10:05:00Z",
       "last_seen_at": "2026-05-27T10:30:02Z",
       "client_count": 1,
-      "healthy": true,
+      "state": "active",
       "health": "healthy",
+      "healthy": true,
       "home_id": "10.0.0.10:8327",
       "home_ip": "10.0.0.10",
       "home_port": 8327,
@@ -707,14 +708,14 @@ openai-compatibility
 | `summary.healthy_home_count` | integer | `last_seen_at` 未超过 `stale_after_seconds` 的 Home 节点数量。 |
 | `summary.stale_home_count` | integer | 数据库已知但已超过 stale cutoff 的 Home 节点数量。 |
 | `summary.unknown_home_count` | integer | 因身份或 heartbeat 数据缺失而无法判断健康状态的 Home 节点数量。 |
-| `summary.cpa_count` | integer | 集群已知的 CPA 节点快照数量。 |
-| `summary.healthy_cpa_count` | integer | 连接到健康 Home 且自身未超过 stale cutoff 的 CPA 快照数量。 |
-| `summary.stale_cpa_count` | integer | Home 或自身心跳已过期的 CPA 快照数量。 |
-| `summary.unknown_cpa_count` | integer | 无法判断服务 Home 身份或健康状态的 CPA 快照数量。 |
+| `summary.cpa_count` | integer | 按证书 fingerprint 对 active 和 draining 快照去重后的逻辑 CPA 数。 |
+| `summary.healthy_cpa_count` | integer | membership heartbeat 与精确 Home incarnation 都健康的活动 CPA 数。 |
+| `summary.stale_cpa_count` | integer | membership heartbeat 或精确 Home incarnation 已 stale 的活动 CPA 数。 |
+| `summary.unknown_cpa_count` | integer | 无法确认精确服务 Home incarnation 的活动 CPA 数。 |
 | `summary.plugin_attention_count` | integer | 插件上报为必需时，插件状态缺失、部分上报或失败的 CPA 节点数量。 |
 | `summary.attention_count` | integer | 合计关注数量：stale/unknown Home 节点、需要关注的 CPA 节点各计一次，再加缺失 master。 |
 | `summary.missing_master` | boolean | 当前是否无法选出健康 Home master。 |
-| `summary.stale_after_seconds` | integer | 拓扑健康判断使用的 heartbeat timeout。 |
+| `summary.stale_after_seconds` | integer | 用于判断 Home 节点健康状态及选择当前 master 的 heartbeat timeout；CPA 健康状态还会使用各 membership 自身的 CPA heartbeat timeout。 |
 | `summary.retention_after_seconds` | integer | 拓扑快照保留窗口；早于该窗口的记录不会出现在 `homes[]` 和 `cpas[]` 中。 |
 | `management.home_id` | string | 当前 Management runtime 的 Home 身份，格式为 `home_ip:home_port`。 |
 | `management.home_ip` | string | 当前 Management runtime 的 Home IP 或集群广播身份。 |
@@ -732,18 +733,19 @@ openai-compatibility
 | `homes[].client_count` | integer | 此 Home 上报的活跃 CPA config subscription 总数。 |
 | `homes[].started_at` | string | Home 进程启动时间。 |
 | `homes[].last_seen_at` | string | 共享数据库中保存的最后一次 Home heartbeat 时间。 |
-| `homes[].cpa_count` | integer | 当前关联到此 Home 的 CPA 快照数量。 |
-| `homes[].healthy_cpa_count` | integer | 当前关联到此 Home 的健康 CPA 快照数量。 |
-| `homes[].stale_cpa_count` | integer | 当前关联到此 Home 的 stale CPA 快照数量。 |
-| `homes[].unknown_cpa_count` | integer | 当前关联到此 Home 的未知健康状态 CPA 快照数量。 |
-| `cpas[]` | array | CPA 节点快照，并包含服务它的 Home 身份。 |
+| `homes[].cpa_count` | integer | 此精确 Home incarnation 当前拥有的活动 CPA 数。 |
+| `homes[].healthy_cpa_count` | integer | 此 Home incarnation 拥有的健康活动 CPA 数。 |
+| `homes[].stale_cpa_count` | integer | 此 Home incarnation 拥有的 stale 活动 CPA 数。 |
+| `homes[].unknown_cpa_count` | integer | 此 Home incarnation 拥有的未知健康活动 CPA 数。 |
+| `cpas[]` | array | active 与 draining CPA 诊断快照；revision-only 快照不会返回。 |
 | `cpas[].node_id` | string | 从客户端证书得到的 CPA node ID。 |
 | `cpas[].ip` | string | 服务它的 Home 观测到的 CPA 节点 IP。 |
 | `cpas[].connected_time` | string | 此 CPA 快照在服务它的 Home 上首次观测到活跃连接的时间。 |
-| `cpas[].last_seen_at` | string | 服务它的 Home 最近一次刷新此 CPA 快照的时间。 |
+| `cpas[].last_seen_at` | string | 服务 Home 最近一次刷新此派生快照的时间。 |
 | `cpas[].client_count` | integer | 此 CPA 快照代表的活跃 RESP 订阅数。 |
-| `cpas[].healthy` | boolean | `cpas[].health` 是否为 `healthy`。 |
+| `cpas[].state` | string | subscription 与权威 membership owner 匹配时为 `active`，否则为 `draining`。 |
 | `cpas[].health` | string | `healthy`、`stale` 或 `unknown`。 |
+| `cpas[].healthy` | boolean | `cpas[].health` 是否为 `healthy`；为保持向后兼容而保留。 |
 | `cpas[].home_id` | string | 服务此 CPA 的 Home 身份，格式为 `home_ip:home_port`。 |
 | `cpas[].home_ip` | string | 服务此 CPA 的 Home IP 或集群广播身份。 |
 | `cpas[].home_port` | integer | 服务此 CPA 的 Home cluster/RESP 端口。 |

--- a/internal/cluster/coordinator.go
+++ b/internal/cluster/coordinator.go
@@ -150,7 +150,10 @@ func (c *Coordinator) runLifecycleCleanup(ctx context.Context) error {
 	if !initialized {
 		return fmt.Errorf("cluster coordinator is not initialized")
 	}
-	return c.runStartupRecovery(ctx, home)
+	if errRecovery := c.runStartupRecovery(ctx, home); errRecovery != nil {
+		return errRecovery
+	}
+	return c.repo.DeleteExpiredCPANodeSnapshots(ctx, cpaNodeSnapshotRetention(c.heartbeatTimeout))
 }
 
 func (c *Coordinator) retireFailedInitialization(ctx context.Context, incarnation HomeIncarnationID, initializationErr error) error {
@@ -470,6 +473,13 @@ func (c *Coordinator) syncCPANodeSnapshot(ctx context.Context, seenAt time.Time)
 		return fmt.Errorf("cluster coordinator is not initialized")
 	}
 	return c.repo.ReplaceCPANodeSnapshotForIncarnation(ctx, home, node.GlobalRegistry().List(), seenAt)
+}
+
+func cpaNodeSnapshotRetention(heartbeatTimeout time.Duration) time.Duration {
+	if heartbeatTimeout <= 0 {
+		heartbeatTimeout = defaultHeartbeatTimeout
+	}
+	return heartbeatTimeout * 6
 }
 
 // setMaster sets a master.

--- a/internal/cluster/database_time.go
+++ b/internal/cluster/database_time.go
@@ -26,6 +26,15 @@ func DatabaseNow(ctx context.Context, tx *gorm.DB) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("parse database timestamp %q", value)
 }
 
+// CurrentDatabaseTime returns the current UTC timestamp reported by the repository database.
+func (r *Repository) CurrentDatabaseTime(ctx context.Context) (time.Time, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return time.Time{}, errDB
+	}
+	return DatabaseNow(ctx, db)
+}
+
 func databaseNowQuery(tx *gorm.DB) string {
 	if tx != nil && tx.Dialector != nil && tx.Dialector.Name() == "postgres" {
 		return "SELECT clock_timestamp()"

--- a/internal/cluster/database_time_test.go
+++ b/internal/cluster/database_time_test.go
@@ -26,6 +26,26 @@ func TestDatabaseNowQueryKeepsCurrentTimestampForSQLite(t *testing.T) {
 	}
 }
 
+func TestRepositoryCurrentDatabaseTime(t *testing.T) {
+	repo := newCredentialFoundationTestRepository(t)
+
+	before, errBefore := DatabaseNow(context.Background(), repo.db)
+	if errBefore != nil {
+		t.Fatal(errBefore)
+	}
+	got, errNow := repo.CurrentDatabaseTime(context.Background())
+	if errNow != nil {
+		t.Fatal(errNow)
+	}
+	after, errAfter := DatabaseNow(context.Background(), repo.db)
+	if errAfter != nil {
+		t.Fatal(errAfter)
+	}
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("CurrentDatabaseTime() = %s, want between %s and %s", got, before, after)
+	}
+}
+
 func TestDatabaseNowAdvancesWithinPostgresTransaction(t *testing.T) {
 	dsn := strings.TrimSpace(os.Getenv("CLIPROXY_HOME_TEST_POSTGRES_DSN"))
 	if dsn == "" {

--- a/internal/cluster/lifecycle_cleanup_test.go
+++ b/internal/cluster/lifecycle_cleanup_test.go
@@ -72,6 +72,59 @@ func TestCoordinatorRunsLifecycleCleanupContinuously(t *testing.T) {
 	}
 }
 
+func TestCoordinatorLifecycleCleanupOwnsCPANodeSnapshotRetention(t *testing.T) {
+	ctx := context.Background()
+	repo := newCredentialFoundationTestRepository(t)
+	coordinator := NewCoordinator(repo, NodeIdentity{IP: "10.0.0.1", Port: 8317}, CoordinatorOptions{
+		HeartbeatTimeout: 20 * time.Second,
+	})
+	if errInitialize := coordinator.Initialize(ctx); errInitialize != nil {
+		t.Fatal(errInitialize)
+	}
+	defer coordinator.setMaster(false)
+
+	databaseNow, errNow := DatabaseNow(ctx, repo.db)
+	if errNow != nil {
+		t.Fatal(errNow)
+	}
+	expired := CPANodeRecord{
+		HomeIP:                 "10.0.0.2",
+		HomePort:               8317,
+		HomeStartedAt:          databaseNow.Add(-time.Hour),
+		NodeKey:                "fingerprint:expired",
+		NodeID:                 "cpa-expired",
+		CertificateFingerprint: "expired",
+		ClientCount:            1,
+		ConnectedAt:            databaseNow.Add(-time.Hour),
+		LastSeenAt:             databaseNow.Add(-cpaNodeSnapshotRetention(coordinator.heartbeatTimeout) - time.Second),
+	}
+	if errCreate := repo.db.Create(&expired).Error; errCreate != nil {
+		t.Fatal(errCreate)
+	}
+
+	if errUpdate := coordinator.UpdateClientCount(ctx, 0); errUpdate != nil {
+		t.Fatal(errUpdate)
+	}
+	var countAfterUpdate int64
+	if errCount := repo.db.Model(&CPANodeRecord{}).Where("node_key = ?", expired.NodeKey).Count(&countAfterUpdate).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if countAfterUpdate != 1 {
+		t.Fatalf("snapshot count after UpdateClientCount() = %d, want 1", countAfterUpdate)
+	}
+
+	if errCleanup := coordinator.runLifecycleCleanup(ctx); errCleanup != nil {
+		t.Fatal(errCleanup)
+	}
+	var countAfterCleanup int64
+	if errCount := repo.db.Model(&CPANodeRecord{}).Where("node_key = ?", expired.NodeKey).Count(&countAfterCleanup).Error; errCount != nil {
+		t.Fatal(errCount)
+	}
+	if countAfterCleanup != 0 {
+		t.Fatalf("snapshot count after runLifecycleCleanup() = %d, want 0", countAfterCleanup)
+	}
+}
+
 func TestCoordinatorReloadsLifecycleCleanupInterval(t *testing.T) {
 	ctx := context.Background()
 	repo := newCredentialFoundationTestRepository(t)

--- a/internal/cluster/management/nodes.go
+++ b/internal/cluster/management/nodes.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
 )
 
@@ -28,6 +28,7 @@ type activeCPANode struct {
 	HomeIP      string
 	HomePort    int
 	LastSeenAt  time.Time
+	Health      string
 }
 
 // ListNodes returns a nodes.
@@ -63,7 +64,7 @@ func (h *Handler) ListNodes(c *gin.Context) {
 			"connected_time":         activeNode.Connected,
 			"last_seen_at":           activeNode.LastSeenAt,
 			"client_count":           activeNode.ClientCount,
-			"healthy":                activeNode.ClientCount > 0,
+			"healthy":                activeNode.Health == topologyHealthHealthy,
 			"home_id":                homeID,
 			"home_ip":                activeNode.HomeIP,
 			"home_port":              activeNode.HomePort,
@@ -81,16 +82,41 @@ func (h *Handler) ListNodes(c *gin.Context) {
 func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
 	nodesByKey := make(map[string]activeCPANode)
 	if h != nil && h.repo != nil {
+		now := time.Now().UTC()
 		cutoff := time.Time{}
 		if h.heartbeatTimeout > 0 {
-			cutoff = time.Now().UTC().Add(-h.heartbeatTimeout)
+			cutoff = now.Add(-topologySnapshotRetention(h.heartbeatTimeout))
 		}
-		records, errRecords := h.repo.ListLiveCPANodes(ctx, cutoff)
+		records, errRecords := h.repo.ListCPANodeSnapshots(ctx, cutoff)
 		if errRecords != nil {
 			return nil, errRecords
 		}
+		memberships, errMemberships := h.repo.ListActiveCPAMemberships(ctx)
+		if errMemberships != nil {
+			return nil, errMemberships
+		}
+		membershipsByFingerprint := make(map[string]cluster.CPANodeMembershipRecord, len(memberships))
+		for _, membership := range memberships {
+			membershipsByFingerprint[strings.TrimSpace(membership.CertificateFingerprint)] = membership
+		}
+		homeRecords, errHomes := h.repo.ListClusterNodes(ctx, cutoff)
+		if errHomes != nil {
+			return nil, errHomes
+		}
+		healthCutoff := now.Add(-h.heartbeatTimeout)
+		homeHealth := make(map[string]string, len(homeRecords))
+		for _, homeRecord := range homeRecords {
+			homeKey := topologyHomeIncarnationKey(homeRecord.IP, homeRecord.Port, homeRecord.StartedAt)
+			homeHealth[homeKey] = topologyHealth(homeRecord.LastSeenAt, healthCutoff)
+		}
 		for _, record := range records {
-			key := activeCPANodeKey(record.HomeIP, record.HomePort, record.NodeID, record.ClientIP)
+			fingerprint := strings.TrimSpace(record.CertificateFingerprint)
+			membership, hasMembership := membershipsByFingerprint[fingerprint]
+			if topologyCPASnapshotState(record, membership, hasMembership) != topologyCPAActive {
+				continue
+			}
+			homeKey := topologyHomeIncarnationKey(record.HomeIP, record.HomePort, record.HomeStartedAt)
+			key := fingerprint
 			if key == "" {
 				continue
 			}
@@ -102,29 +128,8 @@ func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
 				HomeIP:      strings.TrimSpace(record.HomeIP),
 				HomePort:    record.HomePort,
 				LastSeenAt:  record.LastSeenAt,
+				Health:      topologyCPASnapshotHealth(topologyCPAActive, membership, homeHealth[homeKey], healthCutoff),
 			}
-		}
-	}
-
-	localHomeIP := ""
-	localHomePort := 0
-	if h != nil {
-		localHomeIP = strings.TrimSpace(h.nodeIP)
-		localHomePort = h.nodePort
-	}
-	for _, localNode := range node.GlobalRegistry().List() {
-		key := activeCPANodeKey(localHomeIP, localHomePort, localNode.NodeID, localNode.IP)
-		if key == "" {
-			continue
-		}
-		nodesByKey[key] = activeCPANode{
-			NodeID:      strings.TrimSpace(localNode.NodeID),
-			IP:          strings.TrimSpace(localNode.IP),
-			Connected:   localNode.Connected,
-			ClientCount: localNode.ClientCount,
-			HomeIP:      localHomeIP,
-			HomePort:    localHomePort,
-			LastSeenAt:  time.Now().UTC(),
 		}
 	}
 
@@ -148,22 +153,6 @@ func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
 		return nodes[i].Connected.Before(nodes[j].Connected)
 	})
 	return nodes, nil
-}
-
-func activeCPANodeKey(homeIP string, homePort int, nodeID string, clientIP string) string {
-	homeIP = strings.TrimSpace(homeIP)
-	nodeID = strings.TrimSpace(nodeID)
-	clientIP = strings.TrimSpace(clientIP)
-	nodeKey := ""
-	if nodeID != "" {
-		nodeKey = "node:" + nodeID
-	} else if clientIP != "" {
-		nodeKey = "ip:" + clientIP
-	}
-	if nodeKey == "" {
-		return ""
-	}
-	return homeIP + ":" + strconv.Itoa(homePort) + "/" + nodeKey
 }
 
 func (h *Handler) pluginTaskStatuses(ctx context.Context) ([]node.PluginTaskStatus, error) {

--- a/internal/cluster/management/nodes.go
+++ b/internal/cluster/management/nodes.go
@@ -82,7 +82,10 @@ func (h *Handler) ListNodes(c *gin.Context) {
 func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
 	nodesByKey := make(map[string]activeCPANode)
 	if h != nil && h.repo != nil {
-		now := time.Now().UTC()
+		now, errNow := h.repo.CurrentDatabaseTime(ctx)
+		if errNow != nil {
+			return nil, errNow
+		}
 		cutoff := time.Time{}
 		if h.heartbeatTimeout > 0 {
 			cutoff = now.Add(-topologySnapshotRetention(h.heartbeatTimeout))
@@ -128,7 +131,7 @@ func (h *Handler) activeCPANodes(ctx context.Context) ([]activeCPANode, error) {
 				HomeIP:      strings.TrimSpace(record.HomeIP),
 				HomePort:    record.HomePort,
 				LastSeenAt:  record.LastSeenAt,
-				Health:      topologyCPASnapshotHealth(topologyCPAActive, membership, homeHealth[homeKey], healthCutoff),
+				Health:      topologyCPASnapshotHealth(topologyCPAActive, membership, homeHealth[homeKey], now),
 			}
 		}
 	}

--- a/internal/cluster/management/nodes_test.go
+++ b/internal/cluster/management/nodes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
+	"gorm.io/gorm"
 )
 
 func TestListNodesIncludesCPASnapshotsFromAllHomeNodes(t *testing.T) {
@@ -19,18 +20,15 @@ func TestListNodesIncludesCPASnapshotsFromAllHomeNodes(t *testing.T) {
 
 	repo := cluster.NewRepository(db)
 	now := time.Now().UTC()
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-a", 8327, []node.Node{
-		{NodeID: "cpa-a-1", IP: "10.0.1.1", Connected: now.Add(-4 * time.Minute), ClientCount: 1},
-		{NodeID: "cpa-a-2", IP: "10.0.1.2", Connected: now.Add(-3 * time.Minute), ClientCount: 1},
-	}, now); errSnapshot != nil {
-		t.Fatalf("ReplaceCPANodeSnapshot(home-a) error = %v", errSnapshot)
+	homeA := cluster.ClusterNodeRecord{IP: "home-a", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	homeB := cluster.ClusterNodeRecord{IP: "home-b", Port: 8328, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&[]cluster.ClusterNodeRecord{homeA, homeB}).Error; errCreate != nil {
+		t.Fatalf("create Home records: %v", errCreate)
 	}
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-b", 8328, []node.Node{
-		{NodeID: "cpa-b-1", IP: "10.0.2.1", Connected: now.Add(-2 * time.Minute), ClientCount: 1},
-		{NodeID: "cpa-b-2", IP: "10.0.2.2", Connected: now.Add(-1 * time.Minute), ClientCount: 1},
-	}, now); errSnapshot != nil {
-		t.Fatalf("ReplaceCPANodeSnapshot(home-b) error = %v", errSnapshot)
-	}
+	seedActiveManagementCPA(t, db, homeA, "fp-a-1", "cpa-a-1", "10.0.1.1", now.Add(-4*time.Minute), now)
+	seedActiveManagementCPA(t, db, homeA, "fp-a-2", "cpa-a-2", "10.0.1.2", now.Add(-3*time.Minute), now)
+	seedActiveManagementCPA(t, db, homeB, "fp-b-1", "cpa-b-1", "10.0.2.1", now.Add(-2*time.Minute), now)
+	seedActiveManagementCPA(t, db, homeB, "fp-b-2", "cpa-b-2", "10.0.2.2", now.Add(-time.Minute), now)
 
 	handler := NewHandler(repo, nil, "home-a", 8327)
 	engine := gin.New()
@@ -54,6 +52,24 @@ func TestListNodesIncludesCPASnapshotsFromAllHomeNodes(t *testing.T) {
 	}
 	if errDecode := json.Unmarshal(resp.Body.Bytes(), &body); errDecode != nil {
 		t.Fatalf("decode response: %v", errDecode)
+	}
+	var contract struct {
+		Nodes []map[string]json.RawMessage `json:"nodes"`
+	}
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &contract); errDecode != nil {
+		t.Fatalf("decode response contract: %v", errDecode)
+	}
+	for _, item := range contract.Nodes {
+		for _, field := range []string{"last_seen_at", "healthy"} {
+			if _, ok := item[field]; !ok {
+				t.Fatalf("node field %q is missing: %s", field, resp.Body.String())
+			}
+		}
+		for _, field := range []string{"state", "active", "health", "home_started_at", "snapshot_at", "cpa_last_seen_at"} {
+			if _, ok := item[field]; ok {
+				t.Fatalf("node field %q must be omitted: %s", field, resp.Body.String())
+			}
+		}
 	}
 	if len(body.Nodes) != 4 {
 		t.Fatalf("nodes len = %d, want 4: %+v", len(body.Nodes), body.Nodes)
@@ -94,11 +110,11 @@ func TestListNodesUsesConfiguredHeartbeatTimeout(t *testing.T) {
 	repo := cluster.NewRepository(db)
 	now := time.Now().UTC()
 	lastSeenAt := now.Add(-30 * time.Second)
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-timeout", 8327, []node.Node{
-		{NodeID: "cpa-timeout", IP: "10.0.3.1", Connected: now.Add(-2 * time.Minute), ClientCount: 1},
-	}, lastSeenAt); errSnapshot != nil {
-		t.Fatalf("ReplaceCPANodeSnapshot() error = %v", errSnapshot)
+	home := cluster.ClusterNodeRecord{IP: "home-timeout", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&home).Error; errCreate != nil {
+		t.Fatalf("create Home record: %v", errCreate)
 	}
+	seedActiveManagementCPA(t, db, home, "fp-timeout", "cpa-timeout", "10.0.3.1", now.Add(-2*time.Minute), lastSeenAt)
 
 	handler := NewHandler(repo, nil, "home-timeout", 8327)
 	handler.SetHeartbeatTimeout(time.Minute)
@@ -140,7 +156,48 @@ type topologyTestCPAItem struct {
 	HomeIP   string `json:"home_ip"`
 	HomePort int    `json:"home_port"`
 	Health   string `json:"health"`
-	Healthy  bool   `json:"healthy"`
+	State    string `json:"state"`
+}
+
+func seedActiveManagementCPA(t *testing.T, db *gorm.DB, home cluster.ClusterNodeRecord, fingerprint string, nodeID string, clientIP string, connectedAt time.Time, lastSeenAt time.Time) {
+	t.Helper()
+	membership := cluster.CPANodeMembershipRecord{
+		CertificateFingerprint: fingerprint,
+		NodeID:                 nodeID,
+		HomeIP:                 home.IP,
+		HomePort:               home.Port,
+		HomeStartedAt:          home.StartedAt,
+		ProtocolVersion:        1,
+		State:                  cluster.MembershipStateActive,
+		ConnectedAt:            connectedAt,
+		LastSeenAt:             lastSeenAt,
+		UpdatedAt:              lastSeenAt,
+	}
+	if errCreate := db.Create(&membership).Error; errCreate != nil {
+		t.Fatalf("create membership %s: %v", fingerprint, errCreate)
+	}
+	seedManagementCPASnapshot(t, db, home, fingerprint, nodeID, clientIP, 1, 0, 0, connectedAt, lastSeenAt)
+}
+
+func seedManagementCPASnapshot(t *testing.T, db *gorm.DB, home cluster.ClusterNodeRecord, fingerprint string, nodeID string, clientIP string, clientCount int, openConnections int, activeHandlers int, connectedAt time.Time, snapshotAt time.Time) {
+	t.Helper()
+	record := cluster.CPANodeRecord{
+		HomeIP:                 home.IP,
+		HomePort:               home.Port,
+		HomeStartedAt:          home.StartedAt,
+		NodeKey:                "fingerprint:" + fingerprint,
+		NodeID:                 nodeID,
+		ClientIP:               clientIP,
+		ClientCount:            clientCount,
+		CertificateFingerprint: fingerprint,
+		OpenConnections:        openConnections,
+		ActiveHandlers:         activeHandlers,
+		ConnectedAt:            connectedAt,
+		LastSeenAt:             snapshotAt,
+	}
+	if errCreate := db.Create(&record).Error; errCreate != nil {
+		t.Fatalf("create CPA snapshot %s: %v", fingerprint, errCreate)
+	}
 }
 
 func TestListNodesIncludesPluginTaskHealth(t *testing.T) {
@@ -190,8 +247,12 @@ func TestListNodesIncludesPluginTaskHealth(t *testing.T) {
 		t.Fatalf("ReplacePluginStatus() error = %v", errStore)
 	}
 
-	node.GlobalRegistry().AddWithNodeID("10.0.0.5", "node-1", time.Now().UTC())
-	defer node.GlobalRegistry().RemoveWithNodeID("10.0.0.5", "node-1")
+	now := time.Now().UTC()
+	homeRecord := cluster.ClusterNodeRecord{IP: "127.0.0.1", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&homeRecord).Error; errCreate != nil {
+		t.Fatalf("create Home record: %v", errCreate)
+	}
+	seedActiveManagementCPA(t, db, homeRecord, "fp-node-1", "node-1", "10.0.0.5", now.Add(-time.Minute), now)
 
 	handler := NewHandler(repo, nil, "127.0.0.1", 8327)
 	engine := gin.New()
@@ -263,16 +324,8 @@ func TestGetTopologyReturnsHomeAndCPANodes(t *testing.T) {
 		t.Fatalf("create home records: %v", errCreate)
 	}
 
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-a", 8327, []node.Node{
-		{NodeID: "cpa-a", IP: "10.0.0.5", ClientCount: 1, Connected: now.Add(-30 * time.Second)},
-	}, now); errSnapshot != nil {
-		t.Fatalf("replace cpa-a snapshot: %v", errSnapshot)
-	}
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-b", 8327, []node.Node{
-		{NodeID: "cpa-b", IP: "10.0.0.6", ClientCount: 1, Connected: now.Add(-20 * time.Second)},
-	}, now); errSnapshot != nil {
-		t.Fatalf("replace cpa-b snapshot: %v", errSnapshot)
-	}
+	seedActiveManagementCPA(t, db, homeRecords[0], "fp-a", "cpa-a", "10.0.0.5", now.Add(-30*time.Second), now)
+	seedActiveManagementCPA(t, db, homeRecords[1], "fp-b", "cpa-b", "10.0.0.6", now.Add(-20*time.Second), now)
 
 	handler := NewHandler(repo, nil, "home-a", 8327)
 	engine := gin.New()
@@ -305,6 +358,52 @@ func TestGetTopologyReturnsHomeAndCPANodes(t *testing.T) {
 	if errDecode := json.Unmarshal(resp.Body.Bytes(), &body); errDecode != nil {
 		t.Fatalf("decode topology: %v; body=%s", errDecode, resp.Body.String())
 	}
+	var contract struct {
+		Summary map[string]json.RawMessage   `json:"summary"`
+		Homes   []map[string]json.RawMessage `json:"homes"`
+		CPAs    []map[string]json.RawMessage `json:"cpas"`
+	}
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &contract); errDecode != nil {
+		t.Fatalf("decode topology contract: %v", errDecode)
+	}
+	for _, item := range contract.CPAs {
+		for _, field := range []string{"state", "health", "healthy", "last_seen_at"} {
+			if _, ok := item[field]; !ok {
+				t.Fatalf("topology CPA field %q is missing: %s", field, resp.Body.String())
+			}
+		}
+		for _, field := range []string{"active", "draining", "open_connections", "active_handlers", "home_started_at", "home_incarnation_matches", "snapshot_at", "cpa_last_seen_at"} {
+			if _, ok := item[field]; ok {
+				t.Fatalf("topology CPA field %q must be omitted: %s", field, resp.Body.String())
+			}
+		}
+	}
+	if _, ok := contract.Summary["active_cpa_count"]; ok {
+		t.Fatalf("topology summary field %q must be omitted: %s", "active_cpa_count", resp.Body.String())
+	}
+	if _, ok := contract.Summary["draining_cpa_snapshot_count"]; ok {
+		t.Fatalf("topology summary field %q must be omitted: %s", "draining_cpa_snapshot_count", resp.Body.String())
+	}
+	if _, ok := contract.Summary["draining_snapshot_count"]; ok {
+		t.Fatalf("topology summary field %q must be omitted: %s", "draining_snapshot_count", resp.Body.String())
+	}
+	if _, ok := contract.Summary["draining_cpa_count"]; ok {
+		t.Fatalf("topology summary field %q must be omitted: %s", "draining_cpa_count", resp.Body.String())
+	}
+	for _, item := range contract.Homes {
+		if _, ok := item["active_cpa_count"]; ok {
+			t.Fatalf("topology Home field %q must be omitted: %s", "active_cpa_count", resp.Body.String())
+		}
+		if _, ok := item["draining_cpa_snapshot_count"]; ok {
+			t.Fatalf("topology Home field %q must be omitted: %s", "draining_cpa_snapshot_count", resp.Body.String())
+		}
+		if _, ok := item["draining_snapshot_count"]; ok {
+			t.Fatalf("topology Home field %q must be omitted: %s", "draining_snapshot_count", resp.Body.String())
+		}
+		if _, ok := item["draining_cpa_count"]; ok {
+			t.Fatalf("topology Home field %q must be omitted: %s", "draining_cpa_count", resp.Body.String())
+		}
+	}
 	if body.Summary.HomeCount != 2 || body.Summary.HealthyHomeCount != 2 || body.Summary.CPACount != 2 || body.Summary.HealthyCPACount != 2 || body.Summary.MissingMaster {
 		t.Fatalf("summary = %+v, want two healthy homes and cpas with master", body.Summary)
 	}
@@ -318,11 +417,11 @@ func TestGetTopologyReturnsHomeAndCPANodes(t *testing.T) {
 		t.Fatalf("homes = %+v, want one CPA under each Home", body.Homes)
 	}
 	cpaA := topologyTestCPA(body.CPAs, "cpa-a")
-	if cpaA.HomeID != "home-a:8327" || cpaA.HomeIP != "home-a" || cpaA.HomePort != 8327 || cpaA.Health != "healthy" || !cpaA.Healthy {
+	if cpaA.HomeID != "home-a:8327" || cpaA.HomeIP != "home-a" || cpaA.HomePort != 8327 || cpaA.Health != "healthy" {
 		t.Fatalf("cpa-a = %+v, want connected to home-a and healthy", cpaA)
 	}
 	cpaB := topologyTestCPA(body.CPAs, "cpa-b")
-	if cpaB.HomeID != "home-b:8327" || cpaB.HomeIP != "home-b" || cpaB.HomePort != 8327 || cpaB.Health != "healthy" || !cpaB.Healthy {
+	if cpaB.HomeID != "home-b:8327" || cpaB.HomeIP != "home-b" || cpaB.HomePort != 8327 || cpaB.Health != "healthy" {
 		t.Fatalf("cpa-b = %+v, want connected to home-b and healthy", cpaB)
 	}
 }
@@ -369,11 +468,8 @@ func TestGetTopologyMarksCPAUnknownWhenServingHomeIsMissing(t *testing.T) {
 
 	repo := cluster.NewRepository(db)
 	now := time.Now().UTC()
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-missing", 8327, []node.Node{
-		{NodeID: "cpa-orphan", IP: "10.0.0.10", ClientCount: 1, Connected: now.Add(-time.Minute)},
-	}, now); errSnapshot != nil {
-		t.Fatalf("replace orphan cpa snapshot: %v", errSnapshot)
-	}
+	missingHome := cluster.ClusterNodeRecord{IP: "home-missing", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	seedActiveManagementCPA(t, db, missingHome, "fp-orphan", "cpa-orphan", "10.0.0.10", now.Add(-time.Minute), now)
 
 	handler := NewHandler(repo, nil, "home-a", 8327)
 	engine := gin.New()
@@ -403,7 +499,7 @@ func TestGetTopologyMarksCPAUnknownWhenServingHomeIsMissing(t *testing.T) {
 		t.Fatalf("summary = %+v, want orphan cpa counted unknown plus missing master", body.Summary)
 	}
 	cpa := topologyTestCPA(body.CPAs, "cpa-orphan")
-	if cpa.HomeID != "home-missing:8327" || cpa.Health != "unknown" || cpa.Healthy {
+	if cpa.HomeID != "home-missing:8327" || cpa.Health != "unknown" {
 		t.Fatalf("cpa-orphan = %+v, want unknown cpa under missing home", cpa)
 	}
 }
@@ -426,16 +522,18 @@ func TestGetTopologyIncludesStaleCPASnapshots(t *testing.T) {
 	if errCreate := db.Create(&homeRecord).Error; errCreate != nil {
 		t.Fatalf("create stale home record: %v", errCreate)
 	}
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-stale", 8327, []node.Node{
-		{NodeID: "cpa-stale", IP: "10.0.0.7", ClientCount: 1, Connected: staleSeenAt.Add(-time.Minute)},
-	}, staleSeenAt); errSnapshot != nil {
-		t.Fatalf("replace stale cpa snapshot: %v", errSnapshot)
+	seedActiveManagementCPA(t, db, homeRecord, "fp-stale", "cpa-stale", "10.0.0.7", staleSeenAt.Add(-time.Minute), staleSeenAt)
+	if errHeartbeat := db.Model(&cluster.CPANodeMembershipRecord{}).
+		Where("certificate_fingerprint = ?", "fp-stale").
+		Update("last_seen_at", now).Error; errHeartbeat != nil {
+		t.Fatalf("refresh CPA membership heartbeat: %v", errHeartbeat)
 	}
 
 	handler := NewHandler(repo, nil, "home-stale", 8327)
 	handler.SetHeartbeatTimeout(30 * time.Second)
 	engine := gin.New()
 	engine.GET("/topology", handler.GetTopology)
+	engine.GET("/nodes", handler.ListNodes)
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/topology", nil)
@@ -477,8 +575,27 @@ func TestGetTopologyIncludesStaleCPASnapshots(t *testing.T) {
 		t.Fatalf("home-stale = %+v, want stale reported master without current master role", home)
 	}
 	cpa := topologyTestCPA(body.CPAs, "cpa-stale")
-	if cpa.HomeID != "home-stale:8327" || cpa.Health != "stale" || cpa.Healthy {
+	if cpa.HomeID != "home-stale:8327" || cpa.Health != "stale" {
 		t.Fatalf("cpa-stale = %+v, want stale cpa under stale home", cpa)
+	}
+
+	nodesResponse := httptest.NewRecorder()
+	engine.ServeHTTP(nodesResponse, httptest.NewRequest(http.MethodGet, "/nodes", nil))
+	if nodesResponse.Code != http.StatusOK {
+		t.Fatalf("nodes status = %d, body = %s", nodesResponse.Code, nodesResponse.Body.String())
+	}
+	var nodesBody struct {
+		Nodes []struct {
+			NodeID     string    `json:"node_id"`
+			Healthy    bool      `json:"healthy"`
+			LastSeenAt time.Time `json:"last_seen_at"`
+		} `json:"nodes"`
+	}
+	if errDecode := json.Unmarshal(nodesResponse.Body.Bytes(), &nodesBody); errDecode != nil {
+		t.Fatalf("decode nodes: %v", errDecode)
+	}
+	if len(nodesBody.Nodes) != 1 || nodesBody.Nodes[0].NodeID != "cpa-stale" || nodesBody.Nodes[0].Healthy || !nodesBody.Nodes[0].LastSeenAt.Equal(staleSeenAt) {
+		t.Fatalf("nodes = %+v, want same stale active CPA as topology", nodesBody.Nodes)
 	}
 }
 
@@ -511,16 +628,8 @@ func TestGetTopologyPrunesExpiredSnapshots(t *testing.T) {
 	if errCreate := db.Create(&homeRecords).Error; errCreate != nil {
 		t.Fatalf("create home records: %v", errCreate)
 	}
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-recent", 8327, []node.Node{
-		{NodeID: "cpa-recent", IP: "10.0.0.8", ClientCount: 1, Connected: recentSeenAt.Add(-time.Minute)},
-	}, recentSeenAt); errSnapshot != nil {
-		t.Fatalf("replace recent cpa snapshot: %v", errSnapshot)
-	}
-	if errSnapshot := repo.ReplaceCPANodeSnapshot(context.Background(), "home-expired", 8327, []node.Node{
-		{NodeID: "cpa-expired", IP: "10.0.0.9", ClientCount: 1, Connected: expiredSeenAt.Add(-time.Minute)},
-	}, expiredSeenAt); errSnapshot != nil {
-		t.Fatalf("replace expired cpa snapshot: %v", errSnapshot)
-	}
+	seedActiveManagementCPA(t, db, homeRecords[0], "fp-recent", "cpa-recent", "10.0.0.8", recentSeenAt.Add(-time.Minute), recentSeenAt)
+	seedActiveManagementCPA(t, db, homeRecords[1], "fp-expired", "cpa-expired", "10.0.0.9", expiredSeenAt.Add(-time.Minute), expiredSeenAt)
 
 	handler := NewHandler(repo, nil, "home-recent", 8327)
 	handler.SetHeartbeatTimeout(30 * time.Second)
@@ -559,6 +668,195 @@ func TestGetTopologyPrunesExpiredSnapshots(t *testing.T) {
 	}
 	if topologyTestCPA(body.CPAs, "cpa-expired").NodeID != "" {
 		t.Fatalf("cpas = %+v, want cpa-expired pruned", body.CPAs)
+	}
+}
+
+func TestTopologyAndNodesUseMembershipOwnerDuringFailover(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	now := time.Now().UTC()
+	homeA := cluster.ClusterNodeRecord{IP: "home-a", Port: 8327, StartedAt: now.Add(-2 * time.Hour), LastSeenAt: now}
+	homeB := cluster.ClusterNodeRecord{IP: "home-b", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	homeC := cluster.ClusterNodeRecord{IP: "home-c", Port: 8327, StartedAt: now.Add(-3 * time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&[]cluster.ClusterNodeRecord{homeA, homeB, homeC}).Error; errCreate != nil {
+		t.Fatalf("create homes: %v", errCreate)
+	}
+	seedActiveManagementCPA(t, db, homeB, "fp-failover", "cpa-failover", "10.0.0.5", now.Add(-time.Minute), now)
+	seedManagementCPASnapshot(t, db, homeA, "fp-failover", "cpa-failover", "10.0.0.5", 0, 1, 1, now.Add(-2*time.Minute), now)
+	seedManagementCPASnapshot(t, db, homeC, "fp-failover", "cpa-failover", "10.0.0.5", 0, 1, 0, now.Add(-3*time.Minute), now)
+
+	handler := NewHandler(repo, nil, homeB.IP, homeB.Port)
+	engine := gin.New()
+	engine.GET("/topology", handler.GetTopology)
+	engine.GET("/nodes", handler.ListNodes)
+
+	topologyResponse := httptest.NewRecorder()
+	engine.ServeHTTP(topologyResponse, httptest.NewRequest(http.MethodGet, "/topology", nil))
+	if topologyResponse.Code != http.StatusOK {
+		t.Fatalf("topology status = %d, body = %s", topologyResponse.Code, topologyResponse.Body.String())
+	}
+	var topologyBody struct {
+		Summary struct {
+			CPACount int `json:"cpa_count"`
+		} `json:"summary"`
+		CPAs []topologyTestCPAItem `json:"cpas"`
+	}
+	if errDecode := json.Unmarshal(topologyResponse.Body.Bytes(), &topologyBody); errDecode != nil {
+		t.Fatalf("decode topology: %v", errDecode)
+	}
+	if topologyBody.Summary.CPACount != 1 {
+		t.Fatalf("summary = %+v, want one logical CPA", topologyBody.Summary)
+	}
+	statesByHome := make(map[string]string)
+	for _, item := range topologyBody.CPAs {
+		statesByHome[item.HomeID] = item.State
+	}
+	if statesByHome["home-a:8327"] != topologyCPADraining || statesByHome["home-b:8327"] != topologyCPAActive || statesByHome["home-c:8327"] != topologyCPADraining {
+		t.Fatalf("CPA states = %+v", statesByHome)
+	}
+
+	nodesResponse := httptest.NewRecorder()
+	engine.ServeHTTP(nodesResponse, httptest.NewRequest(http.MethodGet, "/nodes", nil))
+	if nodesResponse.Code != http.StatusOK {
+		t.Fatalf("nodes status = %d, body = %s", nodesResponse.Code, nodesResponse.Body.String())
+	}
+	var nodesBody struct {
+		Nodes []struct {
+			NodeID string `json:"node_id"`
+			HomeID string `json:"home_id"`
+		} `json:"nodes"`
+	}
+	if errDecode := json.Unmarshal(nodesResponse.Body.Bytes(), &nodesBody); errDecode != nil {
+		t.Fatalf("decode nodes: %v", errDecode)
+	}
+	if len(nodesBody.Nodes) != 1 || nodesBody.Nodes[0].NodeID != "cpa-failover" || nodesBody.Nodes[0].HomeID != "home-b:8327" {
+		t.Fatalf("nodes = %+v, want only active owner on home-b", nodesBody.Nodes)
+	}
+}
+
+func TestTopologyRepeatedFailoverKeepsOneActiveCPA(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	now := time.Now().UTC()
+	homeA := cluster.ClusterNodeRecord{IP: "home-a", Port: 8327, StartedAt: now.Add(-2 * time.Hour), LastSeenAt: now}
+	homeB := cluster.ClusterNodeRecord{IP: "home-b", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&[]cluster.ClusterNodeRecord{homeA, homeB}).Error; errCreate != nil {
+		t.Fatalf("create homes: %v", errCreate)
+	}
+	seedActiveManagementCPA(t, db, homeA, "fp-repeat", "cpa-repeat", "10.0.0.5", now.Add(-time.Minute), now)
+
+	handler := NewHandler(repo, nil, homeA.IP, homeA.Port)
+	engine := gin.New()
+	engine.GET("/topology", handler.GetTopology)
+
+	assertOwner := func(wantHomeID string) {
+		t.Helper()
+		response := httptest.NewRecorder()
+		engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/topology", nil))
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+		}
+		var body struct {
+			Summary struct {
+				CPACount int `json:"cpa_count"`
+			} `json:"summary"`
+			CPAs []topologyTestCPAItem `json:"cpas"`
+		}
+		if errDecode := json.Unmarshal(response.Body.Bytes(), &body); errDecode != nil {
+			t.Fatalf("decode topology: %v", errDecode)
+		}
+		activeHomeID := ""
+		for _, item := range body.CPAs {
+			if item.State == topologyCPAActive {
+				activeHomeID = item.HomeID
+			}
+		}
+		if body.Summary.CPACount != 1 || activeHomeID != wantHomeID {
+			t.Fatalf("summary = %+v, active home = %q, want %q", body.Summary, activeHomeID, wantHomeID)
+		}
+	}
+
+	assertOwner("home-a:8327")
+	if errDrain := db.Model(&cluster.CPANodeRecord{}).
+		Where("certificate_fingerprint = ? AND home_ip = ?", "fp-repeat", homeA.IP).
+		Updates(map[string]any{"client_count": 0, "active_handlers": 1}).Error; errDrain != nil {
+		t.Fatalf("drain home-a snapshot: %v", errDrain)
+	}
+	if errOwner := db.Model(&cluster.CPANodeMembershipRecord{}).
+		Where("certificate_fingerprint = ?", "fp-repeat").
+		Updates(map[string]any{"home_ip": homeB.IP, "home_port": homeB.Port, "home_started_at": homeB.StartedAt, "last_seen_at": now}).Error; errOwner != nil {
+		t.Fatalf("move membership to home-b: %v", errOwner)
+	}
+	seedManagementCPASnapshot(t, db, homeB, "fp-repeat", "cpa-repeat", "10.0.0.5", 1, 0, 0, now, now)
+	assertOwner("home-b:8327")
+
+	if errDrain := db.Model(&cluster.CPANodeRecord{}).
+		Where("certificate_fingerprint = ? AND home_ip = ?", "fp-repeat", homeB.IP).
+		Updates(map[string]any{"client_count": 0, "active_handlers": 1}).Error; errDrain != nil {
+		t.Fatalf("drain home-b snapshot: %v", errDrain)
+	}
+	if errActivate := db.Model(&cluster.CPANodeRecord{}).
+		Where("certificate_fingerprint = ? AND home_ip = ?", "fp-repeat", homeA.IP).
+		Updates(map[string]any{"client_count": 1, "active_handlers": 0, "last_seen_at": now}).Error; errActivate != nil {
+		t.Fatalf("reactivate home-a snapshot: %v", errActivate)
+	}
+	if errOwner := db.Model(&cluster.CPANodeMembershipRecord{}).
+		Where("certificate_fingerprint = ?", "fp-repeat").
+		Updates(map[string]any{"home_ip": homeA.IP, "home_port": homeA.Port, "home_started_at": homeA.StartedAt, "last_seen_at": now}).Error; errOwner != nil {
+		t.Fatalf("move membership back to home-a: %v", errOwner)
+	}
+	assertOwner("home-a:8327")
+
+	var snapshotCount int64
+	if errCount := db.Model(&cluster.CPANodeRecord{}).Where("certificate_fingerprint = ?", "fp-repeat").Count(&snapshotCount).Error; errCount != nil {
+		t.Fatalf("count snapshots: %v", errCount)
+	}
+	if snapshotCount != 2 {
+		t.Fatalf("snapshot count = %d, want bounded per-Home incarnations", snapshotCount)
+	}
+}
+
+func TestTopologyDoesNotAttachOldSnapshotToRestartedHome(t *testing.T) {
+	db, cleanup := openManagementLogTestDB(t)
+	defer cleanup()
+
+	repo := cluster.NewRepository(db)
+	now := time.Now().UTC()
+	oldHome := cluster.ClusterNodeRecord{IP: "home-a", Port: 8327, StartedAt: now.Add(-2 * time.Hour), LastSeenAt: now.Add(-time.Hour)}
+	newHome := cluster.ClusterNodeRecord{IP: oldHome.IP, Port: oldHome.Port, StartedAt: now.Add(-time.Minute), LastSeenAt: now}
+	if errCreate := db.Create(&newHome).Error; errCreate != nil {
+		t.Fatalf("create restarted Home: %v", errCreate)
+	}
+	seedActiveManagementCPA(t, db, oldHome, "fp-old", "cpa-old", "10.0.0.5", now.Add(-time.Hour), now)
+
+	handler := NewHandler(repo, nil, newHome.IP, newHome.Port)
+	engine := gin.New()
+	engine.GET("/topology", handler.GetTopology)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/topology", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var body struct {
+		Homes []struct {
+			CPACount int `json:"cpa_count"`
+		} `json:"homes"`
+		CPAs []struct {
+			Health string `json:"health"`
+		} `json:"cpas"`
+	}
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("decode topology: %v", errDecode)
+	}
+	if len(body.Homes) != 1 || body.Homes[0].CPACount != 0 {
+		t.Fatalf("homes = %+v, old snapshot must not count under restarted Home", body.Homes)
+	}
+	if len(body.CPAs) != 1 || body.CPAs[0].Health != topologyHealthUnknown {
+		t.Fatalf("cpas = %+v, want unmatched old incarnation", body.CPAs)
 	}
 }
 
@@ -627,10 +925,14 @@ func TestListNodesRequiresCurrentConfiguredPluginInReport(t *testing.T) {
 		t.Fatalf("ReplacePluginStatus() error = %v", errStore)
 	}
 
-	node.GlobalRegistry().AddWithNodeID("10.0.0.6", "node-2", time.Now().UTC())
-	defer node.GlobalRegistry().RemoveWithNodeID("10.0.0.6", "node-2")
+	now := time.Now().UTC()
+	homeRecord := cluster.ClusterNodeRecord{IP: "127.0.0.1", Port: 8327, StartedAt: now.Add(-time.Hour), LastSeenAt: now}
+	if errCreate := db.Create(&homeRecord).Error; errCreate != nil {
+		t.Fatalf("create Home record: %v", errCreate)
+	}
+	seedActiveManagementCPA(t, db, homeRecord, "fp-node-2", "node-2", "10.0.0.6", now.Add(-time.Minute), now)
 
-	handler := NewHandler(repo, nil, "127.0.0.1", 0)
+	handler := NewHandler(repo, nil, "127.0.0.1", 8327)
 	engine := gin.New()
 	engine.GET("/nodes", handler.ListNodes)
 

--- a/internal/cluster/management/nodes_test.go
+++ b/internal/cluster/management/nodes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/config"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/node"
 	"gorm.io/gorm"
 )
@@ -169,6 +170,7 @@ func seedActiveManagementCPA(t *testing.T, db *gorm.DB, home cluster.ClusterNode
 		HomeStartedAt:          home.StartedAt,
 		ProtocolVersion:        1,
 		State:                  cluster.MembershipStateActive,
+		CPAHeartbeatTimeout:    config.DefaultCPAHeartbeatTimeout,
 		ConnectedAt:            connectedAt,
 		LastSeenAt:             lastSeenAt,
 		UpdatedAt:              lastSeenAt,
@@ -197,6 +199,41 @@ func seedManagementCPASnapshot(t *testing.T, db *gorm.DB, home cluster.ClusterNo
 	}
 	if errCreate := db.Create(&record).Error; errCreate != nil {
 		t.Fatalf("create CPA snapshot %s: %v", fingerprint, errCreate)
+	}
+}
+
+func TestTopologyCPASnapshotHealthUsesMembershipHeartbeatTimeout(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name       string
+		lastSeen   time.Time
+		timeout    time.Duration
+		wantHealth string
+	}{
+		{
+			name:       "expired default membership timeout",
+			lastSeen:   now.Add(-config.DefaultCPAHeartbeatTimeout - time.Second),
+			timeout:    config.DefaultCPAHeartbeatTimeout,
+			wantHealth: topologyHealthStale,
+		},
+		{
+			name:       "live custom membership timeout",
+			lastSeen:   now.Add(-30 * time.Second),
+			timeout:    time.Minute,
+			wantHealth: topologyHealthHealthy,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			membership := cluster.CPANodeMembershipRecord{
+				LastSeenAt:          test.lastSeen,
+				CPAHeartbeatTimeout: test.timeout,
+			}
+			gotHealth := topologyCPASnapshotHealth(topologyCPAActive, membership, topologyHealthHealthy, now)
+			if gotHealth != test.wantHealth {
+				t.Fatalf("health = %q, want %q", gotHealth, test.wantHealth)
+			}
+		})
 	}
 }
 

--- a/internal/cluster/management/topology.go
+++ b/internal/cluster/management/topology.go
@@ -16,6 +16,8 @@ const (
 	topologyHealthHealthy = "healthy"
 	topologyHealthStale   = "stale"
 	topologyHealthUnknown = "unknown"
+	topologyCPAActive     = "active"
+	topologyCPADraining   = "draining"
 	topologyRoleMaster    = "master"
 	topologyRoleFollower  = "follower"
 	topologyRoleUnknown   = "unknown"
@@ -24,7 +26,7 @@ const (
 )
 
 type topologyHomeStats struct {
-	CPA        int
+	ActiveCPA  int
 	HealthyCPA int
 	StaleCPA   int
 	UnknownCPA int
@@ -66,18 +68,28 @@ func (h *Handler) GetTopology(c *gin.Context) {
 		respondError(c, http.StatusInternalServerError, "cpa_nodes_load_failed", errCPAs)
 		return
 	}
+	memberships, errMemberships := h.repo.ListActiveCPAMemberships(ctx)
+	if errMemberships != nil {
+		respondError(c, http.StatusInternalServerError, "cpa_memberships_load_failed", errMemberships)
+		return
+	}
 	requiredPluginIDs := h.pluginTaskRequiredIDs(ctx)
 	statusesByNodeID, statusesByIP := pluginStatusesByNode(taskStatuses)
 
 	homeStats := make(map[string]*topologyHomeStats, len(homeRecords))
 	homeHealth := make(map[string]string, len(homeRecords))
 	for _, homeRecord := range homeRecords {
-		homeID := topologyHomeID(homeRecord.IP, homeRecord.Port)
-		homeStats[homeID] = &topologyHomeStats{}
-		homeHealth[homeID] = topologyHealth(homeRecord.LastSeenAt, cutoff)
+		homeKey := topologyHomeIncarnationKey(homeRecord.IP, homeRecord.Port, homeRecord.StartedAt)
+		homeStats[homeKey] = &topologyHomeStats{}
+		homeHealth[homeKey] = topologyHealth(homeRecord.LastSeenAt, cutoff)
+	}
+	membershipsByFingerprint := make(map[string]cluster.CPANodeMembershipRecord, len(memberships))
+	for _, membership := range memberships {
+		membershipsByFingerprint[strings.TrimSpace(membership.CertificateFingerprint)] = membership
 	}
 
 	cpaItems := make([]gin.H, 0, len(cpaRecords))
+	logicalCPAs := make(map[string]struct{})
 	healthyCPACount := 0
 	staleCPACount := 0
 	unknownCPACount := 0
@@ -85,24 +97,38 @@ func (h *Handler) GetTopology(c *gin.Context) {
 	cpaAttentionCount := 0
 	for _, cpaRecord := range cpaRecords {
 		homeID := topologyHomeID(cpaRecord.HomeIP, cpaRecord.HomePort)
-		health := topologyCPAHealth(cpaRecord, homeHealth[homeID], cutoff)
-		healthy := health == topologyHealthHealthy
-		if healthy {
-			healthyCPACount++
-		} else if health == topologyHealthStale {
-			staleCPACount++
-		} else {
-			unknownCPACount++
+		homeKey := topologyHomeIncarnationKey(cpaRecord.HomeIP, cpaRecord.HomePort, cpaRecord.HomeStartedAt)
+		membership, hasMembership := membershipsByFingerprint[strings.TrimSpace(cpaRecord.CertificateFingerprint)]
+		state := topologyCPASnapshotState(cpaRecord, membership, hasMembership)
+		if state == "" {
+			continue
 		}
-		if stats := homeStats[homeID]; stats != nil {
-			stats.CPA++
-			switch health {
-			case topologyHealthHealthy:
-				stats.HealthyCPA++
-			case topologyHealthStale:
-				stats.StaleCPA++
-			default:
-				stats.UnknownCPA++
+		logicalKey := topologyLogicalCPAKey(cpaRecord)
+		if logicalKey != "" {
+			logicalCPAs[logicalKey] = struct{}{}
+		}
+		health := topologyCPASnapshotHealth(state, membership, homeHealth[homeKey], cutoff)
+		healthy := health == topologyHealthHealthy
+		if stats := homeStats[homeKey]; stats != nil && state == topologyCPAActive {
+			stats.ActiveCPA++
+		}
+		if state == topologyCPAActive {
+			if healthy {
+				healthyCPACount++
+			} else if health == topologyHealthStale {
+				staleCPACount++
+			} else {
+				unknownCPACount++
+			}
+			if stats := homeStats[homeKey]; stats != nil {
+				switch health {
+				case topologyHealthHealthy:
+					stats.HealthyCPA++
+				case topologyHealthStale:
+					stats.StaleCPA++
+				default:
+					stats.UnknownCPA++
+				}
 			}
 		}
 
@@ -112,21 +138,21 @@ func (h *Handler) GetTopology(c *gin.Context) {
 		}
 		pluginState := pluginReportState(statuses, requiredPluginIDs)
 		pluginNeedsAttention := topologyPluginNeedsAttention(pluginState)
-		if pluginNeedsAttention {
+		if state == topologyCPAActive && pluginNeedsAttention {
 			pluginAttentionCount++
 		}
-		if health != topologyHealthHealthy || pluginNeedsAttention {
+		if state == topologyCPAActive && (health != topologyHealthHealthy || pluginNeedsAttention) {
 			cpaAttentionCount++
 		}
-
 		cpaItems = append(cpaItems, gin.H{
 			"node_id":                cpaRecord.NodeID,
 			"ip":                     cpaRecord.ClientIP,
 			"connected_time":         cpaRecord.ConnectedAt,
 			"last_seen_at":           cpaRecord.LastSeenAt,
 			"client_count":           cpaRecord.ClientCount,
-			"healthy":                healthy,
+			"state":                  state,
 			"health":                 health,
+			"healthy":                healthy,
 			"home_id":                homeID,
 			"home_ip":                cpaRecord.HomeIP,
 			"home_port":              cpaRecord.HomePort,
@@ -143,7 +169,8 @@ func (h *Handler) GetTopology(c *gin.Context) {
 	var masterHome gin.H
 	for _, homeRecord := range homeRecords {
 		homeID := topologyHomeID(homeRecord.IP, homeRecord.Port)
-		health := homeHealth[homeID]
+		homeKey := topologyHomeIncarnationKey(homeRecord.IP, homeRecord.Port, homeRecord.StartedAt)
+		health := homeHealth[homeKey]
 		healthy := health == topologyHealthHealthy
 		if healthy {
 			healthyHomeCount++
@@ -160,7 +187,7 @@ func (h *Handler) GetTopology(c *gin.Context) {
 				role = topologyRoleFollower
 			}
 		}
-		stats := homeStats[homeID]
+		stats := homeStats[homeKey]
 		if stats == nil {
 			stats = &topologyHomeStats{}
 		}
@@ -176,7 +203,7 @@ func (h *Handler) GetTopology(c *gin.Context) {
 			"client_count":      homeRecord.ClientCount,
 			"started_at":        homeRecord.StartedAt,
 			"last_seen_at":      homeRecord.LastSeenAt,
-			"cpa_count":         stats.CPA,
+			"cpa_count":         stats.ActiveCPA,
 			"healthy_cpa_count": stats.HealthyCPA,
 			"stale_cpa_count":   stats.StaleCPA,
 			"unknown_cpa_count": stats.UnknownCPA,
@@ -199,7 +226,7 @@ func (h *Handler) GetTopology(c *gin.Context) {
 			"healthy_home_count":      healthyHomeCount,
 			"stale_home_count":        staleHomeCount,
 			"unknown_home_count":      unknownHomeCount,
-			"cpa_count":               len(cpaItems),
+			"cpa_count":               len(logicalCPAs),
 			"healthy_cpa_count":       healthyCPACount,
 			"stale_cpa_count":         staleCPACount,
 			"unknown_cpa_count":       unknownCPACount,
@@ -244,6 +271,17 @@ func topologyHomeID(ip string, port int) string {
 	return fmt.Sprintf("%s:%d", ip, port)
 }
 
+func topologyHomeIncarnationKey(ip string, port int, startedAt time.Time) string {
+	if startedAt.IsZero() {
+		return ""
+	}
+	homeID := topologyHomeID(ip, port)
+	if homeID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/%d", homeID, startedAt.UTC().UnixNano())
+}
+
 func topologyHealth(lastSeenAt time.Time, cutoff time.Time) string {
 	if lastSeenAt.IsZero() {
 		return topologyHealthUnknown
@@ -261,8 +299,21 @@ func topologySnapshotRetention(heartbeatTimeout time.Duration) time.Duration {
 	return heartbeatTimeout * topologyRetentionHeartbeatMultiplier
 }
 
-func topologyCPAHealth(record cluster.CPANodeRecord, homeHealth string, cutoff time.Time) string {
-	if strings.TrimSpace(record.HomeIP) == "" || record.HomePort <= 0 || homeHealth == "" {
+func topologyCPASnapshotState(record cluster.CPANodeRecord, membership cluster.CPANodeMembershipRecord, hasMembership bool) string {
+	if record.ClientCount <= 0 && record.OpenConnections <= 0 && record.ActiveHandlers <= 0 {
+		return ""
+	}
+	if record.ClientCount > 0 && hasMembership && strings.TrimSpace(record.CertificateFingerprint) != "" &&
+		strings.TrimSpace(record.CertificateFingerprint) == strings.TrimSpace(membership.CertificateFingerprint) &&
+		strings.TrimSpace(record.HomeIP) == strings.TrimSpace(membership.HomeIP) &&
+		record.HomePort == membership.HomePort && record.HomeStartedAt.Equal(membership.HomeStartedAt) {
+		return topologyCPAActive
+	}
+	return topologyCPADraining
+}
+
+func topologyCPASnapshotHealth(state string, membership cluster.CPANodeMembershipRecord, homeHealth string, cutoff time.Time) string {
+	if homeHealth == "" {
 		return topologyHealthUnknown
 	}
 	if homeHealth == topologyHealthUnknown {
@@ -271,10 +322,23 @@ func topologyCPAHealth(record cluster.CPANodeRecord, homeHealth string, cutoff t
 	if homeHealth != topologyHealthHealthy {
 		return topologyHealthStale
 	}
-	if record.ClientCount <= 0 {
+	if state != topologyCPAActive {
 		return topologyHealthStale
 	}
-	return topologyHealth(record.LastSeenAt, cutoff)
+	return topologyHealth(membership.LastSeenAt, cutoff)
+}
+
+func topologyLogicalCPAKey(record cluster.CPANodeRecord) string {
+	if fingerprint := strings.TrimSpace(record.CertificateFingerprint); fingerprint != "" {
+		return "fingerprint:" + fingerprint
+	}
+	if nodeID := strings.TrimSpace(record.NodeID); nodeID != "" {
+		return "node:" + nodeID
+	}
+	if clientIP := strings.TrimSpace(record.ClientIP); clientIP != "" {
+		return "ip:" + clientIP
+	}
+	return ""
 }
 
 func topologyCurrentMasterHomeID(records []cluster.ClusterNodeRecord, cutoff time.Time) string {

--- a/internal/cluster/management/topology.go
+++ b/internal/cluster/management/topology.go
@@ -50,7 +50,11 @@ func (h *Handler) GetTopology(c *gin.Context) {
 		return
 	}
 
-	now := time.Now().UTC()
+	now, errNow := h.repo.CurrentDatabaseTime(ctx)
+	if errNow != nil {
+		respondError(c, http.StatusInternalServerError, "database_time_load_failed", errNow)
+		return
+	}
 	heartbeatTimeout := h.heartbeatTimeout
 	if heartbeatTimeout <= 0 {
 		heartbeatTimeout = cluster.DefaultHeartbeatTimeout()
@@ -107,7 +111,7 @@ func (h *Handler) GetTopology(c *gin.Context) {
 		if logicalKey != "" {
 			logicalCPAs[logicalKey] = struct{}{}
 		}
-		health := topologyCPASnapshotHealth(state, membership, homeHealth[homeKey], cutoff)
+		health := topologyCPASnapshotHealth(state, membership, homeHealth[homeKey], now)
 		healthy := health == topologyHealthHealthy
 		if stats := homeStats[homeKey]; stats != nil && state == topologyCPAActive {
 			stats.ActiveCPA++
@@ -312,7 +316,7 @@ func topologyCPASnapshotState(record cluster.CPANodeRecord, membership cluster.C
 	return topologyCPADraining
 }
 
-func topologyCPASnapshotHealth(state string, membership cluster.CPANodeMembershipRecord, homeHealth string, cutoff time.Time) string {
+func topologyCPASnapshotHealth(state string, membership cluster.CPANodeMembershipRecord, homeHealth string, now time.Time) string {
 	if homeHealth == "" {
 		return topologyHealthUnknown
 	}
@@ -325,7 +329,10 @@ func topologyCPASnapshotHealth(state string, membership cluster.CPANodeMembershi
 	if state != topologyCPAActive {
 		return topologyHealthStale
 	}
-	return topologyHealth(membership.LastSeenAt, cutoff)
+	if membership.CPAHeartbeatTimeout <= 0 || now.IsZero() {
+		return topologyHealthUnknown
+	}
+	return topologyHealth(membership.LastSeenAt, now.Add(-membership.CPAHeartbeatTimeout))
 }
 
 func topologyLogicalCPAKey(record cluster.CPANodeRecord) string {

--- a/internal/cluster/repository.go
+++ b/internal/cluster/repository.go
@@ -552,7 +552,7 @@ func (r *Repository) replaceCPANodeSnapshot(ctx context.Context, home HomeIncarn
 		} else {
 			connectedAt = connectedAt.UTC()
 		}
-		if clientCount <= 0 && item.OpenConnections <= 0 && item.ActiveHandlers <= 0 && item.LatestCancelRevision <= 0 {
+		if clientCount <= 0 && item.OpenConnections <= 0 && item.ActiveHandlers <= 0 {
 			continue
 		}
 		records = append(records, CPANodeRecord{
@@ -586,6 +586,41 @@ func (r *Repository) replaceCPANodeSnapshot(ctx context.Context, home HomeIncarn
 		}
 		return tx.Create(&records).Error
 	})
+}
+
+// DeleteExpiredCPANodeSnapshots removes derived snapshots after the retention window.
+func (r *Repository) DeleteExpiredCPANodeSnapshots(ctx context.Context, retention time.Duration) error {
+	db, errDB := r.database()
+	if errDB != nil {
+		return errDB
+	}
+	if retention <= 0 {
+		return fmt.Errorf("CPA node snapshot retention must be greater than 0")
+	}
+	return db.WithContext(contextOrBackground(ctx)).Transaction(func(tx *gorm.DB) error {
+		now, errNow := DatabaseNow(ctx, tx)
+		if errNow != nil {
+			return errNow
+		}
+		return tx.Where("last_seen_at < ?", now.Add(-retention)).Delete(&CPANodeRecord{}).Error
+	})
+}
+
+// ListActiveCPAMemberships returns the authoritative active CPA owners.
+func (r *Repository) ListActiveCPAMemberships(ctx context.Context) ([]CPANodeMembershipRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+	var records []CPANodeMembershipRecord
+	errFind := db.WithContext(contextOrBackground(ctx)).
+		Where("state = ?", MembershipStateActive).
+		Order("certificate_fingerprint ASC").
+		Find(&records).Error
+	if errFind != nil {
+		return nil, errFind
+	}
+	return records, nil
 }
 
 // ListLiveCPANodes returns live CPA node snapshots reported by active Home nodes.

--- a/internal/cluster/repository_test.go
+++ b/internal/cluster/repository_test.go
@@ -209,7 +209,7 @@ func TestReplaceCPANodeSnapshotConcurrentSameHome(t *testing.T) {
 	}
 }
 
-func TestReplaceCPANodeSnapshotPersistsRevisionAndHandlerOnlyStates(t *testing.T) {
+func TestReplaceCPANodeSnapshotPersistsHandlerButNotRevisionOnlyState(t *testing.T) {
 	db, errOpenSQLite := OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
 	if errOpenSQLite != nil {
 		t.Fatalf("OpenSQLite failed: %v", errOpenSQLite)
@@ -240,14 +240,53 @@ func TestReplaceCPANodeSnapshotPersistsRevisionAndHandlerOnlyStates(t *testing.T
 	if errList != nil {
 		t.Fatalf("ListLiveCPANodes() error = %v", errList)
 	}
-	if len(records) != 2 {
-		t.Fatalf("snapshot records = %d, want 2", len(records))
+	if len(records) != 1 {
+		t.Fatalf("snapshot records = %d, want only handler state", len(records))
 	}
 	if records[0].NodeID != "handler-only" || records[0].ActiveHandlers != 1 {
 		t.Fatalf("handler-only record = %+v, want active handler state", records[0])
 	}
-	if records[1].NodeID != "revision-only" || records[1].LatestCancelRevision != 1 {
-		t.Fatalf("revision-only record = %+v, want cancellation revision state", records[1])
+}
+
+func TestDeleteExpiredCPANodeSnapshotsUsesRetention(t *testing.T) {
+	db, errOpenSQLite := OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite failed: %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sql db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sql db: %v", errClose)
+		}
+	}()
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate failed: %v", errMigrate)
+	}
+
+	repo := NewRepository(db)
+	databaseNow, errNow := DatabaseNow(context.Background(), db)
+	if errNow != nil {
+		t.Fatalf("DatabaseNow() error = %v", errNow)
+	}
+	records := []CPANodeRecord{
+		{HomeIP: "home-old", HomePort: 8327, HomeStartedAt: databaseNow.Add(-time.Hour), NodeKey: "fingerprint:old", CertificateFingerprint: "old", ClientCount: 1, LastSeenAt: databaseNow.Add(-time.Minute)},
+		{HomeIP: "home-new", HomePort: 8327, HomeStartedAt: databaseNow, NodeKey: "fingerprint:new", CertificateFingerprint: "new", ClientCount: 1, LastSeenAt: databaseNow},
+	}
+	if errCreate := db.Create(&records).Error; errCreate != nil {
+		t.Fatalf("create snapshots: %v", errCreate)
+	}
+	if errDelete := repo.DeleteExpiredCPANodeSnapshots(context.Background(), 30*time.Second); errDelete != nil {
+		t.Fatalf("DeleteExpiredCPANodeSnapshots() error = %v", errDelete)
+	}
+	var remaining []CPANodeRecord
+	if errFind := db.Order("node_key").Find(&remaining).Error; errFind != nil {
+		t.Fatalf("find remaining snapshots: %v", errFind)
+	}
+	if len(remaining) != 1 || remaining[0].CertificateFingerprint != "new" {
+		t.Fatalf("remaining snapshots = %+v, want only new", remaining)
 	}
 }
 

--- a/internal/node/registry.go
+++ b/internal/node/registry.go
@@ -138,7 +138,7 @@ func (r *Registry) updateFingerprintState(fingerprint string, nodeID string, ip 
 	if revision > entry.latestCancelRevision {
 		entry.latestCancelRevision = revision
 	}
-	if entry.count == 0 && entry.openConnections == 0 && entry.activeHandlers == 0 && entry.latestCancelRevision == 0 {
+	if entry.count == 0 && entry.openConnections == 0 && entry.activeHandlers == 0 {
 		delete(r.nodes, key)
 	} else {
 		r.nodes[key] = entry

--- a/internal/node/registry_test.go
+++ b/internal/node/registry_test.go
@@ -59,17 +59,14 @@ func TestRegistryKeepsOpenHandlerAfterSubscriptionDrains(t *testing.T) {
 	}
 }
 
-func TestRegistryKeepsFingerprintStateAfterConnectionsDrain(t *testing.T) {
+func TestRegistryDropsFingerprintStateAfterConnectionsDrainDespiteRevision(t *testing.T) {
 	registry := NewRegistry()
 	registry.UpdateFingerprintState("fp-a", "node-a", "127.0.0.1", 1, 1, 9)
 	registry.UpdateFingerprintState("fp-a", "node-a", "127.0.0.1", -1, -1, 9)
 
 	nodes := registry.List()
-	if len(nodes) != 1 {
-		t.Fatalf("nodes = %d, want state retained for latest cancellation revision", len(nodes))
-	}
-	if nodes[0].OpenConnections != 0 || nodes[0].ActiveHandlers != 0 || nodes[0].LatestCancelRevision != 9 {
-		t.Fatalf("node = %#v", nodes[0])
+	if len(nodes) != 0 {
+		t.Fatalf("nodes = %#v, want revision-only state removed", nodes)
 	}
 }
 


### PR DESCRIPTION
Implement CPA membership for topology management and utilize database time for CPA health checks. This enhances the accuracy of health monitoring and ensures proper handling of topology states.