### PR TITLE
feat(userapi): publish a user-facing model catalog

### DIFF
--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -150,6 +150,8 @@ The table below is extracted from the User API route group registered by `intern
 | Method | Path |
 | --- | --- |
 | `GET` | `/capabilities` |
+| `GET` | `/models` |
+| `GET` | `/models/accessible` |
 | `POST` | `/register` |
 | `POST` | `/login` |
 | `POST` | `/login/passkey/begin` |
@@ -207,7 +209,8 @@ Example response:
   "capabilities": {
     "email_registration": true,
     "email_verification": true,
-    "password_recovery": true
+    "password_recovery": true,
+    "model_catalog": true
   },
   "server_info": {
     "home_version": "v1.2.3",
@@ -217,7 +220,9 @@ Example response:
 }
 ```
 
-All three flags are `false` when `user-email.enabled` is false or the mail configuration is incomplete or invalid. Older Home versions may return `404` because this route does not exist.
+The three email flags are `false` when `user-email.enabled` is false or the mail configuration is incomplete or invalid. Older Home versions may return `404` because this route does not exist.
+
+`model_catalog` is always `true` on a Home build that serves `/user/models`; it is absent on older builds. Clients should read it instead of calling the catalog route and treating a `404` as an outage.
 
 ### POST `/register`
 
