### PR TITLE
fix(auth): preserve OAuth force mapping in Home dispatch

### DIFF
--- a/internal/cliproxy/auth/model_alias_apikey.go
+++ b/internal/cliproxy/auth/model_alias_apikey.go
@@ -84,7 +84,10 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 // resolveDispatchModel resolves the auth-specific upstream model used for execution and runtime state.
 func (m *Manager) resolveDispatchModel(auth *Auth, routeModel string) dispatchModelResolution {
 	requestedModel := rewriteModelForAuth(routeModel, auth)
-	requestedModel = m.applyOAuthModelAlias(auth, requestedModel)
+	oauthAlias := m.resolveOAuthModelAlias(auth, requestedModel)
+	if strings.TrimSpace(oauthAlias.upstreamModel) != "" {
+		requestedModel = oauthAlias.upstreamModel
+	}
 	resolved := m.applyAPIKeyModelAlias(auth, requestedModel)
 	if strings.TrimSpace(resolved) == "" {
 		resolved = requestedModel
@@ -96,7 +99,10 @@ func (m *Manager) resolveDispatchModel(auth *Auth, routeModel string) dispatchMo
 	if resolved == "" {
 		return dispatchModelResolution{}
 	}
-	forceMapping, originalAlias := forceMappingFromAuthConfigModels(auth, requestedModel)
+	forceMapping, originalAlias := oauthAlias.forceMapping, oauthAlias.originalAlias
+	if !forceMapping {
+		forceMapping, originalAlias = forceMappingFromAuthConfigModels(auth, requestedModel)
+	}
 	return dispatchModelResolution{
 		Model:         resolved,
 		Key:           canonicalModelKey(resolved),

--- a/internal/cliproxy/auth/oauth_model_alias.go
+++ b/internal/cliproxy/auth/oauth_model_alias.go
@@ -11,9 +11,21 @@ type modelAliasEntry interface {
 	GetAlias() string
 }
 
+type oauthModelAliasEntry struct {
+	upstreamModel string
+	alias         string
+	forceMapping  bool
+}
+
+type oauthModelAliasResult struct {
+	upstreamModel string
+	originalAlias string
+	forceMapping  bool
+}
+
 type oauthModelAliasTable struct {
-	// reverse maps channel -> alias (lower) -> original upstream model name.
-	reverse map[string]map[string]string
+	// reverse maps channel -> alias (lower) -> upstream model and response mapping metadata.
+	reverse map[string]map[string]oauthModelAliasEntry
 }
 
 // compileOAuthModelAliasTable compiles an o auth model alias table.
@@ -23,14 +35,14 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 		return &oauthModelAliasTable{}
 	}
 	out := &oauthModelAliasTable{
-		reverse: make(map[string]map[string]string, len(aliases)),
+		reverse: make(map[string]map[string]oauthModelAliasEntry, len(aliases)),
 	}
 	for rawChannel, entries := range aliases {
 		channel := strings.ToLower(strings.TrimSpace(rawChannel))
 		if channel == "" || len(entries) == 0 {
 			continue
 		}
-		rev := make(map[string]string, len(entries))
+		rev := make(map[string]oauthModelAliasEntry, len(entries))
 		for _, entry := range entries {
 			name := strings.TrimSpace(entry.Name)
 			alias := strings.TrimSpace(entry.Alias)
@@ -44,7 +56,11 @@ func compileOAuthModelAliasTable(aliases map[string][]internalconfig.OAuthModelA
 			if _, exists := rev[aliasKey]; exists {
 				continue
 			}
-			rev[aliasKey] = name
+			rev[aliasKey] = oauthModelAliasEntry{
+				upstreamModel: name,
+				alias:         alias,
+				forceMapping:  entry.ForceMapping,
+			}
 		}
 		if len(rev) > 0 {
 			out.reverse[channel] = rev
@@ -192,16 +208,20 @@ func resolveModelAliasFromConfigModels(requestedModel string, models []modelAlia
 // the suffix is preserved in the returned model name. However, if the alias's
 // original name already contains a suffix, the config suffix takes priority.
 func (m *Manager) resolveOAuthUpstreamModel(auth *Auth, requestedModel string) string {
-	return resolveUpstreamModelFromAliasTable(m, auth, requestedModel, modelAliasChannel(auth))
+	return m.resolveOAuthModelAlias(auth, requestedModel).upstreamModel
 }
 
-// resolveUpstreamModelFromAliasTable derives resolve upstream model from alias table.
-func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, channel string) string {
+func (m *Manager) resolveOAuthModelAlias(auth *Auth, requestedModel string) oauthModelAliasResult {
+	return resolveModelAliasFromOAuthTable(m, auth, requestedModel, modelAliasChannel(auth))
+}
+
+// resolveModelAliasFromOAuthTable resolves an upstream model and response mapping metadata.
+func resolveModelAliasFromOAuthTable(m *Manager, auth *Auth, requestedModel, channel string) oauthModelAliasResult {
 	if m == nil || auth == nil {
-		return ""
+		return oauthModelAliasResult{}
 	}
 	if channel == "" {
-		return ""
+		return oauthModelAliasResult{}
 	}
 
 	// Extract suffix from requested model.
@@ -217,11 +237,11 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 	raw := m.oauthModelAlias.Load()
 	table, _ := raw.(*oauthModelAliasTable)
 	if table == nil || table.reverse == nil {
-		return ""
+		return oauthModelAliasResult{}
 	}
 	rev := table.reverse[channel]
 	if rev == nil {
-		return ""
+		return oauthModelAliasResult{}
 	}
 
 	for _, candidate := range candidates {
@@ -229,26 +249,32 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 		if key == "" {
 			continue
 		}
-		original := strings.TrimSpace(rev[key])
+		entry, exists := rev[key]
+		if !exists {
+			continue
+		}
+		original := strings.TrimSpace(entry.upstreamModel)
 		if original == "" {
 			continue
 		}
 		if strings.EqualFold(original, baseModel) {
-			return ""
+			return oauthModelAliasResult{}
 		}
 
+		resolved := original
 		// If config already has suffix, it takes priority.
-		if parseModelSuffix(original).HasSuffix {
-			return original
+		if !parseModelSuffix(original).HasSuffix && requestResult.HasSuffix && requestResult.RawSuffix != "" {
+			resolved = original + "(" + requestResult.RawSuffix + ")"
 		}
-		// Preserve user's thinking suffix on the resolved model.
-		if requestResult.HasSuffix && requestResult.RawSuffix != "" {
-			return original + "(" + requestResult.RawSuffix + ")"
+		result := oauthModelAliasResult{upstreamModel: resolved}
+		if entry.forceMapping {
+			result.forceMapping = true
+			result.originalAlias = strings.TrimSpace(entry.alias)
 		}
-		return original
+		return result
 	}
 
-	return ""
+	return oauthModelAliasResult{}
 }
 
 // modelAliasChannel extracts the OAuth model alias channel from an Auth object.

--- a/internal/cliproxy/auth/oauth_model_alias_test.go
+++ b/internal/cliproxy/auth/oauth_model_alias_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+)
+
+func TestDispatchResolvesOAuthModelAliasForceMapping(t *testing.T) {
+	const (
+		aliasModel    = "gemini-3.5-flash"
+		upstreamModel = "gemini-3-flash-agent"
+	)
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"antigravity": {{
+			Name:         upstreamModel,
+			Alias:        aliasModel,
+			Fork:         true,
+			ForceMapping: true,
+		}},
+	})
+	auth := &Auth{
+		ID:       "antigravity-oauth-auth",
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+	}
+	registerDispatchTestAuth(t, manager, auth, aliasModel)
+
+	decision, errDispatch := manager.Dispatch(context.Background(), []string{"antigravity"}, aliasModel, Options{})
+	if errDispatch != nil {
+		t.Fatalf("Dispatch() error = %v", errDispatch)
+	}
+	if decision == nil || decision.Auth == nil || decision.Auth.ID != auth.ID {
+		t.Fatalf("Dispatch() decision = %#v", decision)
+	}
+	if decision.Provider != "antigravity" || decision.UpstreamModel != upstreamModel {
+		t.Fatalf("Dispatch() provider/model = %q/%q, want antigravity/%s", decision.Provider, decision.UpstreamModel, upstreamModel)
+	}
+	if !decision.ForceMapping || decision.OriginalAlias != aliasModel {
+		t.Fatalf("Dispatch() force mapping = %t/%q, want true/%q", decision.ForceMapping, decision.OriginalAlias, aliasModel)
+	}
+}
+
+func TestDispatchOAuthModelAliasWithoutForceMappingOmitsResponseMapping(t *testing.T) {
+	const (
+		aliasModel    = "gemini-3.5-flash"
+		upstreamModel = "gemini-3-flash-agent"
+	)
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"antigravity": {{
+			Name:  upstreamModel,
+			Alias: aliasModel,
+			Fork:  true,
+		}},
+	})
+	auth := &Auth{
+		ID:       "antigravity-oauth-auth-no-force",
+		Provider: "antigravity",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"auth_kind": "oauth",
+		},
+	}
+	registerDispatchTestAuth(t, manager, auth, aliasModel)
+
+	decision, errDispatch := manager.Dispatch(context.Background(), []string{"antigravity"}, aliasModel, Options{})
+	if errDispatch != nil {
+		t.Fatalf("Dispatch() error = %v", errDispatch)
+	}
+	if decision == nil || decision.UpstreamModel != upstreamModel {
+		t.Fatalf("Dispatch() decision = %#v, want upstream model %q", decision, upstreamModel)
+	}
+	if decision.ForceMapping || decision.OriginalAlias != "" {
+		t.Fatalf("Dispatch() force mapping = %t/%q, want false/empty", decision.ForceMapping, decision.OriginalAlias)
+	}
+}

--- a/internal/respserver/pop/dynamic/concurrency_dispatch_test.go
+++ b/internal/respserver/pop/dynamic/concurrency_dispatch_test.go
@@ -154,6 +154,39 @@ func TestConcurrencyDispatchFixture(t *testing.T) {
 	}
 }
 
+func TestPrepareDispatchResponseIncludesForceMapping(t *testing.T) {
+	result := &home.DispatchResult{
+		Model:         "gemini-3-flash-agent",
+		Provider:      "antigravity",
+		ForceMapping:  true,
+		OriginalAlias: "gemini-3.5-flash",
+		Auth: &coreauth.Auth{
+			ID:       "antigravity-auth",
+			Index:    "antigravity-auth",
+			Provider: "antigravity",
+			Status:   coreauth.StatusActive,
+		},
+		Concurrency: home.ConcurrencyAdmissionResult{
+			Accounted:    true,
+			CredentialID: "antigravity-auth",
+			Model:        "gemini-3-flash-agent",
+		},
+	}
+
+	unaccounted, accounted, errPrepare := prepareDispatchResponse(result, "user-key")
+	if errPrepare != nil {
+		t.Fatalf("prepareDispatchResponse() error = %v", errPrepare)
+	}
+	for name, payload := range map[string][]byte{"unaccounted": unaccounted, "accounted": accounted} {
+		if !gjson.GetBytes(payload, "force_mapping").Bool() {
+			t.Fatalf("%s response = %s, want force_mapping true", name, payload)
+		}
+		if got := gjson.GetBytes(payload, "original_alias").String(); got != "gemini-3.5-flash" {
+			t.Fatalf("%s original_alias = %q, want gemini-3.5-flash", name, got)
+		}
+	}
+}
+
 func TestHandleAuthSkipsSaturatedAffinityCandidate(t *testing.T) {
 	runtime, admitter := newConcurrencyDispatchRuntime(t, []string{"cred-a", "cred-b"})
 	admitter.SetResult("cred-a", concurrencyError("credential_concurrency_exceeded"))


### PR DESCRIPTION
Closes #75

## Why

Home resolves `oauth-model-alias` entries to their upstream model before dispatching credentials to CPA nodes, but its compiled alias table discarded `force-mapping` and the configured alias. As a result, OAuth dispatch replies omitted `force_mapping` / `original_alias`, so upstream response model names such as `gemini-default` could leak through instead of the client-facing alias.

## What changed

- retain the upstream model, configured alias, and `force-mapping` flag in Home's OAuth alias table
- propagate the selected OAuth response mapping into `DispatchDecision` / `DispatchResult`
- preserve the existing API-key metadata fallback and unforced OAuth behavior
- cover OAuth dispatch metadata and both accounted/unaccounted RESP reply serialization

## Verification

- [x] `go test ./internal/cliproxy/auth ./internal/respserver/pop/dynamic -run 'TestDispatchResolvesOAuthModelAliasForceMapping|TestDispatchOAuthModelAliasWithoutForceMappingOmitsResponseMapping|TestPrepareDispatchResponseIncludesForceMapping' -count=1`
- [x] `go test ./internal/cliproxy/auth ./internal/home ./internal/respserver/pop/dynamic -count=1`
- [x] `go build -o test-output ./cmd/home && rm test-output`
- [x] `git diff --check`

## Compatibility

CPA already treats the dispatch fields as optional. Older Home behavior remains compatible, API-key aliases keep their existing path, and aliases without `force-mapping` continue to route without response rewriting.