@@ -646,6 +651,243 @@ Common errors:
 { "error": "bearer_token_required", "message": "bearer token is required" }
 { "error": "invalid_token", "message": "invalid token" }
 ```
+
+## Model Catalog
+
+Model catalog routes are under the `/user` base path, so the full paths are `/user/models` and `/user/models/accessible`. `/user/models` is unauthenticated; `/user/models/accessible` requires the bearer token returned by `/user/register` or `/user/login`. Neither route accepts or requires a Management Key.
+
+The two routes answer different questions. `/user/models` answers "what can this cluster serve", which a visitor may ask before holding an account. `/user/models/accessible` answers "what can I call, at what price, and how has it been behaving", which is specific to the caller's API keys and commercial terms.
+
+Neither response includes Management API data, credential identities, node identities, routing details, price rule identifiers, price rule sources, price rule notes, or any other user's data.
+
+### Three-state reporting
+
+Model metadata is reported as an explicit state rather than an empty value, because a model nobody described must not be presented as a model that lacks the capability:
+
+| State | Meaning |
+| --- | --- |
+| `known` / `supported` | The upstream provider or cluster configuration stated this. |
+| `unsupported` | The model published its parameter list and this capability was not in it. |
+| `unknown` | Nothing has described this model. Render it as "not published", not as absence of the capability. |
+
+The same rule governs price and availability:
+
+- A model with no enabled price rule is `unpublished`. It is not free, and it is not priced at zero.
+- A model with fewer observations than the window's minimum is `insufficient_data`. It is not 100% available.
+
+### GET `/models`
+
+Returns the public catalog: every model the cluster can currently serve.
+
+No headers are required.
+
+Example response:
+
+```json
+{
+  "models": [
+    {
+      "id": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
+      "description": "Fast general purpose model.",
+      "type": "chat",
+      "providers": ["openai"],
+      "context_length": 128000,
+      "max_output_tokens": 16384,
+      "modalities": {
+        "status": "known",
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "capabilities": {
+        "reasoning": { "status": "supported", "levels": ["low", "medium", "high"] },
+        "tool_calling": { "status": "supported" },
+        "structured_output": { "status": "supported" },
+        "parameters": ["tools", "temperature", "reasoning_effort", "response_format"]
+      }
+    }
+  ],
+  "total": 1
+}
+```
+
+Model fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | The literal model identifier to send in an API request. Never translated or reformatted. |
+| `display_name` | string | Optional human-readable name. Absent when the upstream never supplied one. |
+| `description` | string | Optional short description supplied by the upstream. |
+| `version` | string | Optional upstream version string. |
+| `owned_by` | string | Optional upstream owner. |
+| `type` | string | Optional model type, for example `chat`. |
+| `providers[]` | array | Provider identifiers that can serve this model. These are the same identifiers used on usage records and price rules. |
+| `context_length` | number | Maximum input tokens. Omitted when unknown; `context_length` and `inputTokenLimit` upstream spellings are normalized into this one field. |
+| `max_output_tokens` | number | Maximum output tokens. Omitted when unknown; normalizes `max_completion_tokens` and `outputTokenLimit`. |
+| `modalities` | object | See below. |
+| `capabilities` | object | See below. |
+
+`modalities`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | string | `known` or `unknown`. |
+| `input[]` | array | Accepted modalities, for example `text`, `image`, `audio`. Present only when `status` is `known`. |
+| `output[]` | array | Produced modalities. Present only when `status` is `known`. |
+
+The published vocabulary is `text`, `image`, `audio` and `video`. Document formats are not modalities and are not reported here: several providers list PDF as an accepted input type and the rest do not describe their inputs that way, so publishing it would compare providers on a distinction only some of them make.
+
+Modalities come from the model catalog (`models.json`), which is curated by hand rather than probed from upstream. Values are taken from provider documentation, or from a first-party manifest where the provider publishes one — the Codex entries are filled from `codex_client_models.json`, which ships alongside the catalog and carries OpenAI's own `input_modalities`. A model the catalog does not describe reports `status: "unknown"` — never an empty `input` array, which a client would be entitled to read as "text only". Values are lower-cased and de-duplicated before they are returned.
+
+Leaving a model undescribed is a normal outcome, not a gap to be filled in later with a guess. A handful of models whose vendor documents context length and speed but never input types are expected to report `unknown` indefinitely; that is the catalog working as intended, not a backlog item.
+
+`capabilities`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `reasoning.status` | string | `supported`, `unsupported`, or `unknown`. |
+| `reasoning.levels[]` | array | Optional reasoning effort levels the model accepts. |
+| `reasoning.budget` | object | Optional thinking budget with `min`, `max`, `can_disable`, `dynamic`. Individual keys are omitted when the model did not state them. |
+| `tool_calling.status` | string | `supported`, `unsupported`, or `unknown`. |
+| `structured_output.status` | string | `supported`, `unsupported`, or `unknown`. Whether the model can be constrained to a caller-supplied schema. Resolved server-side from the parameter list; clients must not re-derive it. |
+| `parameters[]` | array | Optional request parameters the model accepts. |
+| `generation_methods[]` | array | Optional upstream generation methods. |
+
+This route never includes `pricing` or `availability`. Their absence is the contract, not a missing value: an anonymous visitor is not entitled to the operator's commercial terms.
+
+### GET `/models/accessible`
+
+Returns the subset of the catalog the authenticated user's own API keys are allowed to call, with price and observed availability attached.
+
+Headers:
+
+```http
+Authorization: Bearer user.jwt.token
+```
+
+Example response:
+
+```json
+{
+  "models": [
+    {
+      "id": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
+      "providers": ["openai"],
+      "context_length": 128000,
+      "max_output_tokens": 16384,
+      "modalities": { "status": "known", "input": ["text", "image"], "output": ["text"] },
+      "capabilities": { "reasoning": { "status": "supported" }, "tool_calling": { "status": "supported" } },
+      "pricing": {
+        "status": "published",
+        "providers": [
+          {
+            "provider": "openai",
+            "tiers": [
+              {
+                "service_tier": "*",
+                "is_default": true,
+                "rungs": [
+                  {
+                    "min_input_tokens": 0,
+                    "input_price_per_million": 0.4,
+                    "output_price_per_million": 1.6,
+                    "cache_read_price_per_million": 0.1,
+                    "cache_write_price_per_million": 0.5,
+                    "request_price": 0
+                  },
+                  {
+                    "min_input_tokens": 128000,
+                    "input_price_per_million": 0.8,
+                    "output_price_per_million": 3.2,
+                    "cache_read_price_per_million": 0.2,
+                    "cache_write_price_per_million": 1,
+                    "request_price": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "availability": {
+        "status": "observed",
+        "window": {
+          "from": "2026-07-25T00:00:00Z",
+          "to": "2026-08-01T00:00:00Z",
+          "hours": 168,
+          "min_samples": 10
+        },
+        "sample_count": 240,
+        "success_count": 236,
+        "failed_count": 4,
+        "availability_rate": 0.9833,
+        "avg_latency_ms": 2140.5,
+        "avg_ttft_ms": 318.2,
+        "output_tokens_per_second": 42.17,
+        "first_observed_at": "2026-07-25T04:11:02Z",
+        "last_observed_at": "2026-08-01T09:52:44Z"
+      }
+    }
+  ],
+  "total": 1,
+  "access": {
+    "restricted": false,
+    "api_key_count": 2,
+    "reason": "unrestricted"
+  }
+}
+```
+
+`access`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `restricted` | boolean | `true` when every one of the user's API keys is scoped to model groups. |
+| `api_key_count` | number | How many API keys the user holds. |
+| `reason` | string | `unrestricted`, `model_groups`, or `no_api_keys`. Lets a client explain an empty list instead of showing a bare zero state. |
+
+Access is a union across the user's keys, not an intersection: holding one unscoped key makes the whole catalog accessible. Holding no key makes nothing accessible, because an account without a credential cannot call the cluster.
+
+`pricing` is a ladder, not a scalar, because a charge resolves by service tier and then by input size:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | string | `published` or `unpublished`. |
+| `providers[]` | array | One entry per provider that can both serve the model and has an enabled price rule for it. Rules naming a provider that cannot serve the model are excluded, because they are not offers. |
+| `providers[].provider` | string | Provider identifier. |
+| `providers[].tiers[]` | array | One entry per service tier. |
+| `providers[].tiers[].service_tier` | string | Tier name, or `*` for the wildcard tier. |
+| `providers[].tiers[].is_default` | boolean | Present and `true` on the `*` tier, which prices requests that name no tier or a tier nobody priced. |
+| `providers[].tiers[].rungs[]` | array | Ascending by `min_input_tokens`. A request is priced by the last rung whose threshold it clears. |
+| `rungs[].min_input_tokens` | number | Input token count at which this rung takes effect. |
+| `rungs[].input_price_per_million` | number | Price per million input tokens. |
+| `rungs[].output_price_per_million` | number | Price per million output tokens. |
+| `rungs[].cache_read_price_per_million` | number | Price per million cache-read tokens. |
+| `rungs[].cache_write_price_per_million` | number | Price per million cache-write tokens. |
+| `rungs[].request_price` | number | Flat per-request price. |
+
+A zero price component is emitted rather than omitted: a provider that does not bill for cache reads has stated that, and dropping the field would make it indistinguishable from a component nobody priced. A whole model with no enabled rule reports `"status": "unpublished"` and no `providers`.
+
+Discount metadata is not returned in this version. Clients must not derive, infer, or display a discount from these fields.
+
+`availability` summarizes observed behaviour over a rolling window:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `status` | string | `observed` or `insufficient_data`. |
+| `window.from` / `window.to` | string | RFC3339 bounds of the observation window, half-open `[from,to)`. |
+| `window.hours` | number | Window length in hours. Currently `168`. |
+| `window.min_samples` | number | Observations required before a rate is published. Currently `10`. |
+| `sample_count` | number | Observations found in the window. Always present, including when it is `0`. |
+| `success_count` / `failed_count` | number | Present only when `status` is `observed`. |
+| `availability_rate` | number | Successes over samples, rounded to four decimals. **Present only when `status` is `observed`.** |
+| `avg_latency_ms` | number | Mean end-to-end latency of measured successful requests. Absent when nothing was measurable. |
+| `avg_ttft_ms` | number | Mean time to first token. Only streamed responses report it, so it can be absent while `avg_latency_ms` is present. |
+| `output_tokens_per_second` | number | Total output tokens over total generation time, which weights long generations the way a caller experiences them. |
+| `first_observed_at` / `last_observed_at` | string | RFC3339 bounds of the observations actually found, which can be much narrower than the window. `last_observed_at` may also appear on an `insufficient_data` model. |
+
+When `status` is `insufficient_data`, no rate, latency, or throughput is published. Clients must render this as "not enough data", never as full availability. The summary is cluster-wide model health and is cached briefly in-process; it contains no per-user request data.
 
 ## Billing
 

--- a/docs/user/api_CN.md
+++ b/docs/user/api_CN.md
@@ -56,6 +56,7 @@ user-email:
 | Method | Path | 说明 |
 | --- | --- | --- |
 | `GET` | `/capabilities` | 返回可选 User API capability。 |
+| `GET` | `/models` | 返回公开模型目录。 |
 | `POST` | `/register` | 创建用户并返回 bearer token。 |
 | `POST` | `/login` | 用户未启用 passkey 和 TOTP 时的密码登录。 |
 | `POST` | `/login/totp` | 用户启用 TOTP 时的密码 + TOTP 登录。 |
@@ -150,6 +151,8 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 | Method | Path |
 | --- | --- |
 | `GET` | `/capabilities` |
+| `GET` | `/models` |
+| `GET` | `/models/accessible` |
 | `POST` | `/register` |
 | `POST` | `/login` |
 | `POST` | `/login/passkey/begin` |
@@ -207,7 +210,8 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
   "capabilities": {
     "email_registration": true,
     "email_verification": true,
-    "password_recovery": true
+    "password_recovery": true,
+    "model_catalog": true
   },
   "server_info": {
     "home_version": "v1.2.3",
@@ -217,7 +221,9 @@ User API handler 通常同时返回机器可读 `error` 和可读 `message`：
 }
 ```
 
-当 `user-email.enabled` 为 false，或邮件配置不完整/无效时，三个 flag 都为 `false`。旧版 Home 可能因没有该 route 而返回 `404`。
+当 `user-email.enabled` 为 false，或邮件配置不完整/无效时，三个邮箱相关 flag 都为 `false`。旧版 Home 可能因没有该 route 而返回 `404`。
+
+在提供 `/user/models` 的 Home 版本上，`model_catalog` 恒为 `true`；旧版本不会返回该字段。客户端应读取该 flag 来决定是否展示模型目录，而不是直接调用目录 route 并把 `404` 当作故障处理。
 
 ### POST `/register`
 
@@ -646,6 +652,243 @@ Authorization: Bearer user.jwt.token
 { "error": "bearer_token_required", "message": "bearer token is required" }
 { "error": "invalid_token", "message": "invalid token" }
 ```
+
+## 模型目录
+
+模型目录路由位于 `/user` 基础路径下，因此完整路径是 `/user/models` 和 `/user/models/accessible`。`/user/models` 无需认证；`/user/models/accessible` 需要 `/user/register` 或 `/user/login` 返回的 Bearer token。两个路由都不接受也不需要 Management Key。
+
+两个路由回答的是不同的问题。`/user/models` 回答"这个集群能提供什么模型"，访客在拥有账号之前就可以查询。`/user/models/accessible` 回答"我能调用什么、价格是多少、最近表现如何"，答案取决于调用方自己的 API keys 与商务条款。
+
+两个响应都不包含 Management API 数据、凭据身份、节点身份、路由细节、价格规则 ID、价格规则来源、价格规则备注，以及任何其他用户的数据。
+
+### 三态语义
+
+模型元数据以显式状态而非空值返回，因为"没有人描述过这个模型"绝不能被呈现成"这个模型不具备该能力"：
+
+| 状态 | 含义 |
+| --- | --- |
+| `known` / `supported` | 上游 provider 或集群配置明确声明了该能力。 |
+| `unsupported` | 模型公布了参数列表，而该能力不在其中。 |
+| `unknown` | 没有任何来源描述过该模型。应渲染为"未公布"，而不是"不支持"。 |
+
+价格与可用性遵循同一规则：
+
+- 没有启用价格规则的模型是 `unpublished`。它不是免费的，也不是价格为 0。
+- 观测样本少于窗口最小值的模型是 `insufficient_data`。它不是 100% 可用。
+
+### GET `/models`
+
+返回公开目录：集群当前能够提供的全部模型。
+
+无需任何 header。
+
+响应示例：
+
+```json
+{
+  "models": [
+    {
+      "id": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
+      "description": "Fast general purpose model.",
+      "type": "chat",
+      "providers": ["openai"],
+      "context_length": 128000,
+      "max_output_tokens": 16384,
+      "modalities": {
+        "status": "known",
+        "input": ["text", "image"],
+        "output": ["text"]
+      },
+      "capabilities": {
+        "reasoning": { "status": "supported", "levels": ["low", "medium", "high"] },
+        "tool_calling": { "status": "supported" },
+        "structured_output": { "status": "supported" },
+        "parameters": ["tools", "temperature", "reasoning_effort", "response_format"]
+      }
+    }
+  ],
+  "total": 1
+}
+```
+
+模型字段：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | string | 发起 API 请求时使用的字面量模型标识符。不得翻译或改写。 |
+| `display_name` | string | 可选的可读名称。上游未提供时不返回。 |
+| `description` | string | 可选的上游简介。 |
+| `version` | string | 可选的上游版本号。 |
+| `owned_by` | string | 可选的上游归属方。 |
+| `type` | string | 可选的模型类型，例如 `chat`。 |
+| `providers[]` | array | 能够提供该模型的 provider 标识符，与用量记录和价格规则中使用的标识符一致。 |
+| `context_length` | number | 最大输入 token 数。未知时不返回；上游的 `context_length` 与 `inputTokenLimit` 两种写法在此归一为同一字段。 |
+| `max_output_tokens` | number | 最大输出 token 数。未知时不返回；归一 `max_completion_tokens` 与 `outputTokenLimit`。 |
+| `modalities` | object | 见下。 |
+| `capabilities` | object | 见下。 |
+
+`modalities`：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `status` | string | `known` 或 `unknown`。 |
+| `input[]` | array | 支持的输入模态，例如 `text`、`image`、`audio`。仅在 `status` 为 `known` 时出现。 |
+| `output[]` | array | 支持的输出模态。仅在 `status` 为 `known` 时出现。 |
+
+对外发布的取值范围是 `text`、`image`、`audio`、`video`。文档格式不属于模态，因此不在此返回：部分厂商会把 PDF 列为输入类型，其余厂商并不这样描述输入，若一并发布，就会拿只有部分厂商作出的区分去横向比较所有厂商。
+
+模态数据来自人工维护的模型目录（`models.json`），由人整理而非从上游探测。取值来自厂商文档；厂商自己发布清单的，则以清单为准——Codex 系列取自与目录同仓的 `codex_client_models.json`，其中带有 OpenAI 自己声明的 `input_modalities`。目录未描述的模型返回 `status: "unknown"`，绝不返回空的 `input` 数组——客户端有理由把空数组理解为“仅支持文本”。返回前会做小写化与去重。
+
+某个模型没有被描述是正常结果，不是待补的缺口，更不该事后用推测填上。少数只公开了上下文与速度、从未说明输入类型的模型预计将长期返回 `unknown`；这是目录按设计工作，不是待办事项。
+
+`capabilities`：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `reasoning.status` | string | `supported`、`unsupported` 或 `unknown`。 |
+| `reasoning.levels[]` | array | 可选的推理强度级别。 |
+| `reasoning.budget` | object | 可选的思考预算，含 `min`、`max`、`can_disable`、`dynamic`。模型未声明的键不会出现。 |
+| `tool_calling.status` | string | `supported`、`unsupported` 或 `unknown`。 |
+| `structured_output.status` | string | `supported`、`unsupported` 或 `unknown`。表示模型能否被约束为调用方给定的 schema。该判定在服务端根据参数列表完成，客户端不得自行推导。 |
+| `parameters[]` | array | 可选的请求参数列表。 |
+| `generation_methods[]` | array | 可选的上游生成方法。 |
+
+该 route 永远不返回 `pricing` 与 `availability`。它们的缺失本身就是契约，而不是数据缺失：匿名访客无权获取运营方的商务条款。
+
+### GET `/models/accessible`
+
+返回当前认证用户的 API keys 实际可以调用的模型子集，并附带价格与观测到的可用性。
+
+Headers：
+
+```http
+Authorization: Bearer user.jwt.token
+```
+
+响应示例：
+
+```json
+{
+  "models": [
+    {
+      "id": "gpt-4.1-mini",
+      "display_name": "GPT-4.1 mini",
+      "providers": ["openai"],
+      "context_length": 128000,
+      "max_output_tokens": 16384,
+      "modalities": { "status": "known", "input": ["text", "image"], "output": ["text"] },
+      "capabilities": { "reasoning": { "status": "supported" }, "tool_calling": { "status": "supported" } },
+      "pricing": {
+        "status": "published",
+        "providers": [
+          {
+            "provider": "openai",
+            "tiers": [
+              {
+                "service_tier": "*",
+                "is_default": true,
+                "rungs": [
+                  {
+                    "min_input_tokens": 0,
+                    "input_price_per_million": 0.4,
+                    "output_price_per_million": 1.6,
+                    "cache_read_price_per_million": 0.1,
+                    "cache_write_price_per_million": 0.5,
+                    "request_price": 0
+                  },
+                  {
+                    "min_input_tokens": 128000,
+                    "input_price_per_million": 0.8,
+                    "output_price_per_million": 3.2,
+                    "cache_read_price_per_million": 0.2,
+                    "cache_write_price_per_million": 1,
+                    "request_price": 0
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "availability": {
+        "status": "observed",
+        "window": {
+          "from": "2026-07-25T00:00:00Z",
+          "to": "2026-08-01T00:00:00Z",
+          "hours": 168,
+          "min_samples": 10
+        },
+        "sample_count": 240,
+        "success_count": 236,
+        "failed_count": 4,
+        "availability_rate": 0.9833,
+        "avg_latency_ms": 2140.5,
+        "avg_ttft_ms": 318.2,
+        "output_tokens_per_second": 42.17,
+        "first_observed_at": "2026-07-25T04:11:02Z",
+        "last_observed_at": "2026-08-01T09:52:44Z"
+      }
+    }
+  ],
+  "total": 1,
+  "access": {
+    "restricted": false,
+    "api_key_count": 2,
+    "reason": "unrestricted"
+  }
+}
+```
+
+`access`：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `restricted` | boolean | 当用户的每一个 API key 都被限定在 model groups 内时为 `true`。 |
+| `api_key_count` | number | 用户持有的 API key 数量。 |
+| `reason` | string | `unrestricted`、`model_groups` 或 `no_api_keys`。用于向用户解释列表为什么是空的，而不是只显示一个空态。 |
+
+访问范围是用户各个 key 的并集而非交集：只要持有一个未限定范围的 key，整个目录都可访问。一个 key 都没有则任何模型都不可访问，因为没有凭据的账号无法调用集群。
+
+`pricing` 是价格阶梯而不是标量，因为计费先按 service tier 再按输入规模解析：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `status` | string | `published` 或 `unpublished`。 |
+| `providers[]` | array | 每个既能提供该模型、又存在启用价格规则的 provider 一项。指向无法提供该模型的 provider 的规则会被排除，因为它们不构成报价。 |
+| `providers[].provider` | string | Provider 标识符。 |
+| `providers[].tiers[]` | array | 每个 service tier 一项。 |
+| `providers[].tiers[].service_tier` | string | Tier 名称，通配 tier 为 `*`。 |
+| `providers[].tiers[].is_default` | boolean | 仅在 `*` tier 上出现且为 `true`。请求未指定 tier、或指定了没有定价的 tier 时按该 tier 计费。 |
+| `providers[].tiers[].rungs[]` | array | 按 `min_input_tokens` 升序。请求按其满足的最后一个阶梯计价。 |
+| `rungs[].min_input_tokens` | number | 该阶梯生效的输入 token 阈值。 |
+| `rungs[].input_price_per_million` | number | 每百万输入 token 价格。 |
+| `rungs[].output_price_per_million` | number | 每百万输出 token 价格。 |
+| `rungs[].cache_read_price_per_million` | number | 每百万 cache read token 价格。 |
+| `rungs[].cache_write_price_per_million` | number | 每百万 cache write token 价格。 |
+| `rungs[].request_price` | number | 每次请求的固定价格。 |
+
+价格分量为 0 时会显式返回而不是省略：provider 不对 cache read 计费本身就是一种声明，省略字段会让它与"没有人为该分量定价"无法区分。整个模型没有启用规则时返回 `"status": "unpublished"` 且不带 `providers`。
+
+本版本不返回折扣元数据。客户端不得从上述字段推导、推断或展示折扣。
+
+`availability` 汇总滚动窗口内观测到的实际表现：
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `status` | string | `observed` 或 `insufficient_data`。 |
+| `window.from` / `window.to` | string | 观测窗口的 RFC3339 边界，半开区间 `[from,to)`。 |
+| `window.hours` | number | 窗口长度（小时）。当前为 `168`。 |
+| `window.min_samples` | number | 发布可用率所需的最小观测数。当前为 `10`。 |
+| `sample_count` | number | 窗口内的观测数。始终返回，包括为 `0` 时。 |
+| `success_count` / `failed_count` | number | 仅在 `status` 为 `observed` 时出现。 |
+| `availability_rate` | number | 成功数除以观测数，保留四位小数。**仅在 `status` 为 `observed` 时出现。** |
+| `avg_latency_ms` | number | 可测量的成功请求的端到端平均延迟。无可测量样本时不返回。 |
+| `avg_ttft_ms` | number | 平均首 token 时间。仅流式响应上报，因此可能在 `avg_latency_ms` 存在时缺失。 |
+| `output_tokens_per_second` | number | 总输出 token 除以总生成耗时，长生成的权重更高，与调用方的实际体感一致。 |
+| `first_observed_at` / `last_observed_at` | string | 实际观测的 RFC3339 时间边界，可能远窄于窗口。`insufficient_data` 的模型也可能带有 `last_observed_at`。 |
+
+`status` 为 `insufficient_data` 时不返回可用率、延迟与吞吐。客户端必须渲染为"数据不足"，绝不能渲染为完全可用。该汇总是集群级的模型健康度，在进程内做短时缓存，不包含任何单个用户的请求数据。
 
 ## Billing
 

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -816,6 +816,70 @@ func (r *Repository) AllowedModelIDsForAPIKey(ctx context.Context, apiKey string
 	return allowedModelIDsForAPIKeyRecord(ctx, db, &record)
 }
 
+// UserModelAccess summarizes which models one user's API keys may call.
+type UserModelAccess struct {
+	// APIKeyCount is how many active keys the user holds. Zero means the user
+	// cannot call anything yet, which is a different situation from holding a
+	// key that happens to allow nothing.
+	APIKeyCount int
+	// Restricted reports whether every key is scoped to model groups. One
+	// unscoped key is enough to reach everything the cluster serves, so a false
+	// value here makes ModelIDs meaningless.
+	Restricted bool
+	// ModelIDs is the union of canonical model identifiers the scoped keys
+	// allow, sorted for stable output. It is only meaningful when Restricted.
+	ModelIDs []string
+}
+
+// UserModelAccess resolves what the user's own API keys are permitted to call.
+//
+// Access is the union across keys rather than the intersection: a buyer holding
+// a broad key and a narrow one can call everything the broad key reaches, and
+// reporting the intersection would hide models they can actually use today.
+func (r *Repository) UserModelAccess(ctx context.Context, userID uint) (UserModelAccess, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return UserModelAccess{}, errDB
+	}
+	if userID == 0 {
+		return UserModelAccess{}, fmt.Errorf("user id is required")
+	}
+
+	ctx = contextOrBackground(ctx)
+	var records []APIKeyRecord
+	if errFind := db.WithContext(ctx).Where("user_id = ?", userID).Order("id").Find(&records).Error; errFind != nil {
+		return UserModelAccess{}, errFind
+	}
+
+	access := UserModelAccess{APIKeyCount: len(records), Restricted: true}
+	if len(records) == 0 {
+		return access, nil
+	}
+
+	seen := make(map[string]struct{})
+	allowed := make([]string, 0)
+	for i := range records {
+		details, restricted, errDetails := allowedModelGroupDetailsForAPIKeyRecord(ctx, db, &records[i])
+		if errDetails != nil {
+			return UserModelAccess{}, errDetails
+		}
+		if !restricted {
+			return UserModelAccess{APIKeyCount: len(records), Restricted: false}, nil
+		}
+		for _, modelID := range allowedModelIDsFromDetails(details, restricted) {
+			key := strings.ToLower(modelID)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			allowed = append(allowed, modelID)
+		}
+	}
+	sort.Strings(allowed)
+	access.ModelIDs = allowed
+	return access, nil
+}
+
 func allowedAuthIDsForAPIKeyRecord(ctx context.Context, db *gorm.DB, record *APIKeyRecord) ([]string, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database connection is nil")

--- a/internal/cluster/billing.go
+++ b/internal/cluster/billing.go
@@ -600,6 +600,49 @@ func (r *Repository) ListBillingModelPrices(ctx context.Context, query BillingMo
 	return records, nil
 }
 
+// ListEnabledBillingModelPricesForModels returns the enabled price rules for an
+// exact set of model identifiers.
+//
+// ListBillingModelPrices matches models with LIKE because it backs an operator
+// search box; a caller pricing a catalog needs exact identity, or "gpt-4" would
+// drag in every model whose name contains it. The ordering mirrors how the rules
+// are applied at charge time, so a client can read a returned group top to
+// bottom as the ladder a request climbs.
+func (r *Repository) ListEnabledBillingModelPricesForModels(ctx context.Context, modelIDs []string) ([]BillingModelPriceRecord, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+
+	wanted := make([]string, 0, len(modelIDs))
+	seen := make(map[string]struct{}, len(modelIDs))
+	for _, modelID := range modelIDs {
+		trimmed := strings.TrimSpace(modelID)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := seen[trimmed]; ok {
+			continue
+		}
+		seen[trimmed] = struct{}{}
+		wanted = append(wanted, trimmed)
+	}
+	if len(wanted) == 0 {
+		return []BillingModelPriceRecord{}, nil
+	}
+
+	var records []BillingModelPriceRecord
+	if errFind := db.WithContext(contextOrBackground(ctx)).
+		Model(&BillingModelPriceRecord{}).
+		Where("enabled = ?", true).
+		Where("model IN ?", wanted).
+		Order("provider ASC, model ASC, service_tier ASC, min_input_tokens ASC, id ASC").
+		Find(&records).Error; errFind != nil {
+		return nil, errFind
+	}
+	return records, nil
+}
+
 func (r *Repository) createBillingChargeForUsageTx(ctx context.Context, tx *gorm.DB, usage *UsageRecord, payload string) error {
 	if tx == nil {
 		return fmt.Errorf("database transaction is nil")

--- a/internal/cluster/model_availability.go
+++ b/internal/cluster/model_availability.go
@@ -1,0 +1,183 @@
+package cluster
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// ModelAvailabilityQuery selects the observation window and the models to
+// summarize.
+type ModelAvailabilityQuery struct {
+	// ModelIDs restricts the summary to a set of models, matched without regard
+	// to case. An empty set returns nothing rather than scanning every model the
+	// cluster has ever served, because every caller of this already knows which
+	// models it is about to display.
+	ModelIDs []string
+	// From is the inclusive start of the observation window.
+	From time.Time
+	// ToExclusive is the exclusive end of the observation window.
+	ToExclusive time.Time
+}
+
+// ModelAvailabilitySummary is what usage records say about one model over one
+// window.
+//
+// Averages are pointers because "no request had a measurable latency" is a real
+// outcome that must not be reported as a latency of zero. Counts are plain
+// integers because zero requests is genuinely zero requests.
+type ModelAvailabilitySummary struct {
+	// ModelID is one of the spellings the usage records carry for this model.
+	// Records are folded together case-insensitively, so when a model was
+	// written more than one way this is the lowest such spelling rather than
+	// the only one.
+	ModelID string
+	// SampleCount is how many requests were observed in the window. It is the
+	// number a caller weighs before trusting any of the other fields.
+	SampleCount int64
+	// SuccessCount and FailedCount partition SampleCount.
+	SuccessCount int64
+	FailedCount  int64
+	// AvgLatencyMS is the mean end-to-end latency of measured requests.
+	AvgLatencyMS *float64
+	// AvgTTFTMS is the mean time to first token. Only streaming responses
+	// report it, so it can be absent while AvgLatencyMS is present.
+	AvgTTFTMS *float64
+	// ThroughputOutputTokens and ThroughputLatencyMS are the numerator and
+	// denominator of output tokens per second, kept separate so the caller can
+	// decide whether the sample is large enough to divide.
+	ThroughputOutputTokens int64
+	ThroughputLatencyMS    int64
+	// FirstObservedAt and LastObservedAt bound the observations actually found,
+	// which can be much narrower than the requested window.
+	FirstObservedAt *time.Time
+	LastObservedAt  *time.Time
+}
+
+type modelAvailabilityRow struct {
+	// ModelKey is the grouping key the database itself computed. Keying the
+	// result map by it rather than by re-folding Model in Go guarantees the map
+	// has exactly one entry per group, whatever the two case-folding rules
+	// would disagree about.
+	ModelKey               string          `gorm:"column:model_key"`
+	Model                  string          `gorm:"column:model"`
+	SampleCount            int64           `gorm:"column:sample_count"`
+	SuccessCount           sql.NullInt64   `gorm:"column:success_count"`
+	FailedCount            sql.NullInt64   `gorm:"column:failed_count"`
+	AvgLatencyMS           sql.NullFloat64 `gorm:"column:avg_latency_ms"`
+	AvgTTFTMS              sql.NullFloat64 `gorm:"column:avg_ttft_ms"`
+	ThroughputOutputTokens sql.NullInt64   `gorm:"column:throughput_output_tokens"`
+	ThroughputLatencyMS    sql.NullInt64   `gorm:"column:throughput_latency_ms"`
+	// MIN/MAX over a timestamp column comes back as a driver string on SQLite
+	// and as a time on Postgres, so these are scanned as text and parsed with
+	// the same layout set the observability aggregates already use.
+	FirstObservedAt sql.NullString `gorm:"column:first_observed_at"`
+	LastObservedAt  sql.NullString `gorm:"column:last_observed_at"`
+}
+
+// ListModelAvailability summarizes observed reliability and speed per model.
+//
+// This is deliberately not built on the operator observability aggregate. That
+// aggregate answers a much wider question, joins billing and credential tables
+// to do it, and is shaped by what an operator console needs on screen. Reusing
+// it here would drag per-user amounts and credential identities into a query
+// whose result is shown to buyers, so the narrower question gets its own query
+// over the usage table alone.
+func (r *Repository) ListModelAvailability(ctx context.Context, query ModelAvailabilityQuery) (map[string]ModelAvailabilitySummary, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, errDB
+	}
+
+	// Match, group and key on the folded identifier throughout. A usage record
+	// carries whatever spelling the request that produced it used, which is not
+	// always the spelling the catalog registers, and the returned map is keyed
+	// lower-cased. Folding only at the end would both drop the records whose
+	// case differs from the catalog's and, where two spellings did survive,
+	// collapse their two groups onto one key and keep whichever arrived last.
+	wanted := make([]string, 0, len(query.ModelIDs))
+	seen := make(map[string]struct{}, len(query.ModelIDs))
+	for _, modelID := range query.ModelIDs {
+		key := strings.ToLower(strings.TrimSpace(modelID))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		wanted = append(wanted, key)
+	}
+	if len(wanted) == 0 {
+		return map[string]ModelAvailabilitySummary{}, nil
+	}
+
+	// LOWER() on the column rules out an index on model alone, but no such
+	// index exists and none would be used here anyway: the window predicate is
+	// what the planner drives this query from.
+	scope := db.WithContext(contextOrBackground(ctx)).
+		Table("usage").
+		Where(`LOWER("usage"."model") IN ?`, wanted)
+	if !query.From.IsZero() {
+		scope = scope.Where(`"usage"."timestamp" >= ?`, query.From)
+	}
+	if !query.ToExclusive.IsZero() {
+		scope = scope.Where(`"usage"."timestamp" < ?`, query.ToExclusive)
+	}
+
+	var rows []modelAvailabilityRow
+	if errScan := scope.Select(`
+		LOWER("usage"."model") AS model_key,
+		MIN("usage"."model") AS model,
+		COUNT("usage"."id") AS sample_count,
+		SUM(CASE WHEN "usage"."failed" THEN 0 ELSE 1 END) AS success_count,
+		SUM(CASE WHEN "usage"."failed" THEN 1 ELSE 0 END) AS failed_count,
+		AVG(CASE WHEN "usage"."failed" THEN NULL WHEN "usage"."latency_ms" > 0 THEN "usage"."latency_ms" END) AS avg_latency_ms,
+		AVG(CASE WHEN "usage"."failed" THEN NULL WHEN "usage"."ttft_ms" > 0 THEN "usage"."ttft_ms" END) AS avg_ttft_ms,
+		SUM(CASE WHEN "usage"."failed" THEN 0 WHEN "usage"."latency_ms" > 0 AND "usage"."output_tokens" > 0 THEN "usage"."output_tokens" ELSE 0 END) AS throughput_output_tokens,
+		SUM(CASE WHEN "usage"."failed" THEN 0 WHEN "usage"."latency_ms" > 0 AND "usage"."output_tokens" > 0 THEN "usage"."latency_ms" ELSE 0 END) AS throughput_latency_ms,
+		MIN("usage"."timestamp") AS first_observed_at,
+		MAX("usage"."timestamp") AS last_observed_at`).
+		Group(`LOWER("usage"."model")`).
+		Scan(&rows).Error; errScan != nil {
+		return nil, errScan
+	}
+
+	summaries := make(map[string]ModelAvailabilitySummary, len(rows))
+	for i := range rows {
+		modelID := strings.TrimSpace(rows[i].Model)
+		key := strings.TrimSpace(rows[i].ModelKey)
+		if modelID == "" || key == "" {
+			continue
+		}
+		summary := ModelAvailabilitySummary{
+			ModelID:                modelID,
+			SampleCount:            rows[i].SampleCount,
+			SuccessCount:           optionalSQLInt64Value(rows[i].SuccessCount),
+			FailedCount:            optionalSQLInt64Value(rows[i].FailedCount),
+			ThroughputOutputTokens: optionalSQLInt64Value(rows[i].ThroughputOutputTokens),
+			ThroughputLatencyMS:    optionalSQLInt64Value(rows[i].ThroughputLatencyMS),
+		}
+		if rows[i].AvgLatencyMS.Valid {
+			value := rows[i].AvgLatencyMS.Float64
+			summary.AvgLatencyMS = &value
+		}
+		if rows[i].AvgTTFTMS.Valid {
+			value := rows[i].AvgTTFTMS.Float64
+			summary.AvgTTFTMS = &value
+		}
+		if rows[i].FirstObservedAt.Valid {
+			if value, ok := usageObservabilityAggregateTime(rows[i].FirstObservedAt.String); ok {
+				summary.FirstObservedAt = &value
+			}
+		}
+		if rows[i].LastObservedAt.Valid {
+			if value, ok := usageObservabilityAggregateTime(rows[i].LastObservedAt.String); ok {
+				summary.LastObservedAt = &value
+			}
+		}
+		summaries[key] = summary
+	}
+	return summaries, nil
+}

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -13,7 +13,14 @@
         "min": 1024,
         "max": 128000,
         "zero_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-sonnet-4-5-20250929",
@@ -28,7 +35,14 @@
         "min": 1024,
         "max": 128000,
         "zero_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-sonnet-4-6",
@@ -48,7 +62,14 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-opus-4-6",
@@ -70,7 +91,14 @@
           "high",
           "max"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-opus-4-7",
@@ -93,7 +121,14 @@
           "xhigh",
           "max"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-opus-4-5-20251101",
@@ -109,7 +144,14 @@
         "min": 1024,
         "max": 128000,
         "zero_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-opus-4-1-20250805",
@@ -123,7 +165,14 @@
       "thinking": {
         "min": 1024,
         "max": 128000
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-opus-4-20250514",
@@ -137,7 +186,14 @@
       "thinking": {
         "min": 1024,
         "max": 128000
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-sonnet-4-20250514",
@@ -151,7 +207,14 @@
       "thinking": {
         "min": 1024,
         "max": 128000
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-3-7-sonnet-20250219",
@@ -165,7 +228,14 @@
       "thinking": {
         "min": 1024,
         "max": 128000
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-3-5-haiku-20241022",
@@ -201,7 +271,16 @@
         "min": 128,
         "max": 32768,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-2.5-flash",
@@ -225,7 +304,16 @@
         "max": 24576,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-2.5-flash-lite",
@@ -249,7 +337,16 @@
         "max": 24576,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-preview",
@@ -277,7 +374,16 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-pro-preview",
@@ -306,7 +412,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-flash-image-preview",
@@ -334,7 +449,15 @@
           "minimal",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text",
+        "image"
+      ]
     },
     {
       "id": "gemini-3-flash-preview",
@@ -364,7 +487,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-flash-lite-preview",
@@ -392,7 +524,16 @@
           "minimal",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-image-preview",
@@ -420,7 +561,15 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text",
+        "image"
+      ]
     }
   ],
   "vertex": [
@@ -446,7 +595,16 @@
         "min": 128,
         "max": 32768,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-2.5-flash",
@@ -470,7 +628,16 @@
         "max": 24576,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-2.5-flash-lite",
@@ -494,7 +661,16 @@
         "max": 24576,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-preview",
@@ -522,7 +698,16 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-flash-preview",
@@ -552,7 +737,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-pro-preview",
@@ -581,7 +775,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-flash-image-preview",
@@ -609,7 +812,15 @@
           "minimal",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text",
+        "image"
+      ]
     },
     {
       "id": "gemini-3.1-flash-lite-preview",
@@ -639,7 +850,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-image-preview",
@@ -667,7 +887,15 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text",
+        "image"
+      ]
     },
     {
       "id": "imagen-4.0-generate-001",
@@ -681,6 +909,12 @@
       "description": "Imagen 4.0 image generation model",
       "supportedGenerationMethods": [
         "predict"
+      ],
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "image"
       ]
     },
     {
@@ -695,6 +929,12 @@
       "description": "Imagen 4.0 Ultra high-quality image generation model",
       "supportedGenerationMethods": [
         "predict"
+      ],
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "image"
       ]
     },
     {
@@ -709,6 +949,12 @@
       "description": "Imagen 3.0 image generation model",
       "supportedGenerationMethods": [
         "predict"
+      ],
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "image"
       ]
     },
     {
@@ -723,6 +969,12 @@
       "description": "Imagen 3.0 fast image generation model",
       "supportedGenerationMethods": [
         "predict"
+      ],
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "image"
       ]
     },
     {
@@ -737,6 +989,12 @@
       "description": "Imagen 4.0 fast image generation model",
       "supportedGenerationMethods": [
         "predict"
+      ],
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "image"
       ]
     }
   ],
@@ -763,7 +1021,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.3-codex",
@@ -809,7 +1074,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4-mini",
@@ -832,7 +1104,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.5",
@@ -855,7 +1134,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "codex-auto-review",
@@ -878,7 +1164,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "codex-team": [
@@ -904,7 +1197,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.3-codex",
@@ -950,7 +1250,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4-mini",
@@ -973,7 +1280,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.5",
@@ -996,7 +1310,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "codex-auto-review",
@@ -1019,7 +1340,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "codex-plus": [
@@ -1045,7 +1373,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.3-codex",
@@ -1091,7 +1426,13 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4",
@@ -1114,7 +1455,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4-mini",
@@ -1137,7 +1485,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.5",
@@ -1160,7 +1515,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "codex-auto-review",
@@ -1183,7 +1545,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "codex-pro": [
@@ -1209,7 +1578,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.3-codex",
@@ -1255,7 +1631,13 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4",
@@ -1278,7 +1660,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.4-mini",
@@ -1301,7 +1690,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-5.5",
@@ -1324,7 +1720,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "codex-auto-review",
@@ -1347,7 +1750,14 @@
           "high",
           "xhigh"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "kimi": [
@@ -1360,7 +1770,13 @@
       "display_name": "Kimi K2",
       "description": "Kimi K2 - Moonshot AI's flagship coding model",
       "context_length": 131072,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "kimi-k2-thinking",
@@ -1377,7 +1793,13 @@
         "max": 32000,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "kimi-k2.5",
@@ -1394,7 +1816,15 @@
         "max": 32000,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "kimi-k2.6",
@@ -1411,7 +1841,15 @@
         "max": 32000,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "antigravity": [
@@ -1430,7 +1868,14 @@
         "max": 64000,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "claude-sonnet-4-6",
@@ -1447,7 +1892,14 @@
         "max": 64000,
         "zero_allowed": true,
         "dynamic_allowed": true
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-flash",
@@ -1469,7 +1921,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-high",
@@ -1489,7 +1950,16 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3-pro-low",
@@ -1509,7 +1979,16 @@
           "low",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-flash-image",
@@ -1527,7 +2006,15 @@
           "minimal",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text",
+        "image"
+      ]
     },
     {
       "id": "gemini-3.1-pro-high",
@@ -1548,7 +2035,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-pro-low",
@@ -1569,7 +2065,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gpt-oss-120b-medium",
@@ -1580,7 +2085,13 @@
       "name": "gpt-oss-120b-medium",
       "description": "GPT-OSS 120B (Medium)",
       "context_length": 114000,
-      "max_completion_tokens": 32768
+      "max_completion_tokens": 32768,
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "gemini-3.1-flash-lite",
@@ -1603,7 +2114,16 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "xai": [
@@ -1626,7 +2146,14 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "grok-4.20-0309-reasoning",
@@ -1638,7 +2165,14 @@
       "name": "grok-4.20-0309-reasoning",
       "description": "xAI Grok 4.20 0309 reasoning model for the Responses API.",
       "context_length": 2000000,
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "grok-4.20-0309-non-reasoning",
@@ -1650,7 +2184,14 @@
       "name": "grok-4.20-0309-non-reasoning",
       "description": "xAI Grok 4.20 0309 non-reasoning model for the Responses API.",
       "context_length": 2000000,
-      "max_completion_tokens": 65536
+      "max_completion_tokens": 65536,
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "grok-4.20-multi-agent-0309",
@@ -1669,7 +2210,14 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text",
+        "image"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "grok-3-mini",
@@ -1688,7 +2236,13 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     },
     {
       "id": "grok-3-mini-fast",
@@ -1707,7 +2261,13 @@
           "medium",
           "high"
         ]
-      }
+      },
+      "supportedInputModalities": [
+        "text"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ]
 }

--- a/internal/userapi/capabilities.go
+++ b/internal/userapi/capabilities.go
@@ -1,0 +1,33 @@
+package userapi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/buildinfo"
+)
+
+// GetCapabilities reports optional User API features without exposing mail configuration.
+//
+// The manifest spans subsystems on purpose: a client reads it once at startup to
+// decide which surfaces to render, so every optional feature belongs here rather
+// than in whichever file happens to implement it.
+func (h *Handler) GetCapabilities(c *gin.Context) {
+	enabled := h.userEmailEnabled()
+	c.JSON(http.StatusOK, gin.H{
+		"capabilities": gin.H{
+			"email_registration": enabled,
+			"email_verification": enabled,
+			"password_recovery":  enabled,
+			// Advertised so a client can hide the catalog on an older Home
+			// instead of discovering the route is missing by calling it and
+			// handling a 404 as if it were an outage.
+			"model_catalog": true,
+		},
+		"server_info": gin.H{
+			"home_version":    buildinfo.Version,
+			"home_commit":     buildinfo.Commit,
+			"home_build_date": buildinfo.BuildDate,
+		},
+	})
+}

--- a/internal/userapi/capabilities_test.go
+++ b/internal/userapi/capabilities_test.go
@@ -1,0 +1,70 @@
+package userapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+)
+
+type userCapabilitiesPayload struct {
+	Capabilities struct {
+		EmailRegistration bool `json:"email_registration"`
+		EmailVerification bool `json:"email_verification"`
+		PasswordRecovery  bool `json:"password_recovery"`
+		ModelCatalog      bool `json:"model_catalog"`
+	} `json:"capabilities"`
+	ServerInfo struct {
+		HomeVersion   string `json:"home_version"`
+		HomeCommit    string `json:"home_commit"`
+		HomeBuildDate string `json:"home_build_date"`
+	} `json:"server_info"`
+}
+
+func TestUserCapabilitiesReflectUsableConfiguration(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*appconfig.Config)
+		enabled bool
+	}{
+		{name: "disabled", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.Enabled = false }, enabled: false},
+		{name: "invalid", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.FromAddress = "" }, enabled: false},
+		{name: "enabled", mutate: func(*appconfig.Config) {}, enabled: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, router, _ := newUserEmailTestHandler(t, test.mutate)
+			body := getUserCapabilities(t, router)
+			if body.Capabilities.EmailRegistration != test.enabled || body.Capabilities.EmailVerification != test.enabled || body.Capabilities.PasswordRecovery != test.enabled {
+				t.Fatalf("capabilities = %#v, want enabled=%v", body.Capabilities, test.enabled)
+			}
+			// The catalog is served from the model registry, so it stays
+			// advertised on a Home that cannot send mail at all.
+			if !body.Capabilities.ModelCatalog {
+				t.Errorf("model_catalog = false, want true")
+			}
+		})
+	}
+}
+
+func TestUserCapabilitiesReportBuildMetadata(t *testing.T) {
+	_, router, _ := newUserEmailTestHandler(t, nil)
+	info := getUserCapabilities(t, router).ServerInfo
+	if info.HomeVersion == "" || info.HomeCommit == "" || info.HomeBuildDate == "" {
+		t.Fatalf("server_info = %#v, want every field populated", info)
+	}
+}
+
+func getUserCapabilities(t *testing.T, router http.Handler) userCapabilitiesPayload {
+	t.Helper()
+	response := performUserJSONRequest(t, router, http.MethodGet, "/user/capabilities", nil, "")
+	if response.Code != http.StatusOK {
+		t.Fatalf("capabilities status = %d body=%s", response.Code, response.Body.String())
+	}
+	var body userCapabilitiesPayload
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("decode capabilities: %v", errDecode)
+	}
+	return body
+}

--- a/internal/userapi/email_recovery.go
+++ b/internal/userapi/email_recovery.go
@@ -79,6 +79,10 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 			"email_registration": enabled,
 			"email_verification": enabled,
 			"password_recovery":  enabled,
+			// Advertised so a client can hide the catalog on an older Home
+			// instead of discovering the route is missing by calling it and
+			// handling a 404 as if it were an outage.
+			"model_catalog": true,
 		},
 		"server_info": gin.H{
 			"home_version":    buildinfo.Version,

--- a/internal/userapi/email_recovery.go
+++ b/internal/userapi/email_recovery.go
@@ -12,7 +12,6 @@ import (
 	"unicode"
 
 	"github.com/gin-gonic/gin"
-	"github.com/router-for-me/CLIProxyAPIHome/internal/buildinfo"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/usermail"
 	log "github.com/sirupsen/logrus"
@@ -69,27 +68,6 @@ type passwordResetRequest struct {
 	Token           string `json:"token"`
 	NewPassword     string `json:"new_password"`
 	NewPasswordDash string `json:"new-password"`
-}
-
-// GetCapabilities reports optional User API features without exposing mail configuration.
-func (h *Handler) GetCapabilities(c *gin.Context) {
-	enabled := h.userEmailEnabled()
-	c.JSON(http.StatusOK, gin.H{
-		"capabilities": gin.H{
-			"email_registration": enabled,
-			"email_verification": enabled,
-			"password_recovery":  enabled,
-			// Advertised so a client can hide the catalog on an older Home
-			// instead of discovering the route is missing by calling it and
-			// handling a 404 as if it were an outage.
-			"model_catalog": true,
-		},
-		"server_info": gin.H{
-			"home_version":    buildinfo.Version,
-			"home_commit":     buildinfo.Commit,
-			"home_build_date": buildinfo.BuildDate,
-		},
-	})
 }
 
 // UpdateEmail adds or replaces the authenticated user's optional email.

--- a/internal/userapi/email_recovery_test.go
+++ b/internal/userapi/email_recovery_test.go
@@ -64,41 +64,6 @@ func TestRespondErrorDoesNotExposeInternalFailureDetails(t *testing.T) {
 	}
 }
 
-func TestUserCapabilitiesReflectUsableConfiguration(t *testing.T) {
-	tests := []struct {
-		name    string
-		mutate  func(*appconfig.Config)
-		enabled bool
-	}{
-		{name: "disabled", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.Enabled = false }, enabled: false},
-		{name: "invalid", mutate: func(cfg *appconfig.Config) { cfg.UserEmail.FromAddress = "" }, enabled: false},
-		{name: "enabled", mutate: func(*appconfig.Config) {}, enabled: true},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			handler, router, _ := newUserEmailTestHandler(t, test.mutate)
-			_ = handler
-			response := performUserJSONRequest(t, router, http.MethodGet, "/user/capabilities", nil, "")
-			if response.Code != http.StatusOK {
-				t.Fatalf("capabilities status = %d body=%s", response.Code, response.Body.String())
-			}
-			var body struct {
-				Capabilities struct {
-					EmailRegistration bool `json:"email_registration"`
-					EmailVerification bool `json:"email_verification"`
-					PasswordRecovery  bool `json:"password_recovery"`
-				} `json:"capabilities"`
-			}
-			if errDecode := json.Unmarshal(response.Body.Bytes(), &body); errDecode != nil {
-				t.Fatalf("decode capabilities: %v", errDecode)
-			}
-			if body.Capabilities.EmailRegistration != test.enabled || body.Capabilities.EmailVerification != test.enabled || body.Capabilities.PasswordRecovery != test.enabled {
-				t.Fatalf("capabilities = %#v, want enabled=%v", body.Capabilities, test.enabled)
-			}
-		})
-	}
-}
-
 func TestForgotPasswordResponsesDoNotEnumerateAccounts(t *testing.T) {
 	handler, router, db := newUserEmailTestHandler(t, nil)
 	ctx := context.Background()

--- a/internal/userapi/handler.go
+++ b/internal/userapi/handler.go
@@ -107,6 +107,9 @@ func Register(group *gin.RouterGroup, handler *Handler) {
 	group.POST("/login/totp", handler.LoginTOTP)
 	group.POST("/login/passkey", handler.LoginPasskey)
 
+	group.GET("/models", handler.ListModels)
+	group.GET("/models/accessible", handler.ListAccessibleModels)
+
 	group.GET("/me", handler.CurrentUser)
 	group.GET("/billing/overview", handler.CurrentUserBillingOverview)
 	group.GET("/billing/charges", handler.ListCurrentUserBillingCharges)

--- a/internal/userapi/model_availability.go
+++ b/internal/userapi/model_availability.go
@@ -1,0 +1,324 @@
+package userapi
+
+import (
+	"context"
+	"math"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// modelAvailabilityWindow is how far back an observation still counts. A
+	// week is long enough for a small cluster to accumulate a readable sample
+	// and short enough that a model which broke yesterday does not hide behind
+	// last month's successes.
+	modelAvailabilityWindow = 7 * 24 * time.Hour
+	// modelAvailabilityMinSamples is the point below which a rate is noise
+	// rather than a measurement. Two successful calls are not 100% uptime, and
+	// publishing them as such would be the most misleading thing this endpoint
+	// could do.
+	modelAvailabilityMinSamples = 10
+	// modelAvailabilityCacheTTL bounds how often the usage table is grouped by
+	// model. The table has no model-only index, so this scan is the expensive
+	// part of the response; the answer is cluster-wide rather than per-user, so
+	// one computation serves everyone asking within the window.
+	modelAvailabilityCacheTTL = 60 * time.Second
+	// modelAvailabilityQueryTimeout bounds the shared scan. It is longer than
+	// the per-request deadline on purpose: a waiter that gives up first still
+	// leaves the scan running, so the answer it could not wait for is in the
+	// cache by the time the next request asks.
+	modelAvailabilityQueryTimeout = 30 * time.Second
+)
+
+// Availability reporting states.
+const (
+	availabilityStatusObserved         = "observed"
+	availabilityStatusInsufficientData = "insufficient_data"
+)
+
+// modelAvailabilityCache memoizes the cluster-wide availability summary.
+//
+// The cached value is keyed only by the window because the underlying question
+// — how has this model behaved lately — has the same answer for every caller.
+// It holds no per-user data, so sharing it across sessions leaks nothing.
+var modelAvailabilityCache = struct {
+	mu        sync.Mutex
+	summaries map[string]cluster.ModelAvailabilitySummary
+	covered   map[string]struct{}
+	from      time.Time
+	to        time.Time
+	expiresAt time.Time
+}{}
+
+// modelAvailabilityFlight collapses concurrent recomputations into one.
+//
+// The cache alone does not do this. It is read before the scan and written
+// after it, so at the moment it expires every request in flight sees a miss and
+// starts its own copy of the same week-long scan — the load spike lands exactly
+// when the cache was supposed to be absorbing it.
+var modelAvailabilityFlight singleflight.Group
+
+// modelAvailabilityFlightKey is constant because every flight asks the same
+// question. The scan is widened to the whole servable catalog precisely so that
+// one answer serves every caller, which leaves nothing to key on.
+const modelAvailabilityFlightKey = "catalog"
+
+// modelAvailabilityWindowBounds is the summary a handler renders against.
+type modelAvailabilityWindowBounds struct {
+	From time.Time
+	To   time.Time
+}
+
+// modelAvailabilityResult is one computed answer: the summaries, the models the
+// query actually asked about, and the window it asked over. The three travel
+// together because reading any one of them against another computation's
+// results would misreport what was measured.
+type modelAvailabilityResult struct {
+	summaries map[string]cluster.ModelAvailabilitySummary
+	covered   map[string]struct{}
+	bounds    modelAvailabilityWindowBounds
+}
+
+// modelAvailabilityIndex returns the availability summary for the models being
+// listed, recomputing at most once per cache window.
+//
+// Coverage is tracked alongside the summary rather than assumed. A model absent
+// from the map is reported as having no observations, so answering for a model
+// the cached query never asked about would invent a silence that was never
+// measured; when that happens the summary is recomputed instead.
+func (h *Handler) modelAvailabilityIndex(ctx context.Context, modelIDs []string) (map[string]cluster.ModelAvailabilitySummary, modelAvailabilityWindowBounds, error) {
+	if cached, ok := cachedModelAvailability(time.Now().UTC(), modelIDs); ok {
+		return cached.summaries, cached.bounds, nil
+	}
+
+	shared := modelAvailabilityFlight.DoChan(modelAvailabilityFlightKey, func() (any, error) {
+		// Whoever queued behind the leader has already waited out a scan. Read
+		// the cache once more before starting another one: the answer they were
+		// waiting for may have been stored microseconds ago.
+		if cached, ok := cachedModelAvailability(time.Now().UTC(), modelIDs); ok {
+			return cached, nil
+		}
+		// The scan outlives the request that happened to start it. A buyer who
+		// navigates away must not cancel a computation every other waiter is
+		// blocked on, and the result is worth finishing even for an empty room
+		// because the next request will read it from the cache.
+		queryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), modelAvailabilityQueryTimeout)
+		defer cancel()
+		result, errRefresh := h.refreshModelAvailability(queryCtx, modelIDs)
+		if errRefresh != nil {
+			return nil, errRefresh
+		}
+		return result, nil
+	})
+
+	var result modelAvailabilityResult
+	select {
+	case <-ctx.Done():
+		// Waiting inside the flight is not covered by this caller's deadline,
+		// so it is enforced here. The scan continues without them.
+		return nil, modelAvailabilityWindowBounds{}, ctx.Err()
+	case outcome := <-shared:
+		if outcome.Err != nil {
+			return nil, modelAvailabilityWindowBounds{}, outcome.Err
+		}
+		result, _ = outcome.Val.(modelAvailabilityResult)
+	}
+
+	if modelAvailabilityCacheCovers(result.covered, modelIDs) {
+		return result.summaries, result.bounds, nil
+	}
+
+	// The shared answer was computed for a catalog registered a moment before
+	// this caller read its own, and is missing a model this caller is about to
+	// render. Borrowing it would report a model nobody asked about as one
+	// nobody observed, so this caller pays for its own scan instead.
+	own, errOwn := h.refreshModelAvailability(ctx, modelIDs)
+	if errOwn != nil {
+		return nil, modelAvailabilityWindowBounds{}, errOwn
+	}
+	return own.summaries, own.bounds, nil
+}
+
+// refreshModelAvailability recomputes the summary and memoizes it.
+func (h *Handler) refreshModelAvailability(ctx context.Context, modelIDs []string) (modelAvailabilityResult, error) {
+	now := time.Now().UTC()
+	bounds := modelAvailabilityWindowBounds{From: now.Add(-modelAvailabilityWindow), To: now}
+
+	// The query covers the whole servable catalog rather than this caller's
+	// slice of it. The answer is the same for everyone, and widening it here is
+	// what lets one computation serve every buyer within the cache window.
+	wanted := modelAvailabilityCatalogIDs(modelIDs)
+	summaries, errSummaries := h.repo.ListModelAvailability(ctx, cluster.ModelAvailabilityQuery{
+		ModelIDs:    wanted,
+		From:        bounds.From,
+		ToExclusive: bounds.To,
+	})
+	if errSummaries != nil {
+		return modelAvailabilityResult{}, errSummaries
+	}
+
+	covered := make(map[string]struct{}, len(wanted))
+	for _, modelID := range wanted {
+		covered[strings.ToLower(strings.TrimSpace(modelID))] = struct{}{}
+	}
+
+	modelAvailabilityCache.mu.Lock()
+	modelAvailabilityCache.summaries = summaries
+	modelAvailabilityCache.covered = covered
+	modelAvailabilityCache.from = bounds.From
+	modelAvailabilityCache.to = bounds.To
+	modelAvailabilityCache.expiresAt = now.Add(modelAvailabilityCacheTTL)
+	modelAvailabilityCache.mu.Unlock()
+
+	return modelAvailabilityResult{summaries: summaries, covered: covered, bounds: bounds}, nil
+}
+
+// cachedModelAvailability returns the memoized summary when it is both fresh and
+// known to have asked about every model the caller is going to render.
+func cachedModelAvailability(now time.Time, modelIDs []string) (modelAvailabilityResult, bool) {
+	modelAvailabilityCache.mu.Lock()
+	defer modelAvailabilityCache.mu.Unlock()
+
+	if modelAvailabilityCache.summaries == nil || !now.Before(modelAvailabilityCache.expiresAt) {
+		return modelAvailabilityResult{}, false
+	}
+	if !modelAvailabilityCacheCovers(modelAvailabilityCache.covered, modelIDs) {
+		return modelAvailabilityResult{}, false
+	}
+	return modelAvailabilityResult{
+		summaries: modelAvailabilityCache.summaries,
+		covered:   modelAvailabilityCache.covered,
+		bounds:    modelAvailabilityWindowBounds{From: modelAvailabilityCache.from, To: modelAvailabilityCache.to},
+	}, true
+}
+
+// modelAvailabilityCatalogIDs widens the requested models to the full servable
+// catalog, so a cache filled by a narrowly-scoped buyer still answers for the
+// next one.
+func modelAvailabilityCatalogIDs(modelIDs []string) []string {
+	seen := make(map[string]struct{}, len(modelIDs))
+	wanted := make([]string, 0, len(modelIDs))
+	appendID := func(modelID string) {
+		trimmed := strings.TrimSpace(modelID)
+		if trimmed == "" {
+			return
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		wanted = append(wanted, trimmed)
+	}
+	for _, model := range availableUserModels() {
+		appendID(model.ID)
+	}
+	for _, modelID := range modelIDs {
+		appendID(modelID)
+	}
+	return wanted
+}
+
+// modelAvailabilityCacheCovers reports whether every requested model was part of
+// the query that produced the cached summary.
+func modelAvailabilityCacheCovers(covered map[string]struct{}, modelIDs []string) bool {
+	for _, modelID := range modelIDs {
+		key := strings.ToLower(strings.TrimSpace(modelID))
+		if key == "" {
+			continue
+		}
+		if _, ok := covered[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// resetModelAvailabilityCache clears the memoized summary. Tests that seed usage
+// records need each case to see its own data rather than the previous case's.
+func resetModelAvailabilityCache() {
+	modelAvailabilityCache.mu.Lock()
+	modelAvailabilityCache.summaries = nil
+	modelAvailabilityCache.covered = nil
+	modelAvailabilityCache.expiresAt = time.Time{}
+	modelAvailabilityCache.mu.Unlock()
+}
+
+// modelAvailabilityResponse renders one model's observed behaviour.
+//
+// The window is always reported, even when nothing was observed in it, because
+// "no failures" and "no observations" look identical without it. A sample below
+// the threshold reports its size and its window and nothing else: no rate, no
+// latency, no throughput, because none of those numbers mean anything yet.
+func modelAvailabilityResponse(summary cluster.ModelAvailabilitySummary, found bool, bounds modelAvailabilityWindowBounds) gin.H {
+	window := gin.H{
+		"from":        bounds.From.UTC().Format(time.RFC3339),
+		"to":          bounds.To.UTC().Format(time.RFC3339),
+		"hours":       int(modelAvailabilityWindow / time.Hour),
+		"min_samples": modelAvailabilityMinSamples,
+	}
+	payload := gin.H{
+		"window":       window,
+		"sample_count": summary.SampleCount,
+	}
+	if !found || summary.SampleCount < modelAvailabilityMinSamples {
+		payload["status"] = availabilityStatusInsufficientData
+		if !found {
+			payload["sample_count"] = int64(0)
+			return payload
+		}
+		// Even an undersized sample has a most recent observation, and knowing
+		// the model answered an hour ago is useful on its own.
+		if summary.LastObservedAt != nil {
+			payload["last_observed_at"] = summary.LastObservedAt.UTC().Format(time.RFC3339)
+		}
+		return payload
+	}
+
+	payload["status"] = availabilityStatusObserved
+	payload["success_count"] = summary.SuccessCount
+	payload["failed_count"] = summary.FailedCount
+	payload["availability_rate"] = roundTo(float64(summary.SuccessCount)/float64(summary.SampleCount), 4)
+	if summary.FirstObservedAt != nil {
+		payload["first_observed_at"] = summary.FirstObservedAt.UTC().Format(time.RFC3339)
+	}
+	if summary.LastObservedAt != nil {
+		payload["last_observed_at"] = summary.LastObservedAt.UTC().Format(time.RFC3339)
+	}
+	if summary.AvgLatencyMS != nil {
+		payload["avg_latency_ms"] = roundTo(*summary.AvgLatencyMS, 1)
+	}
+	// Time to first token only exists for streamed responses. Its absence next
+	// to a present latency is information, not an error.
+	if summary.AvgTTFTMS != nil {
+		payload["avg_ttft_ms"] = roundTo(*summary.AvgTTFTMS, 1)
+	}
+	// Throughput is total tokens produced over total time spent producing them,
+	// which weights long generations more heavily than short ones — the same
+	// way a buyer experiences the model.
+	if summary.ThroughputLatencyMS > 0 && summary.ThroughputOutputTokens > 0 {
+		payload["output_tokens_per_second"] = roundTo(float64(summary.ThroughputOutputTokens)*1000/float64(summary.ThroughputLatencyMS), 2)
+	}
+	return payload
+}
+
+// availabilityFor looks a model up in the summary index.
+func availabilityFor(index map[string]cluster.ModelAvailabilitySummary, modelID string, bounds modelAvailabilityWindowBounds) gin.H {
+	summary, found := index[strings.ToLower(strings.TrimSpace(modelID))]
+	return modelAvailabilityResponse(summary, found, bounds)
+}
+
+// roundTo trims a computed float to the precision the number actually carries,
+// so a rate does not arrive as 0.9333333333333333.
+func roundTo(value float64, decimals int) float64 {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0
+	}
+	scale := math.Pow(10, float64(decimals))
+	return math.Round(value*scale) / scale
+}

--- a/internal/userapi/model_pricing.go
+++ b/internal/userapi/model_pricing.go
@@ -1,0 +1,171 @@
+package userapi
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+)
+
+// Pricing publication states. Price is not a scalar and its absence is not zero:
+// a model with no enabled rule cannot be charged for, which means it cannot be
+// sold, and reporting that as a price of 0 would advertise it as free.
+const (
+	pricingStatusPublished   = "published"
+	pricingStatusUnpublished = "unpublished"
+)
+
+// modelPriceIndex groups enabled price rules by lower-cased model identifier so
+// a catalog of any size costs one query rather than one query per model.
+type modelPriceIndex map[string][]cluster.BillingModelPriceRecord
+
+// newModelPriceIndex buckets price records by model.
+func newModelPriceIndex(records []cluster.BillingModelPriceRecord) modelPriceIndex {
+	if len(records) == 0 {
+		return modelPriceIndex{}
+	}
+	index := make(modelPriceIndex, len(records))
+	for i := range records {
+		key := strings.ToLower(strings.TrimSpace(records[i].Model))
+		if key == "" {
+			continue
+		}
+		index[key] = append(index[key], records[i])
+	}
+	return index
+}
+
+// pricingFor builds the price ladder a buyer sees for one model.
+//
+// Only the providers that can actually serve the model are priced. A rule for
+// some other provider may exist in the table — operators keep rules for channels
+// they have since removed — and quoting it would promise a route the cluster
+// cannot take. A model whose serving channels are unknown is therefore reported
+// as unpublished, not as priced by everything.
+func (index modelPriceIndex) pricingFor(modelID string, providers []string) gin.H {
+	records := index[strings.ToLower(strings.TrimSpace(modelID))]
+	if len(records) == 0 {
+		return gin.H{"status": pricingStatusUnpublished}
+	}
+
+	servable := make(map[string]struct{}, len(providers))
+	for _, provider := range providers {
+		normalized := strings.ToLower(strings.TrimSpace(provider))
+		if normalized == "" {
+			continue
+		}
+		servable[normalized] = struct{}{}
+	}
+	if len(servable) == 0 {
+		// Knowing of no channel that can serve the model is not the same as
+		// being free to quote every channel in the table. It is the case where
+		// the filter matters most: nothing here can be confirmed to name the
+		// route a request would actually take, so nothing is quoted.
+		return gin.H{"status": pricingStatusUnpublished}
+	}
+
+	// provider -> service tier -> rungs, preserving first-seen order so the
+	// repository's ordering survives into the response.
+	type tierLadder struct {
+		tier  string
+		rungs []cluster.BillingModelPriceRecord
+	}
+	providerOrder := make([]string, 0, len(records))
+	tiersByProvider := make(map[string][]*tierLadder, len(records))
+
+	for i := range records {
+		provider := strings.ToLower(strings.TrimSpace(records[i].Provider))
+		if provider == "" {
+			continue
+		}
+		if _, ok := servable[provider]; !ok {
+			continue
+		}
+		tier := strings.TrimSpace(records[i].ServiceTier)
+		if tier == "" {
+			tier = cluster.BillingServiceTierWildcard
+		}
+
+		ladders, known := tiersByProvider[provider]
+		if !known {
+			providerOrder = append(providerOrder, provider)
+		}
+		var target *tierLadder
+		for _, ladder := range ladders {
+			if ladder.tier == tier {
+				target = ladder
+				break
+			}
+		}
+		if target == nil {
+			target = &tierLadder{tier: tier}
+			ladders = append(ladders, target)
+			tiersByProvider[provider] = ladders
+		}
+		target.rungs = append(target.rungs, records[i])
+	}
+
+	if len(providerOrder) == 0 {
+		return gin.H{"status": pricingStatusUnpublished}
+	}
+	sort.Strings(providerOrder)
+
+	providerPayloads := make([]gin.H, 0, len(providerOrder))
+	for _, provider := range providerOrder {
+		ladders := tiersByProvider[provider]
+		tierPayloads := make([]gin.H, 0, len(ladders))
+		for _, ladder := range ladders {
+			// Rungs ascend by the input size that unlocks them, which is the
+			// order a request climbs them: the last rung whose threshold the
+			// request clears is the one that prices it.
+			sort.SliceStable(ladder.rungs, func(a, b int) bool {
+				return ladder.rungs[a].MinInputTokens < ladder.rungs[b].MinInputTokens
+			})
+			rungPayloads := make([]gin.H, 0, len(ladder.rungs))
+			for i := range ladder.rungs {
+				rungPayloads = append(rungPayloads, modelPriceRungResponse(ladder.rungs[i]))
+			}
+			tierPayload := gin.H{
+				"service_tier": ladder.tier,
+				"rungs":        rungPayloads,
+			}
+			// The wildcard tier is what a request gets when it names no tier or
+			// names one nobody priced, so a client can label it as the default
+			// instead of showing "*" to a buyer.
+			if ladder.tier == cluster.BillingServiceTierWildcard {
+				tierPayload["is_default"] = true
+			}
+			tierPayloads = append(tierPayloads, tierPayload)
+		}
+		providerPayloads = append(providerPayloads, gin.H{
+			"provider": provider,
+			"tiers":    tierPayloads,
+		})
+	}
+
+	return gin.H{
+		"status":    pricingStatusPublished,
+		"providers": providerPayloads,
+	}
+}
+
+// modelPriceRungResponse renders one rung of the ladder. Prices are per million
+// tokens, matching how the rules are stored and charged; a zero component is
+// emitted rather than omitted because zero is a real price here — a provider
+// that does not bill for cache reads has stated that, and dropping the field
+// would make it indistinguishable from a component nobody priced.
+//
+// The rule's own identifier, source and note stay behind: they are operator
+// bookkeeping about how a price came to exist, not part of the quote, and the
+// user contract puts them out of bounds.
+func modelPriceRungResponse(record cluster.BillingModelPriceRecord) gin.H {
+	return gin.H{
+		"min_input_tokens":              record.MinInputTokens,
+		"input_price_per_million":       record.InputPricePerMillion,
+		"output_price_per_million":      record.OutputPricePerMillion,
+		"cache_read_price_per_million":  record.CacheReadPricePerMillion,
+		"cache_write_price_per_million": record.CacheWritePricePerMillion,
+		"request_price":                 record.RequestPrice,
+	}
+}

--- a/internal/userapi/models.go
+++ b/internal/userapi/models.go
@@ -1,0 +1,428 @@
+package userapi
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
+)
+
+// Modality reporting states. A buyer deciding whether a model can read an image
+// must be able to tell "this model does not accept images" apart from "nobody
+// told us what this model accepts"; collapsing the two into an empty list would
+// quietly present the second as the first.
+const (
+	modalityStatusKnown   = "known"
+	modalityStatusUnknown = "unknown"
+)
+
+// Capability reporting states, carrying the same three-way distinction as
+// modalities: stated support, stated absence, and silence.
+const (
+	capabilityStatusSupported   = "supported"
+	capabilityStatusUnsupported = "unsupported"
+	capabilityStatusUnknown     = "unknown"
+)
+
+// toolCallingParameterNames are the parameter spellings that mean a model can be
+// driven with tool definitions. Providers disagree on the name, so membership is
+// checked against every spelling the catalog actually uses.
+var toolCallingParameterNames = map[string]struct{}{
+	"tools":         {},
+	"tool_choice":   {},
+	"functions":     {},
+	"function_call": {},
+}
+
+// reasoningParameterNames are the parameter spellings that mean a model exposes
+// internal reasoning. They are only consulted when the model carries no thinking
+// budget definition, which is the stronger signal.
+var reasoningParameterNames = map[string]struct{}{
+	"reasoning":         {},
+	"reasoning_effort":  {},
+	"include_reasoning": {},
+	"thinking":          {},
+}
+
+// structuredOutputParameterNames are the parameter spellings that mean a model
+// can be constrained to a caller-supplied schema. Like tool calling, this is
+// resolved server-side: a client that inferred it from the parameter list would
+// be synthesising a capability claim the cluster never made.
+var structuredOutputParameterNames = map[string]struct{}{
+	"response_format":    {},
+	"structured_outputs": {},
+	"json_schema":        {},
+	"json_mode":          {},
+	"response_schema":    {},
+}
+
+// Reasons a buyer's accessible catalog looks the way it does. The list being
+// empty is never self-explanatory, and a console that cannot say why would leave
+// the buyer guessing whether the cluster is empty or their key is narrow.
+const (
+	modelAccessReasonUnrestricted = "unrestricted"
+	modelAccessReasonModelGroups  = "model_groups"
+	modelAccessReasonNoAPIKeys    = "no_api_keys"
+)
+
+// ListModels returns the public model catalog: every model the cluster can
+// currently serve, described in buyer terms.
+//
+// The route is unauthenticated on purpose — a visitor has to see what is on
+// offer before deciding to hold an account — and it is deliberately narrower
+// than the signed-in view. Prices and observed performance are withheld here,
+// not because they are secret in principle but because they are the operator's
+// commercial terms with a specific buyer; the visitor sees capability, the
+// account holder sees the offer. Nothing here exposes the registry's internal
+// registration shape, so credentials, auth identifiers and per-client counts
+// stay out of reach.
+func (h *Handler) ListModels(c *gin.Context) {
+	models := availableUserModels()
+
+	items := make([]gin.H, 0, len(models))
+	for _, model := range models {
+		items = append(items, userModelResponse(model, nil))
+	}
+
+	c.JSON(http.StatusOK, gin.H{"models": items, "total": len(items)})
+}
+
+// ListAccessibleModels returns the subset of the catalog the caller's own API
+// keys are allowed to call.
+//
+// It is deliberately separate from the public catalog rather than a query
+// parameter on it: the two answer different questions ("what does this cluster
+// sell" versus "what can I call today"), and only one of them may be answered
+// without a token.
+func (h *Handler) ListAccessibleModels(c *gin.Context) {
+	ctx, cancel := requestContext(c)
+	defer cancel()
+
+	user, ok := h.authenticatedUser(c, ctx, authFields{})
+	if !ok {
+		return
+	}
+
+	access, errAccess := h.repo.UserModelAccess(ctx, user.ID)
+	if errAccess != nil {
+		respondError(c, http.StatusInternalServerError, "model_access_load_failed", errAccess)
+		return
+	}
+
+	models := filterModelsForAccess(availableUserModels(), access)
+	modelIDs := make([]string, 0, len(models))
+	for _, model := range models {
+		modelIDs = append(modelIDs, model.ID)
+	}
+
+	prices, errPrices := h.modelPriceIndex(ctx, modelIDs)
+	if errPrices != nil {
+		respondError(c, http.StatusInternalServerError, "model_price_load_failed", errPrices)
+		return
+	}
+
+	availability, bounds, errAvailability := h.modelAvailabilityIndex(ctx, modelIDs)
+	if errAvailability != nil {
+		respondError(c, http.StatusInternalServerError, "model_availability_load_failed", errAvailability)
+		return
+	}
+
+	items := make([]gin.H, 0, len(models))
+	for _, model := range models {
+		item := userModelResponse(model, prices)
+		item["availability"] = availabilityFor(availability, model.ID, bounds)
+		items = append(items, item)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"models": items,
+		"total":  len(items),
+		"access": gin.H{
+			"restricted":    access.Restricted,
+			"api_key_count": access.APIKeyCount,
+			"reason":        modelAccessReason(access),
+		},
+	})
+}
+
+// availableUserModels returns the registry's currently servable definitions with
+// the unusable entries dropped, so every caller starts from the same list.
+func availableUserModels() []*registry.ModelInfo {
+	definitions := registry.GetGlobalRegistry().GetAvailableModelDefinitions()
+	models := make([]*registry.ModelInfo, 0, len(definitions))
+	for _, model := range definitions {
+		if model == nil || strings.TrimSpace(model.ID) == "" {
+			continue
+		}
+		models = append(models, model)
+	}
+	return models
+}
+
+// filterModelsForAccess narrows the catalog to what the user's keys allow.
+// Holding no key allows nothing: an account without a credential cannot call
+// the cluster, and listing the full catalog as "accessible" would say otherwise.
+func filterModelsForAccess(models []*registry.ModelInfo, access cluster.UserModelAccess) []*registry.ModelInfo {
+	if !access.Restricted {
+		return models
+	}
+	if access.APIKeyCount == 0 || len(access.ModelIDs) == 0 {
+		return nil
+	}
+
+	allowed := make(map[string]struct{}, len(access.ModelIDs))
+	for _, modelID := range access.ModelIDs {
+		key := strings.ToLower(strings.TrimSpace(coreauth.CanonicalModelID(modelID)))
+		if key == "" {
+			continue
+		}
+		allowed[key] = struct{}{}
+	}
+
+	filtered := make([]*registry.ModelInfo, 0, len(models))
+	for _, model := range models {
+		// Model groups store canonical identifiers, so the registry identifier
+		// is canonicalised too rather than compared raw; otherwise a suffixed
+		// registration would never match the group that permits it.
+		key := strings.ToLower(strings.TrimSpace(coreauth.CanonicalModelID(model.ID)))
+		if _, ok := allowed[key]; !ok {
+			continue
+		}
+		filtered = append(filtered, model)
+	}
+	return filtered
+}
+
+// modelAccessReason names why the accessible catalog has the shape it has.
+func modelAccessReason(access cluster.UserModelAccess) string {
+	if !access.Restricted {
+		return modelAccessReasonUnrestricted
+	}
+	if access.APIKeyCount == 0 {
+		return modelAccessReasonNoAPIKeys
+	}
+	return modelAccessReasonModelGroups
+}
+
+// modelPriceIndex loads the enabled price rules for exactly the models being
+// returned, in one query.
+func (h *Handler) modelPriceIndex(ctx context.Context, modelIDs []string) (modelPriceIndex, error) {
+	if len(modelIDs) == 0 {
+		return modelPriceIndex{}, nil
+	}
+	records, errRecords := h.repo.ListEnabledBillingModelPricesForModels(ctx, modelIDs)
+	if errRecords != nil {
+		return nil, errRecords
+	}
+	return newModelPriceIndex(records), nil
+}
+
+// userModelResponse redacts a registry definition into the buyer-facing shape.
+// Fields the registry never learned are omitted rather than zero-filled: a
+// missing context window is unknown, not a context window of zero.
+func userModelResponse(model *registry.ModelInfo, prices modelPriceIndex) gin.H {
+	providers := copyNonEmptyStrings(model.Providers)
+	entry := gin.H{
+		"id":           strings.TrimSpace(model.ID),
+		"modalities":   userModelModalities(model),
+		"capabilities": userModelCapabilities(model),
+	}
+	// A nil index means the caller is not entitled to pricing at all, which is
+	// not the same as a model nobody priced. The key is absent rather than
+	// present-and-unpublished so the two never blur together.
+	if prices != nil {
+		entry["pricing"] = prices.pricingFor(model.ID, providers)
+	}
+	if displayName := strings.TrimSpace(model.DisplayName); displayName != "" {
+		entry["display_name"] = displayName
+	}
+	if description := strings.TrimSpace(model.Description); description != "" {
+		entry["description"] = description
+	}
+	if version := strings.TrimSpace(model.Version); version != "" {
+		entry["version"] = version
+	}
+	if ownedBy := strings.TrimSpace(model.OwnedBy); ownedBy != "" {
+		entry["owned_by"] = ownedBy
+	}
+	if modelType := strings.TrimSpace(model.Type); modelType != "" {
+		entry["type"] = modelType
+	}
+	// Providers are the identifiers that appear on usage records and billing
+	// rules, which makes them the only key a client can use to line a model up
+	// with what it will be charged for.
+	if len(providers) > 0 {
+		entry["providers"] = providers
+	}
+	if contextLength := userModelContextLength(model); contextLength > 0 {
+		entry["context_length"] = contextLength
+	}
+	if maxOutputTokens := userModelMaxOutputTokens(model); maxOutputTokens > 0 {
+		entry["max_output_tokens"] = maxOutputTokens
+	}
+	return entry
+}
+
+// userModelContextLength collapses the two limit spellings the shared catalog
+// uses. OpenAI-shaped entries carry context_length; Gemini-shaped entries carry
+// inputTokenLimit. Clients should not have to know which family a model is from.
+func userModelContextLength(model *registry.ModelInfo) int {
+	if model.ContextLength > 0 {
+		return model.ContextLength
+	}
+	return model.InputTokenLimit
+}
+
+// userModelMaxOutputTokens is the output-side counterpart to
+// userModelContextLength: max_completion_tokens and outputTokenLimit name the
+// same limit.
+func userModelMaxOutputTokens(model *registry.ModelInfo) int {
+	if model.MaxCompletionTokens > 0 {
+		return model.MaxCompletionTokens
+	}
+	return model.OutputTokenLimit
+}
+
+// userModelModalities reports what the model accepts and produces. An empty pair
+// is reported as explicitly unknown so a client can say "not published" instead
+// of rendering a text-only model that may well accept images.
+//
+// The values originate in the hand-maintained model catalog, so they are
+// normalized here rather than trusted verbatim: a stray "TEXT" or a duplicated
+// entry is an editing slip in a JSON file, not a fact worth showing a buyer.
+func userModelModalities(model *registry.ModelInfo) gin.H {
+	input := normalizeModalities(model.SupportedInputModalities)
+	output := normalizeModalities(model.SupportedOutputModalities)
+	if len(input) == 0 && len(output) == 0 {
+		return gin.H{"status": modalityStatusUnknown}
+	}
+
+	payload := gin.H{"status": modalityStatusKnown}
+	if len(input) > 0 {
+		payload["input"] = input
+	}
+	if len(output) > 0 {
+		payload["output"] = output
+	}
+	return payload
+}
+
+// normalizeModalities lower-cases and de-duplicates catalog modality values
+// while preserving the order the catalog listed them in, so the primary modality
+// stays first. It never adds a modality the catalog did not state.
+func normalizeModalities(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		modality := strings.ToLower(strings.TrimSpace(value))
+		if modality == "" {
+			continue
+		}
+		if _, exists := seen[modality]; exists {
+			continue
+		}
+		seen[modality] = struct{}{}
+		normalized = append(normalized, modality)
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+// userModelCapabilities reports the non-modality capabilities a buyer selects on.
+func userModelCapabilities(model *registry.ModelInfo) gin.H {
+	payload := gin.H{
+		"reasoning":         userModelReasoning(model),
+		"tool_calling":      gin.H{"status": parameterCapabilityStatus(model.SupportedParameters, toolCallingParameterNames)},
+		"structured_output": gin.H{"status": parameterCapabilityStatus(model.SupportedParameters, structuredOutputParameterNames)},
+	}
+	if parameters := copyNonEmptyStrings(model.SupportedParameters); len(parameters) > 0 {
+		payload["parameters"] = parameters
+	}
+	if methods := copyNonEmptyStrings(model.SupportedGenerationMethods); len(methods) > 0 {
+		payload["generation_methods"] = methods
+	}
+	return payload
+}
+
+// userModelReasoning describes internal reasoning support. A declared thinking
+// budget is proof of support and carries the range a caller may request; without
+// one the parameter list is the only remaining evidence.
+func userModelReasoning(model *registry.ModelInfo) gin.H {
+	if model.Thinking == nil {
+		return gin.H{"status": parameterCapabilityStatus(model.SupportedParameters, reasoningParameterNames)}
+	}
+
+	payload := gin.H{"status": capabilityStatusSupported}
+	if levels := copyNonEmptyStrings(model.Thinking.Levels); len(levels) > 0 {
+		payload["levels"] = levels
+	}
+	budget := gin.H{}
+	if model.Thinking.Min > 0 {
+		budget["min"] = model.Thinking.Min
+	}
+	if model.Thinking.Max > 0 {
+		budget["max"] = model.Thinking.Max
+	}
+	if model.Thinking.ZeroAllowed {
+		budget["can_disable"] = true
+	}
+	if model.Thinking.DynamicAllowed {
+		budget["dynamic"] = true
+	}
+	if len(budget) > 0 {
+		payload["budget"] = budget
+	}
+	return payload
+}
+
+// parameterCapabilityStatus reads a capability off the model's parameter list.
+// A model that publishes parameters and omits the capability has said no; a
+// model that publishes no parameters at all has said nothing, and the difference
+// is preserved rather than resolved by guessing.
+func parameterCapabilityStatus(parameters []string, names map[string]struct{}) string {
+	stated := false
+	for _, parameter := range parameters {
+		normalized := strings.ToLower(strings.TrimSpace(parameter))
+		if normalized == "" {
+			continue
+		}
+		stated = true
+		if _, ok := names[normalized]; ok {
+			return capabilityStatusSupported
+		}
+	}
+	if !stated {
+		return capabilityStatusUnknown
+	}
+	return capabilityStatusUnsupported
+}
+
+// copyNonEmptyStrings returns a defensive copy with blanks dropped, so a
+// response never shares backing storage with the live registry and never carries
+// an empty string a client would have to filter out itself.
+func copyNonEmptyStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	copied := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		copied = append(copied, trimmed)
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}

--- a/internal/userapi/models_test.go
+++ b/internal/userapi/models_test.go
@@ -1,0 +1,846 @@
+package userapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
+)
+
+// The model registry is process-wide, so these tests register into it and clean
+// up after themselves rather than running in parallel. Sharing it across
+// parallel tests would let one case observe another's catalog.
+
+func TestPublicModelCatalogWithholdsPriceAndAvailability(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+	seedUserModelPrices(t, handler)
+	seedUserModelUsage(t, handler, "gpt-4.1-mini", "catalog-client-key", 12, 0)
+
+	payload := getUserModels(t, handler.ListModels, "/models", "")
+
+	if payload.Total != len(payload.Models) {
+		t.Fatalf("total = %d, want %d", payload.Total, len(payload.Models))
+	}
+	if len(payload.Models) < 3 {
+		t.Fatalf("models = %d, want the full registered catalog", len(payload.Models))
+	}
+	for _, model := range payload.Models {
+		if model.Pricing != nil {
+			t.Errorf("model %s exposes pricing to an anonymous visitor", model.ID)
+		}
+		if model.Availability != nil {
+			t.Errorf("model %s exposes availability to an anonymous visitor", model.ID)
+		}
+	}
+}
+
+func TestPublicModelCatalogReportsUnknownModalitiesAndCapabilities(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+
+	models := indexUserModelsByID(getUserModels(t, handler.ListModels, "/models", "").Models)
+
+	described, ok := models["gpt-4.1-mini"]
+	if !ok {
+		t.Fatalf("gpt-4.1-mini missing from catalog")
+	}
+	if described.Modalities.Status != modalityStatusKnown {
+		t.Errorf("described modality status = %q, want %q", described.Modalities.Status, modalityStatusKnown)
+	}
+	// Hand-maintained catalog values are normalized before a buyer sees them:
+	// lower-cased, trimmed and de-duplicated, with catalog order preserved so the
+	// primary modality stays first.
+	if got := strings.Join(described.Modalities.Input, ","); got != "text,image" {
+		t.Errorf("described input modalities = %q, want %q", got, "text,image")
+	}
+	if got := strings.Join(described.Modalities.Output, ","); got != "text" {
+		t.Errorf("described output modalities = %q, want %q", got, "text")
+	}
+	if described.Capabilities.ToolCalling.Status != capabilityStatusSupported {
+		t.Errorf("described tool calling = %q, want %q", described.Capabilities.ToolCalling.Status, capabilityStatusSupported)
+	}
+	if described.Capabilities.StructuredOutput.Status != capabilityStatusSupported {
+		t.Errorf("described structured output = %q, want %q", described.Capabilities.StructuredOutput.Status, capabilityStatusSupported)
+	}
+	if described.ContextLength != 128000 {
+		t.Errorf("described context length = %d, want 128000", described.ContextLength)
+	}
+	if described.MaxOutputTokens != 16384 {
+		t.Errorf("described max output = %d, want 16384", described.MaxOutputTokens)
+	}
+
+	// The whole point of the tri-state: a model nobody described must not be
+	// rendered as a text-only model with no tool support.
+	silent, ok := models["mystery-model"]
+	if !ok {
+		t.Fatalf("mystery-model missing from catalog")
+	}
+	if silent.Modalities.Status != modalityStatusUnknown {
+		t.Errorf("silent modality status = %q, want %q", silent.Modalities.Status, modalityStatusUnknown)
+	}
+	if len(silent.Modalities.Input) != 0 || len(silent.Modalities.Output) != 0 {
+		t.Errorf("silent modalities = %+v, want empty", silent.Modalities)
+	}
+	if silent.Capabilities.ToolCalling.Status != capabilityStatusUnknown {
+		t.Errorf("silent tool calling = %q, want %q", silent.Capabilities.ToolCalling.Status, capabilityStatusUnknown)
+	}
+	if silent.Capabilities.Reasoning.Status != capabilityStatusUnknown {
+		t.Errorf("silent reasoning = %q, want %q", silent.Capabilities.Reasoning.Status, capabilityStatusUnknown)
+	}
+	if silent.Capabilities.StructuredOutput.Status != capabilityStatusUnknown {
+		t.Errorf("silent structured output = %q, want %q", silent.Capabilities.StructuredOutput.Status, capabilityStatusUnknown)
+	}
+	if silent.ContextLength != 0 {
+		t.Errorf("silent context length = %d, want the field omitted", silent.ContextLength)
+	}
+
+	// A model that publishes parameters and omits tools has said no.
+	stated, ok := models["text-only-model"]
+	if !ok {
+		t.Fatalf("text-only-model missing from catalog")
+	}
+	if stated.Capabilities.ToolCalling.Status != capabilityStatusUnsupported {
+		t.Errorf("stated tool calling = %q, want %q", stated.Capabilities.ToolCalling.Status, capabilityStatusUnsupported)
+	}
+	if stated.Capabilities.StructuredOutput.Status != capabilityStatusUnsupported {
+		t.Errorf("stated structured output = %q, want %q", stated.Capabilities.StructuredOutput.Status, capabilityStatusUnsupported)
+	}
+	if stated.Modalities.Status != modalityStatusKnown {
+		t.Errorf("stated modality status = %q, want %q", stated.Modalities.Status, modalityStatusKnown)
+	}
+}
+
+func TestAccessibleModelsRequireAuthentication(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/models/accessible", nil)
+	handler.ListAccessibleModels(ctx)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d body=%s, want 401", resp.Code, resp.Body.String())
+	}
+}
+
+func TestAccessibleModelsHonorModelGroupRestriction(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+
+	restrictedUser := createUserModelTestUser(t, handler, "restricted-user")
+	group := createUserModelGroup(t, handler, "cheap-tier", "gpt-4.1-mini")
+	createUserModelAPIKey(t, handler, restrictedUser.ID, "restricted-client-key", []uint{group.ID})
+
+	unrestrictedUser := createUserModelTestUser(t, handler, "unrestricted-user")
+	createUserModelAPIKey(t, handler, unrestrictedUser.ID, "unrestricted-client-key", nil)
+
+	keylessUser := createUserModelTestUser(t, handler, "keyless-user")
+
+	restricted := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, restrictedUser.ID))
+	if got := userModelIDs(restricted.Models); len(got) != 1 || got[0] != "gpt-4.1-mini" {
+		t.Errorf("restricted models = %v, want [gpt-4.1-mini]", got)
+	}
+	if !restricted.Access.Restricted {
+		t.Error("restricted access.restricted = false, want true")
+	}
+	if restricted.Access.Reason != modelAccessReasonModelGroups {
+		t.Errorf("restricted reason = %q, want %q", restricted.Access.Reason, modelAccessReasonModelGroups)
+	}
+
+	unrestricted := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, unrestrictedUser.ID))
+	if len(unrestricted.Models) < 3 {
+		t.Errorf("unrestricted models = %d, want the full catalog", len(unrestricted.Models))
+	}
+	if unrestricted.Access.Restricted {
+		t.Error("unrestricted access.restricted = true, want false")
+	}
+	if unrestricted.Access.Reason != modelAccessReasonUnrestricted {
+		t.Errorf("unrestricted reason = %q, want %q", unrestricted.Access.Reason, modelAccessReasonUnrestricted)
+	}
+
+	// No key means no way to call the cluster, which is not the same as access
+	// to everything.
+	keyless := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, keylessUser.ID))
+	if len(keyless.Models) != 0 {
+		t.Errorf("keyless models = %d, want 0", len(keyless.Models))
+	}
+	if keyless.Access.Reason != modelAccessReasonNoAPIKeys {
+		t.Errorf("keyless reason = %q, want %q", keyless.Access.Reason, modelAccessReasonNoAPIKeys)
+	}
+	if keyless.Access.APIKeyCount != 0 {
+		t.Errorf("keyless api_key_count = %d, want 0", keyless.Access.APIKeyCount)
+	}
+}
+
+func TestAccessibleModelsReturnPriceLadderWithoutOperatorBookkeeping(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+	seedUserModelPrices(t, handler)
+
+	user := createUserModelTestUser(t, handler, "ladder-user")
+	createUserModelAPIKey(t, handler, user.ID, "ladder-client-key", nil)
+	payload := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, user.ID))
+	models := indexUserModelsByID(payload.Models)
+
+	priced, ok := models["gpt-4.1-mini"]
+	if !ok {
+		t.Fatalf("gpt-4.1-mini missing from accessible catalog")
+	}
+	if priced.Pricing == nil || priced.Pricing.Status != pricingStatusPublished {
+		t.Fatalf("priced pricing = %+v, want published", priced.Pricing)
+	}
+	if len(priced.Pricing.Providers) != 1 {
+		t.Fatalf("priced providers = %d, want 1", len(priced.Pricing.Providers))
+	}
+	provider := priced.Pricing.Providers[0]
+	if provider.Provider != "openai" {
+		t.Errorf("provider = %q, want openai", provider.Provider)
+	}
+	if len(provider.Tiers) != 2 {
+		t.Fatalf("tiers = %d, want 2", len(provider.Tiers))
+	}
+
+	tiers := make(map[string]userModelPriceTierPayload, len(provider.Tiers))
+	for _, tier := range provider.Tiers {
+		tiers[tier.ServiceTier] = tier
+	}
+	wildcard, ok := tiers["*"]
+	if !ok {
+		t.Fatalf("wildcard tier missing, got %v", provider.Tiers)
+	}
+	if !wildcard.IsDefault {
+		t.Error("wildcard tier is_default = false, want true")
+	}
+	// The ladder must ascend, because the rung a request lands on is the last
+	// threshold it clears.
+	if len(wildcard.Rungs) != 2 {
+		t.Fatalf("wildcard rungs = %d, want 2", len(wildcard.Rungs))
+	}
+	if wildcard.Rungs[0].MinInputTokens != 0 || wildcard.Rungs[1].MinInputTokens != 128000 {
+		t.Errorf("wildcard rung thresholds = %d,%d, want 0,128000", wildcard.Rungs[0].MinInputTokens, wildcard.Rungs[1].MinInputTokens)
+	}
+	if wildcard.Rungs[1].InputPricePerMillion <= wildcard.Rungs[0].InputPricePerMillion {
+		t.Errorf("long-context rung is not more expensive: %v", wildcard.Rungs)
+	}
+	if _, ok := tiers["flex"]; !ok {
+		t.Errorf("flex tier missing, got %v", provider.Tiers)
+	}
+
+	// Operator bookkeeping must not ride along with the quote.
+	assertNoUserModelPriceBookkeeping(t, payload.Raw)
+
+	// A model with no enabled rule is unpriced, never free.
+	unpriced, ok := models["mystery-model"]
+	if !ok {
+		t.Fatalf("mystery-model missing from accessible catalog")
+	}
+	if unpriced.Pricing == nil || unpriced.Pricing.Status != pricingStatusUnpublished {
+		t.Fatalf("unpriced pricing = %+v, want unpublished", unpriced.Pricing)
+	}
+	if len(unpriced.Pricing.Providers) != 0 {
+		t.Errorf("unpriced providers = %v, want none", unpriced.Pricing.Providers)
+	}
+
+	// A rule for a provider that cannot serve the model is not a quote.
+	foreign, ok := models["text-only-model"]
+	if !ok {
+		t.Fatalf("text-only-model missing from accessible catalog")
+	}
+	if foreign.Pricing == nil || foreign.Pricing.Status != pricingStatusUnpublished {
+		t.Errorf("foreign-provider pricing = %+v, want unpublished", foreign.Pricing)
+	}
+}
+
+func TestAccessibleModelsReportInsufficientAvailabilityData(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+
+	user := createUserModelTestUser(t, handler, "availability-user")
+	createUserModelAPIKey(t, handler, user.ID, "availability-client-key", nil)
+	// Twelve observations, two of them failures: enough to publish a rate.
+	seedUserModelUsage(t, handler, "gpt-4.1-mini", "availability-client-key", 10, 2)
+	// Three observations: a sample, but not a measurement.
+	seedUserModelUsage(t, handler, "text-only-model", "availability-client-key", 3, 0)
+
+	payload := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, user.ID))
+	models := indexUserModelsByID(payload.Models)
+
+	observed := models["gpt-4.1-mini"].Availability
+	if observed == nil {
+		t.Fatalf("observed availability missing")
+	}
+	if observed.Status != availabilityStatusObserved {
+		t.Fatalf("observed status = %q body=%s, want %q", observed.Status, payload.Raw, availabilityStatusObserved)
+	}
+	if observed.SampleCount != 12 {
+		t.Errorf("observed sample_count = %d, want 12", observed.SampleCount)
+	}
+	if observed.AvailabilityRate == nil || *observed.AvailabilityRate != 0.8333 {
+		t.Errorf("observed availability_rate = %v, want 0.8333", observed.AvailabilityRate)
+	}
+	if observed.AvgLatencyMS == nil || *observed.AvgLatencyMS <= 0 {
+		t.Errorf("observed avg_latency_ms = %v, want a positive mean", observed.AvgLatencyMS)
+	}
+	if observed.AvgTTFTMS == nil || *observed.AvgTTFTMS <= 0 {
+		t.Errorf("observed avg_ttft_ms = %v, want a positive mean", observed.AvgTTFTMS)
+	}
+	if observed.OutputTokensPerSecond == nil || *observed.OutputTokensPerSecond <= 0 {
+		t.Errorf("observed output_tokens_per_second = %v, want a positive rate", observed.OutputTokensPerSecond)
+	}
+	if observed.Window.Hours != int(modelAvailabilityWindow/time.Hour) {
+		t.Errorf("observed window hours = %d, want %d", observed.Window.Hours, int(modelAvailabilityWindow/time.Hour))
+	}
+	if observed.Window.MinSamples != modelAvailabilityMinSamples {
+		t.Errorf("observed window min_samples = %d, want %d", observed.Window.MinSamples, modelAvailabilityMinSamples)
+	}
+
+	// Three successes out of three is not 100% uptime.
+	undersampled := models["text-only-model"].Availability
+	if undersampled == nil {
+		t.Fatalf("undersampled availability missing")
+	}
+	if undersampled.Status != availabilityStatusInsufficientData {
+		t.Errorf("undersampled status = %q, want %q", undersampled.Status, availabilityStatusInsufficientData)
+	}
+	if undersampled.AvailabilityRate != nil {
+		t.Errorf("undersampled availability_rate = %v, want omitted", *undersampled.AvailabilityRate)
+	}
+	if undersampled.SampleCount != 3 {
+		t.Errorf("undersampled sample_count = %d, want 3", undersampled.SampleCount)
+	}
+
+	// A model nobody called is not a model that never failed.
+	unobserved := models["mystery-model"].Availability
+	if unobserved == nil {
+		t.Fatalf("unobserved availability missing")
+	}
+	if unobserved.Status != availabilityStatusInsufficientData {
+		t.Errorf("unobserved status = %q, want %q", unobserved.Status, availabilityStatusInsufficientData)
+	}
+	if unobserved.SampleCount != 0 {
+		t.Errorf("unobserved sample_count = %d, want 0", unobserved.SampleCount)
+	}
+	if unobserved.AvailabilityRate != nil {
+		t.Errorf("unobserved availability_rate = %v, want omitted", *unobserved.AvailabilityRate)
+	}
+}
+
+// TestAccessibleModelsFoldUsageSpellingsIntoOneSummary pins that observations
+// are counted whatever case the usage record spells the model in.
+//
+// A usage record carries the spelling the caller sent, not the spelling the
+// catalog registers, so the two drift apart in normal operation. Matching them
+// exactly drops the records that differ, which is indistinguishable on screen
+// from a model nobody called.
+func TestAccessibleModelsFoldUsageSpellingsIntoOneSummary(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+
+	user := createUserModelTestUser(t, handler, "case-fold-user")
+	createUserModelAPIKey(t, handler, user.ID, "case-fold-client-key", nil)
+	// The same model, written three ways across fourteen observations. The
+	// catalog registers only the lower-cased spelling.
+	seedUserModelUsage(t, handler, "gpt-4.1-mini", "case-fold-client-key", 6, 1)
+	seedUserModelUsage(t, handler, "GPT-4.1-Mini", "case-fold-client-key", 4, 1)
+	seedUserModelUsage(t, handler, "GPT-4.1-MINI", "case-fold-client-key", 2, 0)
+
+	payload := getUserModels(t, handler.ListAccessibleModels, "/models/accessible", createUserBillingBearerToken(t, handler, user.ID))
+	availability := indexUserModelsByID(payload.Models)["gpt-4.1-mini"].Availability
+	if availability == nil {
+		t.Fatalf("availability missing body=%s", payload.Raw)
+	}
+	if availability.SampleCount != 14 {
+		t.Fatalf("sample_count = %d, want 14 — every spelling counts once", availability.SampleCount)
+	}
+	if availability.Status != availabilityStatusObserved {
+		t.Fatalf("status = %q, want %q", availability.Status, availabilityStatusObserved)
+	}
+	// Twelve of fourteen succeeded. Getting this from a single merged group is
+	// the point: two half-sized groups would each round to a different rate and
+	// only one of them would survive into the response.
+	if availability.AvailabilityRate == nil || *availability.AvailabilityRate != 0.8571 {
+		t.Errorf("availability_rate = %v, want 0.8571", availability.AvailabilityRate)
+	}
+}
+
+// TestModelPricingWithholdsQuotesWhenNoProviderCanServe pins the fail-closed
+// half of the servable-provider filter.
+//
+// The filter exists because the price table outlives the channels it prices. A
+// model with no known channel is the case where nothing in the table can be
+// confirmed to describe the route a request would take, so it is the last case
+// that should quote all of it.
+func TestModelPricingWithholdsQuotesWhenNoProviderCanServe(t *testing.T) {
+	index := newModelPriceIndex([]cluster.BillingModelPriceRecord{
+		{Provider: "anthropic", Model: "orphan-model", ServiceTier: "*", MinInputTokens: 0, InputPricePerMillion: 5, Enabled: true},
+		{Provider: "openai", Model: "orphan-model", ServiceTier: "*", MinInputTokens: 0, InputPricePerMillion: 7, Enabled: true},
+	})
+
+	withoutProviders := index.pricingFor("orphan-model", nil)
+	if status, _ := withoutProviders["status"].(string); status != pricingStatusUnpublished {
+		t.Errorf("status without providers = %q, want %q", status, pricingStatusUnpublished)
+	}
+	if _, quoted := withoutProviders["providers"]; quoted {
+		t.Errorf("providers quoted for a model no channel is known to serve: %#v", withoutProviders)
+	}
+
+	// Blank entries are not a serving channel either.
+	if status, _ := index.pricingFor("orphan-model", []string{" ", ""})["status"].(string); status != pricingStatusUnpublished {
+		t.Errorf("status with blank providers = %q, want %q", status, pricingStatusUnpublished)
+	}
+
+	// Naming a channel still prices it, and still prices only it.
+	served := index.pricingFor("orphan-model", []string{"anthropic"})
+	if status, _ := served["status"].(string); status != pricingStatusPublished {
+		t.Fatalf("status with a serving provider = %q, want %q", status, pricingStatusPublished)
+	}
+	quoted, _ := served["providers"].([]gin.H)
+	if len(quoted) != 1 {
+		t.Fatalf("quoted providers = %d, want 1", len(quoted))
+	}
+	if name, _ := quoted[0]["provider"].(string); name != "anthropic" {
+		t.Errorf("quoted provider = %q, want %q", name, "anthropic")
+	}
+}
+
+// TestModelAvailabilityCollapsesConcurrentRecomputations pins that a cold cache
+// costs one scan rather than one per in-flight request.
+//
+// Callers that share a computation are handed the same map. Callers that each
+// ran their own would hold distinct maps built from distinct result sets, so
+// identity is the observable difference between collapsing and stampeding.
+func TestModelAvailabilityCollapsesConcurrentRecomputations(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	registerUserModelCatalog(t)
+	seedUserModelUsage(t, handler, "gpt-4.1-mini", "stampede-client-key", 12, 0)
+
+	const callers = 8
+	modelIDs := []string{"gpt-4.1-mini", "text-only-model", "mystery-model"}
+	summaries := make([]map[string]cluster.ModelAvailabilitySummary, callers)
+	errs := make([]error, callers)
+
+	var ready, done sync.WaitGroup
+	ready.Add(callers)
+	done.Add(callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		go func(slot int) {
+			defer done.Done()
+			ready.Done()
+			<-start
+			summaries[slot], _, errs[slot] = handler.modelAvailabilityIndex(context.Background(), modelIDs)
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+	done.Wait()
+
+	for slot := range errs {
+		if errs[slot] != nil {
+			t.Fatalf("caller %d error = %v", slot, errs[slot])
+		}
+	}
+	for slot := 1; slot < callers; slot++ {
+		if reflect.ValueOf(summaries[slot]).Pointer() != reflect.ValueOf(summaries[0]).Pointer() {
+			t.Fatalf("caller %d received its own summary, want one shared computation", slot)
+		}
+	}
+	if got := summaries[0]["gpt-4.1-mini"].SampleCount; got != 12 {
+		t.Errorf("shared sample_count = %d, want 12", got)
+	}
+}
+
+func TestModelCatalogCapabilityIsAdvertised(t *testing.T) {
+	handler, closeRepo := newUserModelTestHandler(t)
+	defer closeRepo()
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/capabilities", nil)
+	handler.GetCapabilities(ctx)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		Capabilities struct {
+			ModelCatalog bool `json:"model_catalog"`
+		} `json:"capabilities"`
+	}
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode capabilities: %v", errDecode)
+	}
+	if !payload.Capabilities.ModelCatalog {
+		t.Errorf("model_catalog = false, want true")
+	}
+}
+
+// --- decoding helpers -------------------------------------------------------
+
+type userModelModalitiesPayload struct {
+	Status string   `json:"status"`
+	Input  []string `json:"input"`
+	Output []string `json:"output"`
+}
+
+type userModelCapabilityStatusPayload struct {
+	Status string `json:"status"`
+}
+
+type userModelCapabilitiesPayload struct {
+	Reasoning        userModelCapabilityStatusPayload `json:"reasoning"`
+	ToolCalling      userModelCapabilityStatusPayload `json:"tool_calling"`
+	StructuredOutput userModelCapabilityStatusPayload `json:"structured_output"`
+	Parameters       []string                         `json:"parameters"`
+}
+
+type userModelPriceRungPayload struct {
+	MinInputTokens            int64   `json:"min_input_tokens"`
+	InputPricePerMillion      float64 `json:"input_price_per_million"`
+	OutputPricePerMillion     float64 `json:"output_price_per_million"`
+	CacheReadPricePerMillion  float64 `json:"cache_read_price_per_million"`
+	CacheWritePricePerMillion float64 `json:"cache_write_price_per_million"`
+	RequestPrice              float64 `json:"request_price"`
+}
+
+type userModelPriceTierPayload struct {
+	ServiceTier string                      `json:"service_tier"`
+	IsDefault   bool                        `json:"is_default"`
+	Rungs       []userModelPriceRungPayload `json:"rungs"`
+}
+
+type userModelPriceProviderPayload struct {
+	Provider string                      `json:"provider"`
+	Tiers    []userModelPriceTierPayload `json:"tiers"`
+}
+
+type userModelPricingPayload struct {
+	Status    string                          `json:"status"`
+	Providers []userModelPriceProviderPayload `json:"providers"`
+}
+
+type userModelAvailabilityWindowPayload struct {
+	From       string `json:"from"`
+	To         string `json:"to"`
+	Hours      int    `json:"hours"`
+	MinSamples int    `json:"min_samples"`
+}
+
+type userModelAvailabilityPayload struct {
+	Status                string                             `json:"status"`
+	Window                userModelAvailabilityWindowPayload `json:"window"`
+	SampleCount           int64                              `json:"sample_count"`
+	SuccessCount          int64                              `json:"success_count"`
+	FailedCount           int64                              `json:"failed_count"`
+	AvailabilityRate      *float64                           `json:"availability_rate"`
+	AvgLatencyMS          *float64                           `json:"avg_latency_ms"`
+	AvgTTFTMS             *float64                           `json:"avg_ttft_ms"`
+	OutputTokensPerSecond *float64                           `json:"output_tokens_per_second"`
+	LastObservedAt        string                             `json:"last_observed_at"`
+}
+
+type userModelPayload struct {
+	ID              string                        `json:"id"`
+	DisplayName     string                        `json:"display_name"`
+	Providers       []string                      `json:"providers"`
+	ContextLength   int                           `json:"context_length"`
+	MaxOutputTokens int                           `json:"max_output_tokens"`
+	Modalities      userModelModalitiesPayload    `json:"modalities"`
+	Capabilities    userModelCapabilitiesPayload  `json:"capabilities"`
+	Pricing         *userModelPricingPayload      `json:"pricing"`
+	Availability    *userModelAvailabilityPayload `json:"availability"`
+}
+
+type userModelAccessPayload struct {
+	Restricted  bool   `json:"restricted"`
+	APIKeyCount int    `json:"api_key_count"`
+	Reason      string `json:"reason"`
+}
+
+type userModelListPayload struct {
+	Models []userModelPayload     `json:"models"`
+	Total  int                    `json:"total"`
+	Access userModelAccessPayload `json:"access"`
+	Raw    string                 `json:"-"`
+}
+
+func getUserModels(t *testing.T, handle gin.HandlerFunc, path, token string) userModelListPayload {
+	t.Helper()
+
+	resp := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(resp)
+	ctx.Request = httptest.NewRequest(http.MethodGet, path, nil)
+	if token != "" {
+		ctx.Request.Header.Set("Authorization", "Bearer "+token)
+	}
+	handle(ctx)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d body=%s, want 200", path, resp.Code, resp.Body.String())
+	}
+	var payload userModelListPayload
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode %s: %v body=%s", path, errDecode, resp.Body.String())
+	}
+	payload.Raw = resp.Body.String()
+	return payload
+}
+
+func indexUserModelsByID(models []userModelPayload) map[string]userModelPayload {
+	indexed := make(map[string]userModelPayload, len(models))
+	for _, model := range models {
+		indexed[model.ID] = model
+	}
+	return indexed
+}
+
+func userModelIDs(models []userModelPayload) []string {
+	ids := make([]string, 0, len(models))
+	for _, model := range models {
+		ids = append(ids, model.ID)
+	}
+	return ids
+}
+
+// assertNoUserModelPriceBookkeeping walks the raw JSON rather than a decoded
+// struct, because a field that should not exist cannot be asserted absent by
+// decoding into a type that does not declare it.
+//
+// The walk is scoped to the pricing subtree: "source" is forbidden on a price
+// rung (it names the operator rule's origin) while being expected on modalities
+// (it names who described the model), so a whole-body substring check would
+// report the wrong thing.
+func assertNoUserModelPriceBookkeeping(t *testing.T, raw string) {
+	t.Helper()
+
+	forbidden := map[string]struct{}{
+		"id": {}, "note": {}, "source": {}, "enabled": {}, "revision": {},
+		"created_at": {}, "updated_at": {}, "deleted_at": {},
+	}
+
+	var decoded struct {
+		Models []struct {
+			ID      string          `json:"id"`
+			Pricing json.RawMessage `json:"pricing"`
+		} `json:"models"`
+	}
+	if errDecode := json.Unmarshal([]byte(raw), &decoded); errDecode != nil {
+		t.Fatalf("decode for redaction check: %v", errDecode)
+	}
+	for _, model := range decoded.Models {
+		if len(model.Pricing) == 0 {
+			continue
+		}
+		var pricing any
+		if errDecode := json.Unmarshal(model.Pricing, &pricing); errDecode != nil {
+			t.Fatalf("decode pricing for %s: %v", model.ID, errDecode)
+		}
+		walkJSONKeys(pricing, func(key string) {
+			if _, banned := forbidden[key]; banned {
+				t.Errorf("model %s pricing leaks operator bookkeeping key %q: %s", model.ID, key, model.Pricing)
+			}
+		})
+	}
+}
+
+func walkJSONKeys(value any, visit func(key string)) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			visit(key)
+			walkJSONKeys(nested, visit)
+		}
+	case []any:
+		for _, nested := range typed {
+			walkJSONKeys(nested, visit)
+		}
+	}
+}
+
+// --- seeding helpers --------------------------------------------------------
+
+func newUserModelTestHandler(t *testing.T) (*Handler, func()) {
+	t.Helper()
+
+	resetModelAvailabilityCache()
+	t.Cleanup(resetModelAvailabilityCache)
+
+	ctx := context.Background()
+	db, errOpenSQLite := cluster.OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	closeRepo := func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}
+	if errMigrate := cluster.AutoMigrate(db); errMigrate != nil {
+		closeRepo()
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	return NewHandler(cluster.NewRepository(db), nil), closeRepo
+}
+
+// registerUserModelCatalog installs a catalog covering the three descriptions a
+// buyer-facing endpoint has to tell apart: fully described, partially described,
+// and undescribed.
+func registerUserModelCatalog(t *testing.T) {
+	t.Helper()
+
+	const clientID = "user-model-test-client"
+	registry.GetGlobalRegistry().RegisterClient(clientID, "openai", []*registry.ModelInfo{
+		{
+			ID:                  "gpt-4.1-mini",
+			DisplayName:         "GPT-4.1 mini",
+			Description:         "Fast general purpose model.",
+			Type:                "chat",
+			ContextLength:       128000,
+			MaxCompletionTokens: 16384,
+			SupportedParameters: []string{"tools", "temperature", "reasoning_effort", "response_format"},
+			// Deliberately messy: the catalog is hand-maintained JSON, so casing
+			// slips, padding and duplicates are the realistic input, not the
+			// exception. The endpoint must clean them rather than echo them.
+			SupportedInputModalities: []string{"Text", " IMAGE ", "text", ""},
+			SupportedOutputModalities: []string{
+				"text",
+			},
+		},
+		{
+			ID:                        "text-only-model",
+			DisplayName:               "Text Only",
+			ContextLength:             32000,
+			SupportedParameters:       []string{"temperature", "top_p"},
+			SupportedInputModalities:  []string{"text"},
+			SupportedOutputModalities: []string{"text"},
+		},
+		{
+			ID: "mystery-model",
+		},
+	})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(clientID)
+	})
+}
+
+func createUserModelTestUser(t *testing.T, handler *Handler, username string) *cluster.UserRecord {
+	t.Helper()
+
+	credits := 100.0
+	user, errCreate := handler.repo.CreateUser(context.Background(), cluster.UserUpdate{Username: &username, Credits: &credits})
+	if errCreate != nil {
+		t.Fatalf("CreateUser(%s) error = %v", username, errCreate)
+	}
+	return user
+}
+
+func createUserModelAPIKey(t *testing.T, handler *Handler, userID uint, apiKey string, modelGroups []uint) {
+	t.Helper()
+
+	update := cluster.APIKeyUserUpdate{APIKey: &apiKey}
+	if modelGroups != nil {
+		update.ModelGroups = &modelGroups
+	}
+	if _, errCreate := handler.repo.CreateAPIKeyForUser(context.Background(), userID, update); errCreate != nil {
+		t.Fatalf("CreateAPIKeyForUser(%s) error = %v", apiKey, errCreate)
+	}
+}
+
+func createUserModelGroup(t *testing.T, handler *Handler, groupName string, modelIDs ...string) *cluster.ModelGroupRecord {
+	t.Helper()
+
+	ctx := context.Background()
+	group, errGroup := handler.repo.CreateModelGroup(ctx, groupName, false)
+	if errGroup != nil {
+		t.Fatalf("CreateModelGroup(%s) error = %v", groupName, errGroup)
+	}
+	for _, modelID := range modelIDs {
+		if _, errDetail := handler.repo.CreateModelGroupDetail(ctx, group.ID, modelID, nil); errDetail != nil {
+			t.Fatalf("CreateModelGroupDetail(%s) error = %v", modelID, errDetail)
+		}
+	}
+	return group
+}
+
+// seedUserModelPrices installs a two-rung ladder on the wildcard tier, a named
+// tier, and a rule for a provider that cannot serve the model it names.
+func seedUserModelPrices(t *testing.T, handler *Handler) {
+	t.Helper()
+
+	ctx := context.Background()
+	prices := []cluster.BillingModelPriceUpdate{
+		{Provider: "openai", Model: "gpt-4.1-mini", ServiceTier: "*", MinInputTokens: 0, InputPricePerMillion: 0.4, OutputPricePerMillion: 1.6, Enabled: true},
+		{Provider: "openai", Model: "gpt-4.1-mini", ServiceTier: "*", MinInputTokens: 128000, InputPricePerMillion: 0.8, OutputPricePerMillion: 3.2, Enabled: true},
+		{Provider: "openai", Model: "gpt-4.1-mini", ServiceTier: "flex", MinInputTokens: 0, InputPricePerMillion: 0.2, OutputPricePerMillion: 0.8, Enabled: true, Note: "internal rate card"},
+		// Disabled rules are not offers.
+		{Provider: "openai", Model: "mystery-model", ServiceTier: "*", MinInputTokens: 0, InputPricePerMillion: 9.9, Enabled: false},
+		// A rule whose provider does not serve this model must not be quoted.
+		{Provider: "anthropic", Model: "text-only-model", ServiceTier: "*", MinInputTokens: 0, InputPricePerMillion: 5, Enabled: true},
+	}
+	for i := range prices {
+		if _, errCreate := handler.repo.CreateBillingModelPrice(ctx, prices[i]); errCreate != nil {
+			t.Fatalf("CreateBillingModelPrice(%d) error = %v", i, errCreate)
+		}
+	}
+}
+
+// seedUserModelUsage appends successful and failed observations for one model.
+func seedUserModelUsage(t *testing.T, handler *Handler, modelID, apiKey string, successes, failures int) {
+	t.Helper()
+
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Hour)
+	for i := 0; i < successes; i++ {
+		payload := fmt.Sprintf(
+			`{"timestamp":%q,"provider":"openai","model":%q,"api_key":%q,"request_id":%q,"latency_ms":%d,"ttft_ms":%d,"failed":false,"tokens":{"input_tokens":1000,"output_tokens":500,"total_tokens":1500}}`,
+			base.Add(time.Duration(i)*time.Second).Format(time.RFC3339), modelID, apiKey,
+			fmt.Sprintf("req-%s-ok-%d", modelID, i), 2000+i*10, 300+i*5,
+		)
+		if _, errAppend := handler.repo.AppendUsage(ctx, payload, "192.0.2.10"); errAppend != nil {
+			t.Fatalf("AppendUsage(success %d) error = %v", i, errAppend)
+		}
+	}
+	for i := 0; i < failures; i++ {
+		payload := fmt.Sprintf(
+			`{"timestamp":%q,"provider":"openai","model":%q,"api_key":%q,"request_id":%q,"latency_ms":0,"failed":true,"tokens":{"input_tokens":1000,"output_tokens":0,"total_tokens":1000}}`,
+			base.Add(time.Duration(successes+i)*time.Second).Format(time.RFC3339), modelID, apiKey,
+			fmt.Sprintf("req-%s-fail-%d", modelID, i),
+		)
+		if _, errAppend := handler.repo.AppendUsage(ctx, payload, "192.0.2.10"); errAppend != nil {
+			t.Fatalf("AppendUsage(failure %d) error = %v", i, errAppend)
+		}
+	}
+}

--- a/internal/userapi/models_test.go
+++ b/internal/userapi/models_test.go
@@ -479,31 +479,6 @@ func TestModelAvailabilityCollapsesConcurrentRecomputations(t *testing.T) {
 	}
 }
 
-func TestModelCatalogCapabilityIsAdvertised(t *testing.T) {
-	handler, closeRepo := newUserModelTestHandler(t)
-	defer closeRepo()
-
-	resp := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(resp)
-	ctx.Request = httptest.NewRequest(http.MethodGet, "/capabilities", nil)
-	handler.GetCapabilities(ctx)
-
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status = %d body=%s, want 200", resp.Code, resp.Body.String())
-	}
-	var payload struct {
-		Capabilities struct {
-			ModelCatalog bool `json:"model_catalog"`
-		} `json:"capabilities"`
-	}
-	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
-		t.Fatalf("decode capabilities: %v", errDecode)
-	}
-	if !payload.Capabilities.ModelCatalog {
-		t.Errorf("model_catalog = false, want true")
-	}
-}
-
 // --- decoding helpers -------------------------------------------------------
 
 type userModelModalitiesPayload struct {


### PR DESCRIPTION
Closes #85

## Why

A buyer had no way to see what the cluster serves, what it costs, or whether their own keys could reach it. This adds the catalog behind that.

## Routes

| Route | Auth | Returns |
| --- | --- | --- |
| `GET /models` | none | Every model the cluster serves |
| `GET /models/accessible` | token | What the caller's keys may call, **plus** prices and observed availability |

The two shapes differ on purpose. The public catalog withholds pricing and availability **by contract**, so an anonymous visitor cannot mine the cluster's commercial terms.

## Three-state honesty

This is the part worth reviewing closely. `unsupported` and `unknown` are different answers and stay different all the way to the client:

- **Capabilities** — `unsupported` means the cluster said a model cannot do this. `unknown` means nobody ever said.
- **Modalities** — report `status: "unknown"` rather than an empty `input` array, which a client would be entitled to read as "text only". Values are lower-cased and de-duplicated.
- **Pricing** — a missing price is `unpublished`, never `0`. A zero component is real (a provider that does not bill for cache reads has said so), which is exactly why absence must not be zero-filled.
- **Availability** — an undersampled window returns its sample count and **withholds every derived number**. Three successes out of three is not full availability, so the server refuses to hand a client something it could render as one.

## Prices are a ladder, not a scalar

Providers bill in tiers, so a single number would misstate the cost of a long request. `ListEnabledBillingModelPricesForModels` matches models **exactly** rather than with `LIKE` — the existing operator-facing search uses `LIKE`, which would drag every model containing `gpt-4` into a request pricing `gpt-4`. Rows come back in the order the rules are applied at charge time, so a client can read a group top to bottom as the ladder a request climbs.

## Access is a union, not an intersection

A buyer holding one broad key and one narrow key can call everything the broad key reaches. Reporting the intersection would hide models they can use today. One unscoped key short-circuits to "unrestricted".

## Capability advertisement

`GET /capabilities` now reports `model_catalog: true`, so a client can hide the catalog on an older Home rather than calling the route and having to tell a 404 apart from an outage.

## Modalities need no upstream changes

Modality data comes from the hand-maintained catalog (`models.json`), not from probing providers. `ModelInfo` already declared `SupportedInputModalities` / `SupportedOutputModalities` and the catalog unmarshals straight into it, so **CPA needs no changes at all**. The catalog side is router-for-me/models#31; the embedded copy here is only the offline fallback, since `StartModelsUpdater` replaces it from the remote catalog at boot and every 3h.

## Verification

`go build ./...` clean, `gofmt -l internal/` clean, **full `go test ./...` suite passes with zero failures**. Branched off `main` rather than `dev` so the diff carries only this work.
