### PR TITLE
fix(auth): restore Home-managed credential cooling

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -178,7 +178,8 @@ max-retry-credentials: 0
 # Maximum wait time in seconds for a cooled-down credential before triggering a retry.
 max-retry-interval: 30
 
-# When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
+# Home always owns auth/model cooldown scheduling and normalizes this to false.
+# Home-mode CPA nodes always receive true and defer credential management to Home.
 disable-cooling: false
 
 # disable-image-generation supports: false (default), true, or "chat".

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -2618,7 +2618,7 @@ Example response:
 
 ### DELETE `/credentials/:credential_id/cooldown`
 
-Clears Home-owned execution quota cooldown state for one credential. Without a query parameter, the operation clears quota cooldowns for every model. With `?model=<model>`, it clears only the canonicalized model key; request-option suffixes such as `(high)` are removed before lookup.
+Clears Home-owned execution quota cooldown state for one credential. Without a query parameter, the operation clears quota cooldowns for every model. With `?model=<model>`, request-option suffixes such as `(high)` are removed and credential-specific public aliases or prefixes are resolved to the canonical upstream model before lookup. The compatibility route-model key is also cleared when it differs from the upstream key.
 
 Execution cooldowns are always scoped to a credential and canonical model pair; Home never creates a credential-wide execution cooldown. CPA execution results without a canonical model are ignored by the cooldown state machine. HTTP 429 results use the capped model-level exponential backoff and do not use `Retry-After` or provider `retryDelay` hints for scheduling.
 

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -3970,7 +3970,7 @@ These fields are accepted by Home YAML config. `PUT /config.yaml` accepts non-cr
 | `plugins.configs` | object | Per-plugin config keyed by plugin ID. Store installs write a pinned `store` manifest under each plugin entry. Home-mode CPA nodes download store entries from that manifest; Home downloads and loads them only when `load-in-home: true` is explicitly set. |
 | `usage-statistics-enabled` | boolean | Enables in-memory usage aggregation. Home forces this to `true` for downstream CPA nodes and rejects disabling it through Management API updates. |
 | `redis-usage-queue-retention-seconds` | integer | Usage queue retention window. Default `60`, max `3600`. |
-| `disable-cooling` | boolean | Globally disables quota cooldown scheduling. Home forces this to `true` for downstream CPA nodes. |
+| `disable-cooling` | boolean | Compatibility field. Home is the sole credential scheduler and always normalizes this to `false` so central quota cooldown remains enabled. Config sent to downstream CPA nodes is independently forced to `true`, disabling only CPA-local cooldown. |
 | `auth-auto-refresh-workers` | integer | Overrides auth auto-refresh worker count. |
 | `request-retry` | integer | Failed request retry count. |
 | `max-retry-credentials` | integer | Max credentials to try per failed request; `<=0` means all available. |

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -182,6 +182,7 @@ The table below is extracted from the final Home route registry built by `intern
 | `GET` | `/credentials/concurrency` |
 | `GET` | `/credentials/:credential_id/concurrency-policy` |
 | `PATCH` | `/credentials/:credential_id/concurrency-policy` |
+| `DELETE` | `/credentials/:credential_id/cooldown` |
 | `GET` | `/config.yaml` |
 | `PUT` | `/config.yaml` |
 | `GET` | `/debug` |
@@ -2615,6 +2616,36 @@ Example response:
 }
 ```
 
+### DELETE `/credentials/:credential_id/cooldown`
+
+Clears Home-owned execution quota cooldown state for one credential. Without a query parameter, the operation clears quota cooldowns for every model. With `?model=<model>`, it clears only the canonicalized model key; request-option suffixes such as `(high)` are removed before lookup.
+
+Execution cooldowns are always scoped to a credential and canonical model pair; Home never creates a credential-wide execution cooldown. CPA execution results without a canonical model are ignored by the cooldown state machine. HTTP 429 results use the capped model-level exponential backoff and do not use `Retry-After` or provider `retryDelay` hints for scheduling.
+
+This operation is idempotent. It only clears cooldown state created by quota-exceeded/HTTP 429 results: quota flags, retry deadline, and backoff level. It does not enable a manually disabled credential, clear model-level 401/403/404/5xx state, change refresh scheduling, modify provider quota snapshots, or consume provider reset credits.
+
+Examples:
+
+```http
+DELETE /credentials/credential-db-id/cooldown
+DELETE /credentials/credential-db-id/cooldown?model=gpt-5
+```
+
+Example model-scoped response:
+
+```json
+{
+  "status": "ok",
+  "credential_id": "credential-db-id",
+  "scope": "model",
+  "model": "gpt-5",
+  "cleared": true,
+  "cleared_models": ["gpt-5"]
+}
+```
+
+For an all-model request, `scope` is `all` and `model` is omitted. `cleared` is `false` when the credential exists but the requested scope has no quota cooldown. An unknown credential returns HTTP `404` with `error: "credential_not_found"`; an explicitly empty `model` returns HTTP `400` with `error: "model_required"`; an unavailable atomic state backend returns HTTP `503` with `error: "cooldown_reset_unavailable"`.
+
 ### Credential in-flight observation
 
 `GET /credentials/in-flight` returns bounded request details derived only from the latest complete CPA snapshots. It accepts optional `credential_id` and `model` exact-match filters plus `limit` and `offset`. `limit` defaults to 100 and is bounded to 1 through 1000; `offset` defaults to 0. Each item contains `request_id`, `credential_id`, normalized upstream `model`, `request_kind`, and `started_at`. `request_id` is a display and correlation field, not a row-uniqueness guarantee; clients must preserve distinct returned rows even when request IDs repeat. A credential with a policy also includes its authoritative `limiter` state. It never exposes CPA identity, tokens, or request payloads. Every response also returns `total`, nullable `next_offset`, nullable `snapshot_cursor`, nullable `snapshot_cursor_read_at`, and nullable `snapshot_expires_at`. When `offset + returned item count < total`, `next_offset` equals that sum; otherwise `next_offset` is `null`.
@@ -2704,6 +2735,7 @@ Response fields:
 | `capabilities.credential_in_flight_snapshots` | boolean | Whether the independent CPA in-flight observation snapshot APIs are available. |
 | `capabilities.credential_in_flight_snapshot_cursor` | boolean | Whether `GET /credentials/in-flight` supports database-backed stable snapshot cursors for multi-page reads. |
 | `capabilities.credential_concurrency_limits_v2` | boolean | Whether concurrency policy and authoritative admitted-counter APIs are available. |
+| `capabilities.credential_cooldown_reset` | boolean | Whether `DELETE /credentials/:credential_id/cooldown` supports all-model and model-scoped quota cooldown resets. |
 | `server_info.home_version` | string | Home build version. |
 | `server_info.home_commit` | string | Home build commit. |
 | `server_info.home_build_date` | string | Home build time. |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -2617,7 +2617,7 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 
 ### DELETE `/credentials/:credential_id/cooldown`
 
-清除一个凭证中由 Home 管理的执行 quota cooldown。不带 query 参数时，会清除全部模型的 quota cooldown；带 `?model=<model>` 时，只清除 canonicalization 后的 model key，请求选项后缀（例如 `(high)`）会在查找前移除。
+清除一个凭证中由 Home 管理的执行 quota cooldown。不带 query 参数时，会清除全部模型的 quota cooldown；带 `?model=<model>` 时，会先移除请求选项后缀（例如 `(high)`），再按目标凭证把公开 alias 或 prefix 解析为 canonical upstream model 后查找。若兼容用的 route-model key 与 upstream key 不同，也会一并清除。
 
 执行 cooldown 始终限定到 credential 与 canonical model 的组合；Home 不会创建凭证级执行 cooldown。缺少 canonical model 的 CPA 执行结果不会进入 cooldown 状态机。HTTP 429 始终使用有上限的模型级指数退避，不使用 `Retry-After` 或 provider `retryDelay` 提示进行调度。
 

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -182,6 +182,7 @@ DB-backed handler 通常同时返回机器可读 `error` 和可读 `message`：
 | `GET` | `/credentials/concurrency` |
 | `GET` | `/credentials/:credential_id/concurrency-policy` |
 | `PATCH` | `/credentials/:credential_id/concurrency-policy` |
+| `DELETE` | `/credentials/:credential_id/cooldown` |
 | `GET` | `/config.yaml` |
 | `PUT` | `/config.yaml` |
 | `GET` | `/debug` |
@@ -2614,6 +2615,36 @@ Token 替换更严格：只要任意 header 包含 `$TOKEN$`，`auth_index` 就�
 }
 ```
 
+### DELETE `/credentials/:credential_id/cooldown`
+
+清除一个凭证中由 Home 管理的执行 quota cooldown。不带 query 参数时，会清除全部模型的 quota cooldown；带 `?model=<model>` 时，只清除 canonicalization 后的 model key，请求选项后缀（例如 `(high)`）会在查找前移除。
+
+执行 cooldown 始终限定到 credential 与 canonical model 的组合；Home 不会创建凭证级执行 cooldown。缺少 canonical model 的 CPA 执行结果不会进入 cooldown 状态机。HTTP 429 始终使用有上限的模型级指数退避，不使用 `Retry-After` 或 provider `retryDelay` 提示进行调度。
+
+该操作是幂等的，只清除 quota-exceeded/HTTP 429 产生的 cooldown 状态，包括 quota 标记、retry deadline 和 backoff level。它不会启用人工 disabled 的凭证，不会清除模型级 401/403/404/5xx 状态，不会改变 refresh 调度、修改 provider quota snapshot，也不会消费 provider reset credit。
+
+示例：
+
+```http
+DELETE /credentials/credential-db-id/cooldown
+DELETE /credentials/credential-db-id/cooldown?model=gpt-5
+```
+
+指定 model 的响应示例：
+
+```json
+{
+  "status": "ok",
+  "credential_id": "credential-db-id",
+  "scope": "model",
+  "model": "gpt-5",
+  "cleared": true,
+  "cleared_models": ["gpt-5"]
+}
+```
+
+全模型请求的 `scope` 为 `all`，且不返回 `model`。凭证存在但目标范围当前没有 quota cooldown 时，`cleared` 为 `false`。未知凭证返回 HTTP `404` 和 `error: "credential_not_found"`；显式提供空 `model` 返回 HTTP `400` 和 `error: "model_required"`；原子状态后端不可用时返回 HTTP `503` 和 `error: "cooldown_reset_unavailable"`。
+
 ### Credential in-flight observation
 
 `GET /credentials/in-flight` 只返回从最新完整 CPA snapshot 派生的有界请求详情。它支持可选的精确匹配 `credential_id`、`model` 过滤，以及 `limit` 和 `offset`。`limit` 默认 100，范围为 1 到 1000；`offset` 默认 0。每项包含 `request_id`、`credential_id`、规范化上游 `model`、`request_kind` 和 `started_at`。`request_id` 只是展示和关联字段，不保证每行唯一；即使 request ID 重复，客户端也必须保留后端返回的不同记录。带有策略的凭证还会包含权威 `limiter` 状态。接口绝不暴露 CPA 身份、token 或请求 payload。每个响应还会返回 `total`、可空的 `next_offset`、可空的 `snapshot_cursor`、可空的 `snapshot_cursor_read_at` 和可空的 `snapshot_expires_at`。当 `offset + 本页返回条数 < total` 时，`next_offset` 必须等于该和值；否则 `next_offset` 为 `null`。
@@ -2703,6 +2734,7 @@ Home 管理的 CPA 使用数据库支持的 observation 配置。`credential-in-
 | `capabilities.credential_in_flight_snapshots` | boolean | 是否支持独立的 CPA in-flight observation snapshot 接口。 |
 | `capabilities.credential_in_flight_snapshot_cursor` | boolean | `GET /credentials/in-flight` 是否支持数据库支持的稳定 snapshot cursor 多页读取。 |
 | `capabilities.credential_concurrency_limits_v2` | boolean | 是否支持 concurrency policy 和权威已准入计数接口。 |
+| `capabilities.credential_cooldown_reset` | boolean | 是否支持通过 `DELETE /credentials/:credential_id/cooldown` 清除全部模型或指定模型的 quota cooldown。 |
 | `server_info.home_version` | string | Home 构建版本。 |
 | `server_info.home_commit` | string | Home 构建 commit。 |
 | `server_info.home_build_date` | string | Home 构建时间。 |

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -3939,7 +3939,7 @@ DELETE query：
 | `plugins.configs` | object | 以插件 ID 为 key 的单插件配置。插件商店安装会在插件条目下写入固定 `store` manifest；Home-mode CPA 节点根据该 manifest 下载产物，Home 仅在显式设置 `load-in-home: true` 时下载并加载。 |
 | `usage-statistics-enabled` | boolean | 启用内存 usage aggregation。Home 会向下游 CPA 强制为 `true`，并拒绝通过 Management API 关闭。 |
 | `redis-usage-queue-retention-seconds` | integer | Usage queue 保留窗口；默认 `60`，最大 `3600`。 |
-| `disable-cooling` | boolean | 全局禁用 quota cooldown scheduling。Home 会向下游 CPA 强制为 `true`。 |
+| `disable-cooling` | boolean | 兼容字段。Home 是唯一的凭证调度器，会始终将该值规范为 `false`，确保中央 quota cooldown 启用；发送给下游 CPA 的配置会独立强制为 `true`，仅禁用 CPA 本地 cooldown。 |
 | `auth-auto-refresh-workers` | integer | 覆盖 auth auto-refresh worker 数量。 |
 | `request-retry` | integer | 失败请求重试次数。 |
 | `max-retry-credentials` | integer | 一个失败请求最多尝试的凭证数量；`<=0` 表示所有可用凭证。 |

--- a/internal/cliproxy/auth/cooldown.go
+++ b/internal/cliproxy/auth/cooldown.go
@@ -1,8 +1,283 @@
 package auth
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
 )
+
+// ErrCooldownMutationUnsupported indicates that the auth store cannot apply an
+// atomic cooldown reset. Home requires atomic mutation so multiple instances
+// sharing one database cannot overwrite each other's credential state.
+var ErrCooldownMutationUnsupported = errors.New("auth manager: cooldown reset requires an atomic state store")
+
+// CooldownClearResult describes quota cooldown state removed by an operator.
+type CooldownClearResult struct {
+	CredentialID  string
+	Model         string
+	Cleared       bool
+	ClearedModels []string
+}
+
+type cooldownClearTransition struct {
+	clearedModels []string
+}
+
+func (t cooldownClearTransition) changed() bool {
+	return len(t.clearedModels) > 0
+}
+
+// ClearQuotaCooldown atomically clears model quota cooldown state for one
+// credential. An empty model clears every model; a non-empty model clears only
+// that canonical model key.
+func (m *Manager) ClearQuotaCooldown(ctx context.Context, credentialID, model string) (CooldownClearResult, error) {
+	result := CooldownClearResult{}
+	if m == nil {
+		return result, errors.New("auth manager: nil manager")
+	}
+	credentialID = strings.TrimSpace(credentialID)
+	if credentialID == "" {
+		return result, errors.New("auth manager: missing auth id")
+	}
+	model = canonicalModelKey(model)
+	result.CredentialID = credentialID
+	result.Model = model
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.RLock()
+	store := m.store
+	m.mu.RUnlock()
+	mutator, ok := store.(StateMutator)
+	if !ok || mutator == nil {
+		return result, ErrCooldownMutationUnsupported
+	}
+
+	now := time.Now().UTC()
+	transition := cooldownClearTransition{}
+	persisted, errMutate := mutator.MutateAuthState(ctx, credentialID, func(auth *Auth) bool {
+		transition = clearQuotaCooldownState(auth, model, now)
+		return transition.changed()
+	})
+	if errMutate != nil {
+		return result, errMutate
+	}
+	if persisted == nil {
+		return result, errors.New("auth manager: cooldown reset returned no auth")
+	}
+
+	authSnapshot, adopted := m.adoptPersistedCooldownState(persisted, now)
+	if adopted && m.scheduler != nil && authSnapshot != nil {
+		m.scheduler.upsertAuth(authSnapshot)
+	}
+	if adopted {
+		m.ReconcileRegistryModelStates(ctx, credentialID)
+	}
+
+	result.Cleared = transition.changed()
+	result.ClearedModels = append([]string(nil), transition.clearedModels...)
+	return result, nil
+}
+
+func clearQuotaCooldownState(auth *Auth, model string, now time.Time) cooldownClearTransition {
+	transition := cooldownClearTransition{}
+	if auth == nil {
+		return transition
+	}
+
+	wasDisabled := auth.Disabled || auth.Status == StatusDisabled
+	disabledStatus := auth.Status
+	disabledMessage := auth.StatusMessage
+	disabledLastError := cloneError(auth.LastError)
+	disabledUnavailable := auth.Unavailable
+	disabledRetryAfter := auth.NextRetryAfter
+
+	preserveLegacyCredentialQuota := hasLegacyCredentialQuota(auth)
+	preservedAuthQuota := auth.Quota
+	preservedAuthStatus := auth.Status
+	preservedAuthMessage := auth.StatusMessage
+	preservedAuthLastError := cloneError(auth.LastError)
+	preservedAuthUnavailable := auth.Unavailable
+	preservedAuthRetryAfter := auth.NextRetryAfter
+	preserveNonQuotaAuthError := auth.LastError != nil && statusCodeFromResult(auth.LastError) != http.StatusTooManyRequests && !authErrorMirroredByModel(auth)
+
+	if model != "" {
+		if state := auth.ModelStates[model]; clearModelQuotaCooldown(state, now) {
+			transition.clearedModels = append(transition.clearedModels, model)
+		}
+	} else {
+		models := make([]string, 0, len(auth.ModelStates))
+		for modelID := range auth.ModelStates {
+			models = append(models, modelID)
+		}
+		sort.Strings(models)
+		for _, modelID := range models {
+			state := auth.ModelStates[modelID]
+			if !clearModelQuotaCooldown(state, now) {
+				continue
+			}
+			transition.clearedModels = append(transition.clearedModels, modelID)
+		}
+	}
+
+	if !transition.changed() {
+		return transition
+	}
+
+	updateAggregatedAvailability(auth, now)
+	if preserveLegacyCredentialQuota {
+		auth.Quota = preservedAuthQuota
+	}
+	switch {
+	case wasDisabled:
+		auth.Disabled = true
+		auth.Status = disabledStatus
+		auth.StatusMessage = disabledMessage
+		auth.LastError = disabledLastError
+		auth.Unavailable = disabledUnavailable
+		auth.NextRetryAfter = disabledRetryAfter
+	case preserveLegacyCredentialQuota:
+		auth.Status = preservedAuthStatus
+		auth.StatusMessage = preservedAuthMessage
+		auth.LastError = preservedAuthLastError
+		auth.Unavailable = preservedAuthUnavailable
+		auth.NextRetryAfter = preservedAuthRetryAfter
+	case preserveNonQuotaAuthError:
+		auth.Status = preservedAuthStatus
+		auth.StatusMessage = preservedAuthMessage
+		auth.LastError = preservedAuthLastError
+		auth.Unavailable = preservedAuthUnavailable
+		auth.NextRetryAfter = preservedAuthRetryAfter
+	case !auth.Quota.Exceeded && !hasModelError(auth, now):
+		auth.Status = StatusActive
+		auth.StatusMessage = ""
+		auth.LastError = nil
+		auth.Unavailable = false
+		auth.NextRetryAfter = time.Time{}
+	}
+	reconcileAuthErrorAfterQuotaClear(auth)
+	auth.UpdatedAt = now
+	return transition
+}
+
+func hasLegacyCredentialQuota(auth *Auth) bool {
+	if auth == nil || !auth.Quota.Exceeded {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(auth.Quota.Scope)) {
+	case "credential":
+		return true
+	case quotaScopeModel:
+		return false
+	}
+
+	// Quota scope was not persisted before Home introduced model-only
+	// scheduling. Distinguish the old model aggregate from an independent
+	// credential quota so an operator reset changes only ModelStates.
+	hasModelQuota := false
+	recoverAt := time.Time{}
+	maxBackoffLevel := 0
+	for _, state := range auth.ModelStates {
+		if state == nil || !state.Quota.Exceeded {
+			continue
+		}
+		hasModelQuota = true
+		if recoverAt.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(recoverAt)) {
+			recoverAt = state.Quota.NextRecoverAt
+		}
+		if state.Quota.BackoffLevel > maxBackoffLevel {
+			maxBackoffLevel = state.Quota.BackoffLevel
+		}
+	}
+	return !hasModelQuota ||
+		!strings.EqualFold(strings.TrimSpace(auth.Quota.Reason), "quota") ||
+		!auth.Quota.NextRecoverAt.Equal(recoverAt) ||
+		auth.Quota.BackoffLevel != maxBackoffLevel
+}
+
+func clearModelQuotaCooldown(state *ModelState, now time.Time) bool {
+	if state == nil || !state.Quota.Exceeded {
+		return false
+	}
+	quotaOwnsAvailability := state.LastError == nil || statusCodeFromResult(state.LastError) == http.StatusTooManyRequests
+	state.Quota = QuotaState{}
+	if state.Status != StatusDisabled && quotaOwnsAvailability {
+		state.Status = StatusActive
+		state.StatusMessage = ""
+		state.LastError = nil
+		state.Unavailable = false
+		state.NextRetryAfter = time.Time{}
+	}
+	// Keep the execution timestamp unchanged. Older Home versions merge model
+	// states only by UpdatedAt, so advancing it for an operator reset would let
+	// the cleared quota snapshot overwrite a newer local 401/403/404/5xx state
+	// during a rolling upgrade. QuotaResetAt carries the mutation timestamp for
+	// reset-aware peers and state-version fingerprints.
+	state.QuotaResetAt = now
+	return true
+}
+
+func authErrorMirroredByModel(auth *Auth) bool {
+	if auth == nil || auth.LastError == nil {
+		return false
+	}
+	for _, state := range auth.ModelStates {
+		if state == nil || state.LastError == nil {
+			continue
+		}
+		if state.LastError.HTTPStatus == auth.LastError.HTTPStatus &&
+			strings.TrimSpace(state.LastError.Code) == strings.TrimSpace(auth.LastError.Code) &&
+			strings.TrimSpace(state.LastError.Message) == strings.TrimSpace(auth.LastError.Message) {
+			return true
+		}
+	}
+	return false
+}
+
+func reconcileAuthErrorAfterQuotaClear(auth *Auth) {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled || auth.Quota.Exceeded || auth.LastError == nil || statusCodeFromResult(auth.LastError) != http.StatusTooManyRequests {
+		return
+	}
+	var latest *ModelState
+	for _, state := range auth.ModelStates {
+		if state == nil || state.LastError == nil || state.Quota.Exceeded {
+			continue
+		}
+		if latest == nil || state.UpdatedAt.After(latest.UpdatedAt) {
+			latest = state
+		}
+	}
+	if latest == nil {
+		return
+	}
+	auth.Status = latest.Status
+	if auth.Status == StatusActive || auth.Status == StatusDisabled {
+		auth.Status = StatusError
+	}
+	auth.StatusMessage = latest.StatusMessage
+	auth.LastError = cloneError(latest.LastError)
+}
+
+func mergePersistedCooldownModelStates(persisted, local map[string]*ModelState) map[string]*ModelState {
+	merged := make(map[string]*ModelState, len(persisted)+len(local))
+	for model, state := range persisted {
+		merged[model] = state.Clone()
+	}
+	for model, localState := range local {
+		if localState == nil {
+			continue
+		}
+		merged[model] = MergePersistedModelState(merged[model], localState)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}
 
 // MergePersistedModelState combines authoritative persisted quota state with
 // newer execution-only state accumulated by one Home instance.
@@ -69,4 +344,54 @@ func modelHasNonQuotaState(state *ModelState) bool {
 		return statusCodeFromResult(state.LastError) != http.StatusTooManyRequests
 	}
 	return state.Status == StatusError && !state.Quota.Exceeded
+}
+
+func (m *Manager) adoptPersistedCooldownState(persisted *Auth, now time.Time) (*Auth, bool) {
+	if m == nil || persisted == nil {
+		return nil, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	local := m.auths[persisted.ID]
+	if local == nil {
+		return persisted.Clone(), false
+	}
+	if local.StateVersion > 0 && persisted.StateVersion > 0 && local.StateVersion > persisted.StateVersion {
+		return local.Clone(), false
+	}
+
+	persistedClone := persisted.Clone()
+	persistedLegacyCredentialQuota := hasLegacyCredentialQuota(persistedClone)
+	persistedGlobalError := persistedClone.LastError != nil && statusCodeFromResult(persistedClone.LastError) != http.StatusTooManyRequests && !authErrorMirroredByModel(persistedClone)
+	local.StateVersion = persistedClone.StateVersion
+	local.Disabled = persistedClone.Disabled
+	local.Status = persistedClone.Status
+	local.StatusMessage = persistedClone.StatusMessage
+	local.LastError = cloneError(persistedClone.LastError)
+	local.Unavailable = persistedClone.Unavailable
+	local.NextRetryAfter = persistedClone.NextRetryAfter
+	local.Quota = persistedClone.Quota
+	local.ModelStates = mergePersistedCooldownModelStates(persistedClone.ModelStates, local.ModelStates)
+	local.UpdatedAt = persistedClone.UpdatedAt
+
+	if !local.Disabled && local.Status != StatusDisabled {
+		updateAggregatedAvailability(local, now)
+		switch {
+		case persistedLegacyCredentialQuota:
+			local.Status = persistedClone.Status
+			local.StatusMessage = persistedClone.StatusMessage
+			local.LastError = cloneError(persistedClone.LastError)
+			local.Unavailable = persistedClone.Unavailable
+			local.NextRetryAfter = persistedClone.NextRetryAfter
+			local.Quota = persistedClone.Quota
+		case persistedGlobalError:
+			local.Status = persistedClone.Status
+			local.StatusMessage = persistedClone.StatusMessage
+			local.LastError = cloneError(persistedClone.LastError)
+			local.Unavailable = persistedClone.Unavailable
+			local.NextRetryAfter = persistedClone.NextRetryAfter
+		}
+		reconcileAuthErrorAfterQuotaClear(local)
+	}
+	return local.Clone(), true
 }

--- a/internal/cliproxy/auth/cooldown.go
+++ b/internal/cliproxy/auth/cooldown.go
@@ -42,9 +42,9 @@ func (m *Manager) ClearQuotaCooldown(ctx context.Context, credentialID, model st
 	if credentialID == "" {
 		return result, errors.New("auth manager: missing auth id")
 	}
-	model = canonicalModelKey(model)
+	requestedModel := canonicalModelKey(model)
 	result.CredentialID = credentialID
-	result.Model = model
+	result.Model = requestedModel
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -60,7 +60,21 @@ func (m *Manager) ClearQuotaCooldown(ctx context.Context, credentialID, model st
 	now := time.Now().UTC()
 	transition := cooldownClearTransition{}
 	persisted, errMutate := mutator.MutateAuthState(ctx, credentialID, func(auth *Auth) bool {
-		transition = clearQuotaCooldownState(auth, model, now)
+		modelKeys := []string(nil)
+		if requestedModel != "" {
+			resolvedModel := requestedModel
+			if resolved := m.resolveDispatchModel(auth, requestedModel); resolved.Key != "" {
+				resolvedModel = resolved.Key
+			}
+			result.Model = resolvedModel
+			modelKeys = append(modelKeys, resolvedModel)
+			if requestedModel != resolvedModel {
+				// Clear the pre-upstream-key route state too so rolling upgrades do
+				// not leave the scheduler blocked by its compatibility fallback.
+				modelKeys = append(modelKeys, requestedModel)
+			}
+		}
+		transition = clearQuotaCooldownState(auth, modelKeys, now)
 		return transition.changed()
 	})
 	if errMutate != nil {
@@ -83,7 +97,7 @@ func (m *Manager) ClearQuotaCooldown(ctx context.Context, credentialID, model st
 	return result, nil
 }
 
-func clearQuotaCooldownState(auth *Auth, model string, now time.Time) cooldownClearTransition {
+func clearQuotaCooldownState(auth *Auth, models []string, now time.Time) cooldownClearTransition {
 	transition := cooldownClearTransition{}
 	if auth == nil {
 		return transition
@@ -105,17 +119,29 @@ func clearQuotaCooldownState(auth *Auth, model string, now time.Time) cooldownCl
 	preservedAuthRetryAfter := auth.NextRetryAfter
 	preserveNonQuotaAuthError := auth.LastError != nil && statusCodeFromResult(auth.LastError) != http.StatusTooManyRequests && !authErrorMirroredByModel(auth)
 
-	if model != "" {
-		if state := auth.ModelStates[model]; clearModelQuotaCooldown(state, now) {
-			transition.clearedModels = append(transition.clearedModels, model)
-		}
-	} else {
-		models := make([]string, 0, len(auth.ModelStates))
-		for modelID := range auth.ModelStates {
-			models = append(models, modelID)
-		}
-		sort.Strings(models)
+	if len(models) > 0 {
+		seen := make(map[string]struct{}, len(models))
 		for _, modelID := range models {
+			modelID = canonicalModelKey(modelID)
+			if modelID == "" {
+				continue
+			}
+			if _, exists := seen[modelID]; exists {
+				continue
+			}
+			seen[modelID] = struct{}{}
+			if state := auth.ModelStates[modelID]; clearModelQuotaCooldown(state, now) {
+				transition.clearedModels = append(transition.clearedModels, modelID)
+			}
+		}
+		sort.Strings(transition.clearedModels)
+	} else {
+		allModels := make([]string, 0, len(auth.ModelStates))
+		for modelID := range auth.ModelStates {
+			allModels = append(allModels, modelID)
+		}
+		sort.Strings(allModels)
+		for _, modelID := range allModels {
 			state := auth.ModelStates[modelID]
 			if !clearModelQuotaCooldown(state, now) {
 				continue

--- a/internal/cliproxy/auth/cooldown.go
+++ b/internal/cliproxy/auth/cooldown.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"net/http"
+)
+
+// MergePersistedModelState combines authoritative persisted quota state with
+// newer execution-only state accumulated by one Home instance.
+func MergePersistedModelState(persistedState, localState *ModelState) *ModelState {
+	if persistedState == nil {
+		if localState == nil {
+			return nil
+		}
+		return localState.Clone()
+	}
+	if localState == nil {
+		return persistedState.Clone()
+	}
+
+	if !persistedState.QuotaResetAt.IsZero() {
+		// A reset owns quota state even when a repeated in-window 429 gave the
+		// local copy a newer execution timestamp.
+		if modelHasNonQuotaState(localState) {
+			return mergePersistedQuotaIntoLocalState(persistedState, localState)
+		}
+		return persistedState.Clone()
+	}
+	if persistedState.Quota.Exceeded {
+		// Shared quota remains authoritative. Preserve a newer local non-quota
+		// error without shortening the persisted quota recovery window.
+		if localState.UpdatedAt.After(persistedState.UpdatedAt) && modelHasNonQuotaState(localState) {
+			return mergePersistedQuotaIntoLocalState(persistedState, localState)
+		}
+		return persistedState.Clone()
+	}
+	if localState.UpdatedAt.After(persistedState.UpdatedAt) {
+		return localState.Clone()
+	}
+	return persistedState.Clone()
+}
+
+func mergePersistedQuotaIntoLocalState(persistedState, localState *ModelState) *ModelState {
+	merged := localState.Clone()
+	merged.Quota = persistedState.Quota
+	merged.QuotaResetAt = persistedState.QuotaResetAt
+	if !persistedState.Quota.Exceeded {
+		return merged
+	}
+
+	merged.Unavailable = true
+	persistedRetry := persistedState.NextRetryAfter
+	if persistedState.Quota.NextRecoverAt.After(persistedRetry) {
+		persistedRetry = persistedState.Quota.NextRecoverAt
+	}
+	if persistedRetry.After(merged.NextRetryAfter) {
+		merged.NextRetryAfter = persistedRetry
+	}
+	return merged
+}
+
+func modelHasNonQuotaState(state *ModelState) bool {
+	if state == nil {
+		return false
+	}
+	if state.Status == StatusDisabled {
+		return true
+	}
+	if state.LastError != nil {
+		return statusCodeFromResult(state.LastError) != http.StatusTooManyRequests
+	}
+	return state.Status == StatusError && !state.Quota.Exceeded
+}

--- a/internal/cliproxy/auth/cooldown_backoff_test.go
+++ b/internal/cliproxy/auth/cooldown_backoff_test.go
@@ -95,50 +95,6 @@ func TestMarkResultQuotaBackoffEscalatesAfterWindowExpiry(t *testing.T) {
 	}
 }
 
-func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
-	manager := NewManager(nil, nil, nil)
-	now := time.Now()
-	quotaErr := &Error{Message: "quota", HTTPStatus: http.StatusTooManyRequests}
-	auth := &Auth{ID: "auth-level-quota"}
-
-	applyAuthFailureState(manager, auth, quotaErr, nil, now)
-	if auth.Quota.BackoffLevel != 1 {
-		t.Fatalf("expected BackoffLevel 1 after first failure, got %d", auth.Quota.BackoffLevel)
-	}
-	firstRecover := auth.Quota.NextRecoverAt
-	if !firstRecover.Equal(now.Add(time.Second)) {
-		t.Fatalf("expected first window to close at %v, got %v", now.Add(time.Second), firstRecover)
-	}
-
-	// In-window failure keeps the current window and level.
-	applyAuthFailureState(manager, auth, quotaErr, nil, now.Add(100*time.Millisecond))
-	if auth.Quota.BackoffLevel != 1 {
-		t.Fatalf("expected BackoffLevel to stay 1 for in-window failure, got %d", auth.Quota.BackoffLevel)
-	}
-	if !auth.Quota.NextRecoverAt.Equal(firstRecover) {
-		t.Fatalf("expected NextRecoverAt to stay %v for in-window failure, got %v", firstRecover, auth.Quota.NextRecoverAt)
-	}
-
-	// A failure after the window expired escalates to the next level.
-	applyAuthFailureState(manager, auth, quotaErr, nil, now.Add(2*time.Second))
-	if auth.Quota.BackoffLevel != 2 {
-		t.Fatalf("expected BackoffLevel 2 after post-window failure, got %d", auth.Quota.BackoffLevel)
-	}
-	if !auth.Quota.NextRecoverAt.Equal(now.Add(4 * time.Second)) {
-		t.Fatalf("expected second window to close at %v, got %v", now.Add(4*time.Second), auth.Quota.NextRecoverAt)
-	}
-
-	// A provider supplied retry hint always takes effect, even in-window.
-	retryAfter := 10 * time.Second
-	applyAuthFailureState(manager, auth, quotaErr, &retryAfter, now.Add(3*time.Second))
-	if auth.Quota.BackoffLevel != 2 {
-		t.Fatalf("expected BackoffLevel to stay 2 with retry hint, got %d", auth.Quota.BackoffLevel)
-	}
-	if !auth.Quota.NextRecoverAt.Equal(now.Add(13 * time.Second)) {
-		t.Fatalf("expected retry hint window to close at %v, got %v", now.Add(13*time.Second), auth.Quota.NextRecoverAt)
-	}
-}
-
 func TestNextQuotaCooldownLadder(t *testing.T) {
 	cases := []struct {
 		prevLevel    int

--- a/internal/cliproxy/auth/cooldown_test.go
+++ b/internal/cliproxy/auth/cooldown_test.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
 )
 
 func quotaCooldownModelState(now time.Time, delay time.Duration) *ModelState {
@@ -103,5 +106,103 @@ func TestLegacyCredentialWideStateDoesNotBlockDispatch(t *testing.T) {
 		if blocked, reason, retryAt := isAuthBlockedForModel(auth, model, now); blocked || reason != blockReasonNone || !retryAt.IsZero() {
 			t.Fatalf("model %q blocked/reason/next = %v/%v/%v, want available", model, blocked, reason, retryAt)
 		}
+	}
+}
+func registryHasAvailableModel(modelRegistry *registry.ModelRegistry, model string) bool {
+	for _, item := range modelRegistry.GetAvailableModelDefinitions() {
+		if item != nil && item.ID == model {
+			return true
+		}
+	}
+	return false
+}
+
+func TestReconcileRegistryModelStatesKeepsTransientErrorsVisible(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized},
+		{name: "request-timeout", status: http.StatusRequestTimeout},
+		{name: "internal-server-error", status: http.StatusInternalServerError},
+		{name: "bad-gateway", status: http.StatusBadGateway},
+		{name: "service-unavailable", status: http.StatusServiceUnavailable},
+		{name: "gateway-timeout", status: http.StatusGatewayTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			authID := "auth-registry-transient-" + tc.name
+			model := "registry-transient-" + tc.name
+			modelRegistry := registry.GetGlobalRegistry()
+			modelRegistry.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model, Object: "model", Type: "openai"}})
+			t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+
+			manager := NewManager(nil, nil, nil)
+			if _, errRegister := manager.Register(context.Background(), &Auth{ID: authID, Index: authID, Provider: "codex", Status: StatusActive}); errRegister != nil {
+				t.Fatalf("Register() error = %v", errRegister)
+			}
+			manager.MarkResult(context.Background(), Result{
+				AuthID: authID, Provider: "codex", Model: model,
+				Error: &Error{Message: http.StatusText(tc.status), HTTPStatus: tc.status},
+			})
+			manager.ReconcileRegistryModelStates(context.Background(), authID)
+			if !registryHasAvailableModel(modelRegistry, model) {
+				t.Fatalf("registry hid model for transient HTTP %d", tc.status)
+			}
+		})
+	}
+}
+
+func TestShouldSuspendRegistryModelMatchesResultTransitions(t *testing.T) {
+	const model = "registry-transition-model"
+	modelUnsupported := &Error{Message: "requested model is not supported", HTTPStatus: http.StatusBadRequest}
+	cases := []struct {
+		name   string
+		reason blockReason
+		err    *Error
+		want   bool
+	}{
+		{name: "quota", reason: blockReasonCooldown, want: true},
+		{name: "disabled", reason: blockReasonDisabled, want: true},
+		{name: "payment-required", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusPaymentRequired}, want: true},
+		{name: "forbidden", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusForbidden}, want: true},
+		{name: "not-found", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusNotFound}, want: true},
+		{name: "model-not-supported", reason: blockReasonOther, err: modelUnsupported, want: true},
+		{name: "unauthorized", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusUnauthorized}},
+		{name: "request-timeout", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusRequestTimeout}},
+		{name: "service-unavailable", reason: blockReasonOther, err: &Error{HTTPStatus: http.StatusServiceUnavailable}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &Auth{ModelStates: map[string]*ModelState{model: {LastError: tc.err}}}
+			if got := shouldSuspendRegistryModel(auth, model, tc.reason); got != tc.want {
+				t.Fatalf("shouldSuspendRegistryModel() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReconcileRegistryModelStatesResumesPeerAfterStateReset(t *testing.T) {
+	const authID = "auth-registry-peer"
+	const model = "registry-peer-model"
+	now := time.Now().UTC()
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model, Object: "model", Type: "openai"}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+	modelRegistry.SuspendClientModel(authID, model, "forbidden")
+	if registryHasAvailableModel(modelRegistry, model) {
+		t.Fatal("test setup did not suspend model")
+	}
+
+	manager := NewManager(nil, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusActive,
+		ModelStates: map[string]*ModelState{model: {Status: StatusActive, UpdatedAt: now, QuotaResetAt: now}},
+	}); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	manager.ReconcileRegistryModelStates(context.Background(), authID)
+	if !registryHasAvailableModel(modelRegistry, model) {
+		t.Fatal("registry remained suspended after peer reconciliation")
 	}
 }

--- a/internal/cliproxy/auth/cooldown_test.go
+++ b/internal/cliproxy/auth/cooldown_test.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func quotaCooldownModelState(now time.Time, delay time.Duration) *ModelState {
+	next := now.Add(delay)
+	return &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+			BackoffLevel:  3,
+		},
+		UpdatedAt: now,
+	}
+}
+
+func TestModelScopedAggregateDoesNotBlockUnrelatedModel(t *testing.T) {
+	now := time.Now().UTC()
+	early := now.Add(10 * time.Minute)
+	late := now.Add(20 * time.Minute)
+	auth := &Auth{
+		ID:       "auth-model-aggregate",
+		Provider: "antigravity",
+		Status:   StatusError,
+		ModelStates: map[string]*ModelState{
+			"model-a": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: early,
+				Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: early, BackoffLevel: 1},
+			},
+			"model-b": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: late,
+				Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: late, BackoffLevel: 3},
+			},
+		},
+	}
+
+	updateAggregatedAvailability(auth, now)
+	if !auth.Quota.Exceeded || auth.Quota.Scope != quotaScopeModel || !auth.Quota.NextRecoverAt.Equal(early) || auth.Quota.BackoffLevel != 3 {
+		t.Fatalf("model aggregate = %#v, want earliest recovery and maximum backoff", auth.Quota)
+	}
+	if blocked, reason, next := isAuthBlockedForModel(auth, "model-c", now); blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("unrelated model blocked/reason/next = %v/%v/%v, want available", blocked, reason, next)
+	}
+}
+
+func TestLegacyMixedModelAggregateDoesNotBlockUnrelatedModel(t *testing.T) {
+	now := time.Now().UTC()
+	early := now.Add(10 * time.Minute)
+	late := now.Add(20 * time.Minute)
+	auth := &Auth{
+		ID:       "auth-legacy-model-aggregate",
+		Provider: "antigravity",
+		Status:   StatusError,
+		Quota:    QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: early, BackoffLevel: 3},
+		ModelStates: map[string]*ModelState{
+			"model-a": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: early,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: early, BackoffLevel: 1},
+			},
+			"model-b": {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: late,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: late, BackoffLevel: 3},
+			},
+		},
+	}
+
+	if blocked, reason, next := isAuthBlockedForModel(auth, "model-c", now); blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("unrelated model blocked/reason/next = %v/%v/%v, want available", blocked, reason, next)
+	}
+}
+
+func TestLegacyCredentialWideStateDoesNotBlockDispatch(t *testing.T) {
+	now := time.Now().UTC()
+	next := now.Add(15 * time.Minute)
+	auth := &Auth{
+		ID:             "auth-legacy-wide",
+		Provider:       "codex",
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: next,
+		Quota:          QuotaState{Exceeded: true, Scope: "credential", Reason: "quota", NextRecoverAt: next, BackoffLevel: 4},
+	}
+
+	for _, model := range []string{"", "gpt-5"} {
+		if blocked, reason, retryAt := isAuthBlockedForModel(auth, model, now); blocked || reason != blockReasonNone || !retryAt.IsZero() {
+			t.Fatalf("model %q blocked/reason/next = %v/%v/%v, want available", model, blocked, reason, retryAt)
+		}
+	}
+}

--- a/internal/cliproxy/auth/cooldown_test.go
+++ b/internal/cliproxy/auth/cooldown_test.go
@@ -206,3 +206,37 @@ func TestReconcileRegistryModelStatesResumesPeerAfterStateReset(t *testing.T) {
 		t.Fatal("registry remained suspended after peer reconciliation")
 	}
 }
+func TestMergePersistedModelStatePreservesActiveQuotaWithNewerNonQuotaError(t *testing.T) {
+	now := time.Now().UTC()
+	quotaRecover := now.Add(10 * time.Minute)
+	persisted := quotaCooldownModelState(now, 10*time.Minute)
+	persisted.Quota.Scope = quotaScopeModel
+	localRetry := now.Add(time.Minute)
+	localUpdated := now.Add(2 * time.Minute)
+	local := &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "transient upstream error",
+		Unavailable:    true,
+		NextRetryAfter: localRetry,
+		LastError:      &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+		UpdatedAt:      localUpdated,
+	}
+
+	merged := MergePersistedModelState(persisted, local)
+	if merged == nil || merged.LastError == nil || merged.LastError.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("merged state = %#v, want newer local 5xx", merged)
+	}
+	if !merged.Quota.Exceeded || merged.Quota.Scope != quotaScopeModel || !merged.Quota.NextRecoverAt.Equal(quotaRecover) {
+		t.Fatalf("merged quota = %#v, want persisted quota", merged.Quota)
+	}
+	if !merged.Unavailable || !merged.NextRetryAfter.Equal(quotaRecover) {
+		t.Fatalf("merged availability = %v/%v, want quota deadline %v", merged.Unavailable, merged.NextRetryAfter, quotaRecover)
+	}
+	if !merged.UpdatedAt.Equal(localUpdated) {
+		t.Fatalf("merged UpdatedAt = %v, want local timestamp %v", merged.UpdatedAt, localUpdated)
+	}
+	auth := &Auth{ModelStates: map[string]*ModelState{"gpt-a": merged}}
+	if blocked, reason, next := isAuthBlockedForModel(auth, "gpt-a", now.Add(2*time.Minute)); !blocked || reason != blockReasonCooldown || !next.Equal(quotaRecover) {
+		t.Fatalf("blocked/reason/next after local retry = %v/%v/%v, want shared quota until %v", blocked, reason, next, quotaRecover)
+	}
+}

--- a/internal/cliproxy/auth/cooldown_test.go
+++ b/internal/cliproxy/auth/cooldown_test.go
@@ -206,6 +206,44 @@ func TestClearQuotaCooldownOverridesNewerLocalQuotaTimestamp(t *testing.T) {
 	}
 }
 
+func TestClearQuotaCooldownResolvesConfiguredAlias(t *testing.T) {
+	const authID = "auth-reset-alias"
+	const routeModel = "team/alias-b"
+	const upstreamModel = "upstream-shared"
+	now := time.Now().UTC()
+	quotaState := quotaCooldownModelState(now, 10*time.Minute)
+	quotaState.Quota.Scope = quotaScopeModel
+	auth := geminiAPIKeyAuth(authID, "high-key", "1")
+	auth.Prefix = "team"
+	auth.Status = StatusError
+	auth.Quota = quotaState.Quota
+	auth.ModelStates = map[string]*ModelState{
+		routeModel:    quotaState.Clone(),
+		upstreamModel: quotaState,
+	}
+	store := &fakeMutatorStore{persisted: auth.Clone()}
+	manager := NewManager(store, nil, nil)
+	setGeminiAliasConfig(manager)
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), authID, routeModel+"(high)")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared || result.Model != upstreamModel || !reflect.DeepEqual(result.ClearedModels, []string{routeModel, upstreamModel}) {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+	persisted := store.persistedSnapshot()
+	for _, model := range []string{routeModel, upstreamModel} {
+		state := persisted.ModelStates[model]
+		if state == nil || state.Quota.Exceeded || state.Unavailable || state.QuotaResetAt.IsZero() {
+			t.Fatalf("persisted %s state after alias reset = %#v", model, state)
+		}
+	}
+}
+
 func TestMergePersistedModelStatePreservesActiveQuotaWithNewerNonQuotaError(t *testing.T) {
 	now := time.Now().UTC()
 	quotaRecover := now.Add(10 * time.Minute)
@@ -656,6 +694,29 @@ func TestReconcileRegistryModelStatesKeepsTransientErrorsVisible(t *testing.T) {
 				t.Fatalf("registry hid model for transient HTTP %d", tc.status)
 			}
 		})
+	}
+}
+
+func TestReconcileRegistryModelStatesMapsUpstreamStateToRegisteredAlias(t *testing.T) {
+	const authID = "auth-registry-alias"
+	const routeModel = "team/alias-b"
+	const upstreamModel = "upstream-shared"
+	manager := NewManager(nil, nil, nil)
+	setGeminiAliasConfig(manager)
+	auth := geminiAPIKeyAuth(authID, "high-key", "1")
+	auth.Prefix = "team"
+	registerDispatchTestAuth(t, manager, auth, routeModel)
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: "gemini",
+		Model:    upstreamModel,
+		Error:    &Error{Message: "forbidden", HTTPStatus: http.StatusForbidden},
+	})
+	manager.ReconcileRegistryModelStates(context.Background(), authID)
+
+	if registryHasAvailableModel(registry.GetGlobalRegistry(), routeModel) {
+		t.Fatal("registry kept alias visible despite blocked upstream model")
 	}
 }
 

--- a/internal/cliproxy/auth/cooldown_test.go
+++ b/internal/cliproxy/auth/cooldown_test.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -108,6 +110,510 @@ func TestLegacyCredentialWideStateDoesNotBlockDispatch(t *testing.T) {
 		}
 	}
 }
+
+func TestClearModelQuotaCooldownKeepsLegacyMergeTimestamp(t *testing.T) {
+	observedAt := time.Now().UTC()
+	resetAt := observedAt.Add(2 * time.Minute)
+	state := quotaCooldownModelState(observedAt, 10*time.Minute)
+	staleQuota := state.Clone()
+
+	if !clearModelQuotaCooldown(state, resetAt) {
+		t.Fatal("clearModelQuotaCooldown() = false, want quota cleared")
+	}
+	if !state.UpdatedAt.Equal(observedAt) {
+		t.Fatalf("UpdatedAt = %v, want execution timestamp %v preserved", state.UpdatedAt, observedAt)
+	}
+	if !state.QuotaResetAt.Equal(resetAt) {
+		t.Fatalf("QuotaResetAt = %v, want %v", state.QuotaResetAt, resetAt)
+	}
+
+	// Home versions before quota reset markers keep the newer model state by
+	// UpdatedAt. Equal timestamps must adopt the cleared persisted quota.
+	legacySelected := state.Clone()
+	if staleQuota.UpdatedAt.After(legacySelected.UpdatedAt) {
+		legacySelected = staleQuota
+	}
+	if legacySelected.Quota.Exceeded || legacySelected.Unavailable {
+		t.Fatalf("legacy peer kept stale quota state: %#v", legacySelected)
+	}
+
+	// A non-quota error observed after the quota must remain newer than the
+	// reset snapshot, so a rolling-upgrade peer does not resume it early.
+	newerError := staleQuota.Clone()
+	newerError.LastError = &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable}
+	newerError.StatusMessage = "transient upstream error"
+	newerError.NextRetryAfter = observedAt.Add(5 * time.Minute)
+	newerError.UpdatedAt = observedAt.Add(time.Minute)
+	legacySelected = state.Clone()
+	if newerError.UpdatedAt.After(legacySelected.UpdatedAt) {
+		legacySelected = newerError
+	}
+	if legacySelected.LastError == nil || legacySelected.LastError.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("legacy peer lost newer non-quota error: %#v", legacySelected)
+	}
+}
+
+func TestClearQuotaCooldownOverridesNewerLocalQuotaTimestamp(t *testing.T) {
+	const authID = "auth-reset-newer-local-quota"
+	const model = "gpt-5"
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:       authID,
+		Index:    authID,
+		Provider: "codex",
+		Status:   StatusActive,
+	}}
+	manager := newHomeNodeManager(t, store, authID)
+
+	manager.MarkResult(context.Background(), quotaResult(authID, model))
+	persistedBefore := store.persistedSnapshot().ModelStates[model]
+	if persistedBefore == nil || !persistedBefore.Quota.Exceeded {
+		t.Fatalf("persisted state after first 429 = %#v", persistedBefore)
+	}
+
+	// A repeated 429 inside the open window stays local but advances the
+	// execution timestamp beyond the persisted quota snapshot.
+	manager.MarkResult(context.Background(), quotaResult(authID, model))
+	localBefore, ok := manager.GetByID(authID)
+	if !ok || localBefore.ModelStates[model] == nil || !localBefore.ModelStates[model].UpdatedAt.After(persistedBefore.UpdatedAt) {
+		t.Fatalf("local state before reset = %#v, want newer in-window 429", localBefore)
+	}
+	if mutations := store.mutationCount(); mutations != 1 {
+		t.Fatalf("mutation count before reset = %d, want one persisted 429", mutations)
+	}
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), authID, model)
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared || !reflect.DeepEqual(result.ClearedModels, []string{model}) {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+
+	persistedAfter := store.persistedSnapshot().ModelStates[model]
+	if persistedAfter == nil || persistedAfter.Quota.Exceeded || persistedAfter.QuotaResetAt.IsZero() {
+		t.Fatalf("persisted state after reset = %#v", persistedAfter)
+	}
+	localAfter, ok := manager.GetByID(authID)
+	if !ok || localAfter.ModelStates[model] == nil {
+		t.Fatalf("local state after reset = %#v", localAfter)
+	}
+	localState := localAfter.ModelStates[model]
+	if localState.Quota.Exceeded || localState.QuotaResetAt.IsZero() || localState.Unavailable || !localState.NextRetryAfter.IsZero() {
+		t.Fatalf("local state after reset = %#v, want persisted reset adopted", localState)
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(localAfter, model, time.Now()); blocked || reason != blockReasonNone {
+		t.Fatalf("model blocked/reason after reset = %v/%v, want available", blocked, reason)
+	}
+}
+
+func TestMergePersistedModelStatePreservesActiveQuotaWithNewerNonQuotaError(t *testing.T) {
+	now := time.Now().UTC()
+	quotaRecover := now.Add(10 * time.Minute)
+	persisted := quotaCooldownModelState(now, 10*time.Minute)
+	persisted.Quota.Scope = quotaScopeModel
+	localRetry := now.Add(time.Minute)
+	localUpdated := now.Add(2 * time.Minute)
+	local := &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "transient upstream error",
+		Unavailable:    true,
+		NextRetryAfter: localRetry,
+		LastError:      &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+		UpdatedAt:      localUpdated,
+	}
+
+	merged := MergePersistedModelState(persisted, local)
+	if merged == nil || merged.LastError == nil || merged.LastError.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("merged state = %#v, want newer local 5xx", merged)
+	}
+	if !merged.Quota.Exceeded || merged.Quota.Scope != quotaScopeModel || !merged.Quota.NextRecoverAt.Equal(quotaRecover) {
+		t.Fatalf("merged quota = %#v, want persisted quota", merged.Quota)
+	}
+	if !merged.Unavailable || !merged.NextRetryAfter.Equal(quotaRecover) {
+		t.Fatalf("merged availability = %v/%v, want quota deadline %v", merged.Unavailable, merged.NextRetryAfter, quotaRecover)
+	}
+	if !merged.UpdatedAt.Equal(localUpdated) {
+		t.Fatalf("merged UpdatedAt = %v, want local timestamp %v", merged.UpdatedAt, localUpdated)
+	}
+	auth := &Auth{ModelStates: map[string]*ModelState{"gpt-a": merged}}
+	if blocked, reason, next := isAuthBlockedForModel(auth, "gpt-a", now.Add(2*time.Minute)); !blocked || reason != blockReasonCooldown || !next.Equal(quotaRecover) {
+		t.Fatalf("blocked/reason/next after local retry = %v/%v/%v, want shared quota until %v", blocked, reason, next, quotaRecover)
+	}
+}
+
+func TestClearQuotaCooldownClearsOnlyRequestedModel(t *testing.T) {
+	now := time.Now().UTC()
+	modelA := quotaCooldownModelState(now, 10*time.Minute)
+	modelB := quotaCooldownModelState(now, 20*time.Minute)
+	refreshAt := now.Add(time.Hour)
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:               "auth-clear-one",
+		Index:            "auth-clear-one",
+		Provider:         "codex",
+		Status:           StatusError,
+		Unavailable:      true,
+		NextRetryAfter:   modelA.NextRetryAfter,
+		NextRefreshAfter: refreshAt,
+		Quota:            modelA.Quota,
+		ModelStates: map[string]*ModelState{
+			"gpt-a": modelA,
+			"gpt-b": modelB,
+		},
+	}}
+	manager := newHomeNodeManager(t, store, "auth-clear-one")
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-clear-one", "gpt-a(high)")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared || result.Model != "gpt-a" || !reflect.DeepEqual(result.ClearedModels, []string{"gpt-a"}) {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+
+	persisted := store.persistedSnapshot()
+	stateA := persisted.ModelStates["gpt-a"]
+	if stateA == nil || stateA.Status != StatusActive || stateA.Unavailable || stateA.Quota.Exceeded || !stateA.NextRetryAfter.IsZero() || stateA.LastError != nil {
+		t.Fatalf("gpt-a state = %#v, want cleared quota cooldown", stateA)
+	}
+	stateB := persisted.ModelStates["gpt-b"]
+	if stateB == nil || !stateB.Quota.Exceeded || !stateB.Unavailable || stateB.NextRetryAfter.IsZero() {
+		t.Fatalf("gpt-b state = %#v, want cooldown preserved", stateB)
+	}
+	if !persisted.NextRefreshAfter.Equal(refreshAt) {
+		t.Fatalf("NextRefreshAfter = %v, want %v", persisted.NextRefreshAfter, refreshAt)
+	}
+
+	local, ok := manager.GetByID("auth-clear-one")
+	if !ok || local == nil {
+		t.Fatal("GetByID() missing auth")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(local, "gpt-a", time.Now()); blocked {
+		t.Fatal("gpt-a remains blocked after cooldown clear")
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(local, "gpt-b", time.Now()); !blocked || reason != blockReasonCooldown {
+		t.Fatalf("gpt-b blocked/reason = %v/%v, want quota cooldown", blocked, reason)
+	}
+}
+
+func TestClearQuotaCooldownClearsAllQuotaModelsAndPreservesOtherErrors(t *testing.T) {
+	now := time.Now().UTC()
+	modelA := quotaCooldownModelState(now, 10*time.Minute)
+	modelB := quotaCooldownModelState(now, 20*time.Minute)
+	transientRetry := now.Add(time.Minute)
+	transient := &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "transient upstream error",
+		Unavailable:    true,
+		NextRetryAfter: transientRetry,
+		LastError:      &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+		UpdatedAt:      now,
+	}
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:             "auth-clear-all",
+		Index:          "auth-clear-all",
+		Provider:       "codex",
+		Status:         StatusError,
+		StatusMessage:  modelA.StatusMessage,
+		LastError:      cloneError(modelA.LastError),
+		Unavailable:    true,
+		NextRetryAfter: modelA.NextRetryAfter,
+		Quota:          modelA.Quota,
+		ModelStates: map[string]*ModelState{
+			"gpt-a": modelA,
+			"gpt-b": modelB,
+			"gpt-c": transient,
+		},
+	}}
+	manager := newHomeNodeManager(t, store, "auth-clear-all")
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-clear-all", "")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared || !reflect.DeepEqual(result.ClearedModels, []string{"gpt-a", "gpt-b"}) {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+
+	persisted := store.persistedSnapshot()
+	for _, model := range []string{"gpt-a", "gpt-b"} {
+		state := persisted.ModelStates[model]
+		if state == nil || state.Status != StatusActive || state.Unavailable || state.Quota.Exceeded {
+			t.Fatalf("%s state = %#v, want cleared quota cooldown", model, state)
+		}
+	}
+	stateC := persisted.ModelStates["gpt-c"]
+	if stateC == nil || stateC.LastError == nil || stateC.LastError.HTTPStatus != http.StatusServiceUnavailable || !stateC.NextRetryAfter.Equal(transientRetry) {
+		t.Fatalf("gpt-c state = %#v, want transient error preserved", stateC)
+	}
+	if persisted.Status != StatusError || persisted.LastError == nil || persisted.LastError.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("aggregate state = %#v, want non-quota error preserved", persisted)
+	}
+	if persisted.Quota.Exceeded {
+		t.Fatalf("aggregate quota = %#v, want cleared", persisted.Quota)
+	}
+}
+
+func TestClearQuotaCooldownPreservesLegacyCredentialQuota(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		model      string
+		quotaScope string
+	}{
+		{name: "one model explicit scope", model: "gpt-a", quotaScope: "credential"},
+		{name: "all models explicit scope", quotaScope: "credential"},
+		{name: "one model legacy scope", model: "gpt-a"},
+		{name: "all models legacy scope"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			modelState := quotaCooldownModelState(now, 10*time.Minute)
+			credentialRetry := now.Add(20 * time.Minute)
+			credentialQuota := QuotaState{
+				Exceeded:      true,
+				Scope:         tc.quotaScope,
+				Reason:        "quota",
+				NextRecoverAt: credentialRetry,
+				BackoffLevel:  5,
+			}
+			store := &fakeMutatorStore{persisted: &Auth{
+				ID:             "auth-legacy-reset",
+				Index:          "auth-legacy-reset",
+				Provider:       "codex",
+				Status:         StatusError,
+				StatusMessage:  "legacy credential quota",
+				Unavailable:    true,
+				NextRetryAfter: credentialRetry,
+				LastError:      &Error{Message: "legacy credential quota", HTTPStatus: http.StatusTooManyRequests},
+				Quota:          credentialQuota,
+				ModelStates:    map[string]*ModelState{"gpt-a": modelState},
+			}}
+			manager := newHomeNodeManager(t, store, "auth-legacy-reset")
+
+			result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-legacy-reset", tc.model)
+			if errClear != nil {
+				t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+			}
+			if !result.Cleared || !reflect.DeepEqual(result.ClearedModels, []string{"gpt-a"}) {
+				t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+			}
+			persisted := store.persistedSnapshot()
+			if persisted.ModelStates["gpt-a"].Quota.Exceeded {
+				t.Fatalf("model quota = %#v, want cleared", persisted.ModelStates["gpt-a"].Quota)
+			}
+			if !reflect.DeepEqual(persisted.Quota, credentialQuota) || persisted.Status != StatusError || persisted.StatusMessage != "legacy credential quota" || !persisted.Unavailable || !persisted.NextRetryAfter.Equal(credentialRetry) {
+				t.Fatalf("persisted legacy credential state changed: %#v", persisted)
+			}
+			local, ok := manager.GetByID("auth-legacy-reset")
+			if !ok || local == nil || !reflect.DeepEqual(local.Quota, credentialQuota) || local.Status != StatusError || local.StatusMessage != "legacy credential quota" || !local.Unavailable || !local.NextRetryAfter.Equal(credentialRetry) {
+				t.Fatalf("local legacy credential state changed: %#v", local)
+			}
+		})
+	}
+}
+
+func TestClearQuotaCooldownPreservesDisabledState(t *testing.T) {
+	now := time.Now().UTC()
+	state := quotaCooldownModelState(now, 10*time.Minute)
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:            "auth-disabled",
+		Index:         "auth-disabled",
+		Provider:      "codex",
+		Disabled:      true,
+		Status:        StatusDisabled,
+		StatusMessage: "disabled via management API",
+		Unavailable:   true,
+		Quota:         state.Quota,
+		ModelStates:   map[string]*ModelState{"gpt-a": state},
+	}}
+	manager := newHomeNodeManager(t, store, "auth-disabled")
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-disabled", "")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+	persisted := store.persistedSnapshot()
+	if !persisted.Disabled || persisted.Status != StatusDisabled || !persisted.Unavailable || persisted.StatusMessage != "disabled via management API" {
+		t.Fatalf("disabled state = %#v, want preserved", persisted)
+	}
+	if persisted.ModelStates["gpt-a"].Quota.Exceeded {
+		t.Fatalf("model quota = %#v, want bookkeeping cleared", persisted.ModelStates["gpt-a"].Quota)
+	}
+}
+
+func TestClearQuotaCooldownPreservesLocalNonQuotaState(t *testing.T) {
+	now := time.Now().UTC()
+	quotaState := quotaCooldownModelState(now, 10*time.Minute)
+	quotaState.Quota.Scope = quotaScopeModel
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:             "auth-local-non-quota",
+		Index:          "auth-local-non-quota",
+		Provider:       "codex",
+		Status:         StatusError,
+		StatusMessage:  quotaState.StatusMessage,
+		LastError:      cloneError(quotaState.LastError),
+		Unavailable:    true,
+		NextRetryAfter: quotaState.NextRetryAfter,
+		Quota:          quotaState.Quota,
+		ModelStates:    map[string]*ModelState{"gpt-a": quotaState},
+	}}
+	manager := newHomeNodeManager(t, store, "auth-local-non-quota")
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   "auth-local-non-quota",
+		Provider: "codex",
+		Model:    "gpt-a",
+		Success:  false,
+		Error:    &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+	})
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-local-non-quota", "gpt-a")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if !result.Cleared {
+		t.Fatalf("ClearQuotaCooldown() result = %#v", result)
+	}
+	local, ok := manager.GetByID("auth-local-non-quota")
+	if !ok || local == nil || local.ModelStates["gpt-a"] == nil {
+		t.Fatalf("GetByID() = %#v/%v", local, ok)
+	}
+	state := local.ModelStates["gpt-a"]
+	if state.LastError == nil || state.LastError.HTTPStatus != http.StatusServiceUnavailable || state.Quota.Exceeded || state.NextRetryAfter.IsZero() {
+		t.Fatalf("local model state = %#v, want 5xx preserved with quota cleared", state)
+	}
+}
+
+func TestClearQuotaCooldownDoesNotClearNonQuotaModelError(t *testing.T) {
+	now := time.Now().UTC()
+	next := now.Add(time.Minute)
+	state := &ModelState{
+		Status:         StatusError,
+		StatusMessage:  "transient upstream error",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+		UpdatedAt:      now,
+	}
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID:          "auth-non-quota",
+		Index:       "auth-non-quota",
+		Provider:    "codex",
+		Status:      StatusError,
+		Unavailable: true,
+		ModelStates: map[string]*ModelState{"gpt-a": state},
+	}}
+	manager := newHomeNodeManager(t, store, "auth-non-quota")
+
+	result, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-non-quota", "gpt-a")
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	if result.Cleared || store.mutationCount() != 0 {
+		t.Fatalf("ClearQuotaCooldown() result/mutations = %#v/%d, want no-op", result, store.mutationCount())
+	}
+	persisted := store.persistedSnapshot().ModelStates["gpt-a"]
+	if persisted.LastError == nil || persisted.LastError.HTTPStatus != http.StatusServiceUnavailable || !persisted.NextRetryAfter.Equal(next) {
+		t.Fatalf("non-quota state = %#v, want preserved", persisted)
+	}
+}
+
+func TestModelSuccessPersistsQuotaResetMarkerRemoval(t *testing.T) {
+	const authID = "auth-reset-marker-success"
+	const model = "gpt-a"
+	now := time.Now().UTC()
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusActive,
+		ModelStates: map[string]*ModelState{model: {Status: StatusActive, UpdatedAt: now, QuotaResetAt: now}},
+	}}
+	manager := NewManager(store, nil, nil)
+	local := &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusActive,
+		ModelStates: map[string]*ModelState{model: {Status: StatusActive, UpdatedAt: now, QuotaResetAt: now}},
+	}
+	if _, errRegister := manager.Register(context.Background(), local); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{AuthID: authID, Provider: "codex", Model: model, Success: true})
+	if marker := store.persistedSnapshot().ModelStates[model].QuotaResetAt; !marker.IsZero() {
+		t.Fatalf("persisted QuotaResetAt = %v, want zero", marker)
+	}
+	if store.mutationCount() != 1 {
+		t.Fatalf("mutation count = %d, want 1 marker update", store.mutationCount())
+	}
+	got, ok := manager.GetByID(authID)
+	if !ok || got.ModelStates[model] == nil || got.ModelStates[model].LastError != nil || got.ModelStates[model].Status != StatusActive {
+		t.Fatalf("local state after success = %#v", got)
+	}
+}
+
+func TestUnauthorizedPreservesQuotaResetMarker(t *testing.T) {
+	const authID = "auth-reset-marker-unauthorized"
+	const model = "gpt-a"
+	now := time.Now().UTC()
+	state := &ModelState{Status: StatusActive, UpdatedAt: now, QuotaResetAt: now}
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusActive,
+		ModelStates: map[string]*ModelState{model: state.Clone()},
+	}}
+	manager := NewManager(store, nil, nil)
+	if _, errRegister := manager.Register(context.Background(), &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusActive,
+		ModelStates: map[string]*ModelState{model: state.Clone()},
+	}); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{Message: "unauthorized", HTTPStatus: http.StatusUnauthorized},
+	})
+
+	persisted := store.persistedSnapshot().ModelStates[model]
+	if persisted == nil || persisted.LastError == nil || persisted.LastError.HTTPStatus != http.StatusUnauthorized {
+		t.Fatalf("persisted unauthorized state = %#v", persisted)
+	}
+	if !persisted.QuotaResetAt.Equal(now) {
+		t.Fatalf("persisted QuotaResetAt = %v, want %v", persisted.QuotaResetAt, now)
+	}
+}
+
+func TestClearQuotaCooldownKeepsRegistrySuspendedForPreserved403(t *testing.T) {
+	const authID = "auth-registry-preserve"
+	const model = "registry-preserve-model"
+	now := time.Now().UTC()
+	quotaState := quotaCooldownModelState(now, 10*time.Minute)
+	quotaState.Quota.Scope = quotaScopeModel
+	store := &fakeMutatorStore{persisted: &Auth{
+		ID: authID, Index: authID, Provider: "codex", Status: StatusError,
+		Quota: quotaState.Quota, ModelStates: map[string]*ModelState{model: quotaState},
+	}}
+	manager := newHomeNodeManager(t, store, authID)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model, Object: "model", Type: "openai"}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{Message: "forbidden", HTTPStatus: http.StatusForbidden},
+	})
+	if registryHasAvailableModel(modelRegistry, model) {
+		t.Fatal("403 did not suspend model before reset")
+	}
+	if _, errClear := manager.ClearQuotaCooldown(context.Background(), authID, model); errClear != nil {
+		t.Fatalf("ClearQuotaCooldown() error = %v", errClear)
+	}
+	got, ok := manager.GetByID(authID)
+	if !ok || got.ModelStates[model] == nil || got.ModelStates[model].LastError == nil || got.ModelStates[model].LastError.HTTPStatus != http.StatusForbidden {
+		t.Fatalf("local 403 state after reset = %#v", got)
+	}
+	if registryHasAvailableModel(modelRegistry, model) {
+		t.Fatal("registry resumed model despite preserved 403")
+	}
+}
+
 func registryHasAvailableModel(modelRegistry *registry.ModelRegistry, model string) bool {
 	for _, item := range modelRegistry.GetAvailableModelDefinitions() {
 		if item != nil && item.ID == model {
@@ -206,37 +712,11 @@ func TestReconcileRegistryModelStatesResumesPeerAfterStateReset(t *testing.T) {
 		t.Fatal("registry remained suspended after peer reconciliation")
 	}
 }
-func TestMergePersistedModelStatePreservesActiveQuotaWithNewerNonQuotaError(t *testing.T) {
-	now := time.Now().UTC()
-	quotaRecover := now.Add(10 * time.Minute)
-	persisted := quotaCooldownModelState(now, 10*time.Minute)
-	persisted.Quota.Scope = quotaScopeModel
-	localRetry := now.Add(time.Minute)
-	localUpdated := now.Add(2 * time.Minute)
-	local := &ModelState{
-		Status:         StatusError,
-		StatusMessage:  "transient upstream error",
-		Unavailable:    true,
-		NextRetryAfter: localRetry,
-		LastError:      &Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
-		UpdatedAt:      localUpdated,
-	}
 
-	merged := MergePersistedModelState(persisted, local)
-	if merged == nil || merged.LastError == nil || merged.LastError.HTTPStatus != http.StatusServiceUnavailable {
-		t.Fatalf("merged state = %#v, want newer local 5xx", merged)
-	}
-	if !merged.Quota.Exceeded || merged.Quota.Scope != quotaScopeModel || !merged.Quota.NextRecoverAt.Equal(quotaRecover) {
-		t.Fatalf("merged quota = %#v, want persisted quota", merged.Quota)
-	}
-	if !merged.Unavailable || !merged.NextRetryAfter.Equal(quotaRecover) {
-		t.Fatalf("merged availability = %v/%v, want quota deadline %v", merged.Unavailable, merged.NextRetryAfter, quotaRecover)
-	}
-	if !merged.UpdatedAt.Equal(localUpdated) {
-		t.Fatalf("merged UpdatedAt = %v, want local timestamp %v", merged.UpdatedAt, localUpdated)
-	}
-	auth := &Auth{ModelStates: map[string]*ModelState{"gpt-a": merged}}
-	if blocked, reason, next := isAuthBlockedForModel(auth, "gpt-a", now.Add(2*time.Minute)); !blocked || reason != blockReasonCooldown || !next.Equal(quotaRecover) {
-		t.Fatalf("blocked/reason/next after local retry = %v/%v/%v, want shared quota until %v", blocked, reason, next, quotaRecover)
+func TestClearQuotaCooldownRequiresAtomicStore(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	_, errClear := manager.ClearQuotaCooldown(context.Background(), "auth-no-store", "")
+	if !errors.Is(errClear, ErrCooldownMutationUnsupported) {
+		t.Fatalf("ClearQuotaCooldown() error = %v, want ErrCooldownMutationUnsupported", errClear)
 	}
 }

--- a/internal/cliproxy/auth/manager.go
+++ b/internal/cliproxy/auth/manager.go
@@ -538,31 +538,49 @@ func (m *Manager) ReconcileRegistryModelStates(_ context.Context, authID string)
 	}
 
 	modelRegistry := registry.GetGlobalRegistry()
-	models := make(map[string]struct{}, len(auth.ModelStates))
+	// Registry IDs are client-visible route models, while execution state is
+	// keyed by the credential-specific upstream model. Keep both so aliases and
+	// credential prefixes reconcile against the same state used by Dispatch.
+	models := make(map[string]string, len(auth.ModelStates))
 	for model := range auth.ModelStates {
 		if model = canonicalModelKey(model); model != "" {
-			models[model] = struct{}{}
+			models[model] = model
 		}
 	}
 	for _, model := range modelRegistry.GetModelsForClient(auth.ID) {
-		if model != nil {
-			if modelID := canonicalModelKey(model.ID); modelID != "" {
-				models[modelID] = struct{}{}
-			}
+		if model == nil {
+			continue
 		}
+		registryModel := strings.TrimSpace(model.ID)
+		if registryModel == "" {
+			continue
+		}
+		stateModel := canonicalModelKey(registryModel)
+		if resolved := m.resolveDispatchModel(auth, registryModel); resolved.Key != "" {
+			stateModel = resolved.Key
+		}
+		models[registryModel] = stateModel
 	}
 
 	now := time.Now()
-	for model := range models {
-		blocked, reason, _ := isAuthBlockedForModel(auth, model, now)
+	for registryModel, stateModel := range models {
+		blocked, reason, _ := isAuthBlockedForModel(auth, stateModel, now)
+		legacyModel := canonicalModelKey(registryModel)
+		if !blocked && stateModel != legacyModel {
+			if legacyBlocked, legacyReason, _ := isAuthBlockedForModel(auth, legacyModel, now); legacyBlocked {
+				blocked = true
+				reason = legacyReason
+				stateModel = legacyModel
+			}
+		}
 		if blocked && reason == blockReasonCooldown {
-			modelRegistry.SetModelQuotaExceeded(auth.ID, model)
+			modelRegistry.SetModelQuotaExceeded(auth.ID, registryModel)
 		} else {
-			modelRegistry.ClearModelQuotaExceeded(auth.ID, model)
+			modelRegistry.ClearModelQuotaExceeded(auth.ID, registryModel)
 		}
 
-		if !blocked || !shouldSuspendRegistryModel(auth, model, reason) {
-			modelRegistry.ResumeClientModel(auth.ID, model)
+		if !blocked || !shouldSuspendRegistryModel(auth, stateModel, reason) {
+			modelRegistry.ResumeClientModel(auth.ID, registryModel)
 			continue
 		}
 		suspendReason := "unavailable"
@@ -572,14 +590,14 @@ func (m *Manager) ReconcileRegistryModelStates(_ context.Context, authID string)
 		case blockReasonDisabled:
 			suspendReason = "disabled"
 		default:
-			if state := auth.ModelStates[model]; state != nil && strings.TrimSpace(state.StatusMessage) != "" {
+			if state := auth.ModelStates[stateModel]; state != nil && strings.TrimSpace(state.StatusMessage) != "" {
 				suspendReason = strings.TrimSpace(state.StatusMessage)
 			}
 		}
 		// Recreate the suspension so a transition from quota to another error
 		// also updates the registry reason.
-		modelRegistry.ResumeClientModel(auth.ID, model)
-		modelRegistry.SuspendClientModel(auth.ID, model, suspendReason)
+		modelRegistry.ResumeClientModel(auth.ID, registryModel)
+		modelRegistry.SuspendClientModel(auth.ID, registryModel, suspendReason)
 	}
 }
 

--- a/internal/cliproxy/auth/manager.go
+++ b/internal/cliproxy/auth/manager.go
@@ -1661,8 +1661,6 @@ func applyRefreshSuccessState(auth *Auth, now time.Time) []string {
 		return nil
 	}
 	wasDisabled := auth.Disabled || auth.Status == StatusDisabled
-	authQuota := auth.Quota
-	preserveAuthQuota := authQuota.Exceeded && authQuota.NextRecoverAt.After(now) && !quotaAggregatedFromModel(authQuota, auth.ModelStates)
 	clearUnauthorizedAuth := isUnauthorizedAuthState(auth)
 	clearRefreshAcquisition := isRefreshAcquisitionState(auth)
 
@@ -1691,17 +1689,10 @@ func applyRefreshSuccessState(auth *Auth, now time.Time) []string {
 	if clearUnauthorizedAuth || len(resumed) > 0 {
 		updateAggregatedAvailability(auth, now)
 	}
-	if preserveAuthQuota {
-		auth.Quota = authQuota
-		auth.Unavailable = true
-		if auth.NextRetryAfter.Before(authQuota.NextRecoverAt) {
-			auth.NextRetryAfter = authQuota.NextRecoverAt
-		}
-	}
 	if wasDisabled {
 		auth.Status = StatusDisabled
 		auth.Unavailable = true
-	} else if preserveAuthQuota || hasModelError(auth, now) {
+	} else if hasModelError(auth, now) {
 		auth.Status = StatusError
 	} else if clearUnauthorizedAuth || len(resumed) > 0 {
 		auth.Status = StatusActive
@@ -1724,18 +1715,6 @@ func resetUnauthorizedModelStateAfterRefresh(state *ModelState, now time.Time) b
 		return false
 	}
 	return true
-}
-
-func quotaAggregatedFromModel(quota QuotaState, states map[string]*ModelState) bool {
-	for _, state := range states {
-		if state == nil || !state.Quota.Exceeded {
-			continue
-		}
-		if state.Quota.NextRecoverAt.Equal(quota.NextRecoverAt) && state.Quota.BackoffLevel == quota.BackoffLevel && strings.TrimSpace(state.Quota.Reason) == strings.TrimSpace(quota.Reason) {
-			return true
-		}
-	}
-	return false
 }
 
 func isRefreshAcquisitionState(auth *Auth) bool {

--- a/internal/cliproxy/auth/manager.go
+++ b/internal/cliproxy/auth/manager.go
@@ -526,10 +526,84 @@ func (m *Manager) RefreshSchedulerEntry(authID string) {
 	m.scheduler.upsertAuth(auth)
 }
 
-// ReconcileRegistryModelStates reconciles a registry model states.
-func (m *Manager) ReconcileRegistryModelStates(_ context.Context, _ string) {
-	// CLIProxyAPIHome does not execute upstream requests, so it does not maintain
-	// per-model runtime state beyond the shared model registry.
+// ReconcileRegistryModelStates aligns the derived model registry with the
+// authoritative scheduler state held by this Home instance.
+func (m *Manager) ReconcileRegistryModelStates(_ context.Context, authID string) {
+	if m == nil {
+		return
+	}
+	auth, ok := m.GetByID(authID)
+	if !ok || auth == nil {
+		return
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	models := make(map[string]struct{}, len(auth.ModelStates))
+	for model := range auth.ModelStates {
+		if model = canonicalModelKey(model); model != "" {
+			models[model] = struct{}{}
+		}
+	}
+	for _, model := range modelRegistry.GetModelsForClient(auth.ID) {
+		if model != nil {
+			if modelID := canonicalModelKey(model.ID); modelID != "" {
+				models[modelID] = struct{}{}
+			}
+		}
+	}
+
+	now := time.Now()
+	for model := range models {
+		blocked, reason, _ := isAuthBlockedForModel(auth, model, now)
+		if blocked && reason == blockReasonCooldown {
+			modelRegistry.SetModelQuotaExceeded(auth.ID, model)
+		} else {
+			modelRegistry.ClearModelQuotaExceeded(auth.ID, model)
+		}
+
+		if !blocked || !shouldSuspendRegistryModel(auth, model, reason) {
+			modelRegistry.ResumeClientModel(auth.ID, model)
+			continue
+		}
+		suspendReason := "unavailable"
+		switch reason {
+		case blockReasonCooldown:
+			suspendReason = "quota"
+		case blockReasonDisabled:
+			suspendReason = "disabled"
+		default:
+			if state := auth.ModelStates[model]; state != nil && strings.TrimSpace(state.StatusMessage) != "" {
+				suspendReason = strings.TrimSpace(state.StatusMessage)
+			}
+		}
+		// Recreate the suspension so a transition from quota to another error
+		// also updates the registry reason.
+		modelRegistry.ResumeClientModel(auth.ID, model)
+		modelRegistry.SuspendClientModel(auth.ID, model, suspendReason)
+	}
+}
+
+func shouldSuspendRegistryModel(auth *Auth, model string, reason blockReason) bool {
+	switch reason {
+	case blockReasonCooldown, blockReasonDisabled:
+		return true
+	}
+	if auth == nil {
+		return false
+	}
+	state := auth.ModelStates[canonicalModelKey(model)]
+	if state == nil {
+		return false
+	}
+	if isModelSupportResultError(state.LastError) {
+		return true
+	}
+	switch statusCodeFromResult(state.LastError) {
+	case http.StatusPaymentRequired, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
 }
 
 // ensureRequestedModelMetadata ensures a requested model metadata.

--- a/internal/cliproxy/auth/refresh_test.go
+++ b/internal/cliproxy/auth/refresh_test.go
@@ -177,7 +177,7 @@ func TestApplyRefreshFailureStateKeepsTransientFailuresRetryable(t *testing.T) {
 	}
 }
 
-func TestApplyRefreshSuccessStateClearsUnauthorizedCooldown(t *testing.T) {
+func TestApplyRefreshSuccessStateClearsUnauthorizedModelCooldown(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -18,6 +18,7 @@ const (
 	quotaBackoffBase         = time.Second
 	quotaBackoffMax          = 30 * time.Minute
 	unauthorizedRetryBackoff = time.Minute
+	quotaScopeModel          = "model"
 )
 
 var usageRetryDelayPattern = regexp.MustCompile(`(?i)\b(?:resets in|after)\s+([0-9]+(?:\.[0-9]+)?(?:h|m|s)(?:[0-9]+(?:\.[0-9]+)?(?:h|m|s))*)`)
@@ -57,6 +58,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	transitionVersion := int64(0)
 	var authSnapshot *Auth
 	resultModel := canonicalModelKey(result.Model)
+	if resultModel == "" {
+		return
+	}
 	resultAuthID := ""
 	now := time.Now()
 
@@ -107,31 +111,21 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 			return changed
 		})
-		if errMutate != nil || persisted == nil {
-			if errMutate != nil {
-				log.Warnf("auth manager: persisted result transition failed for %s: %v", resultAuthID, errMutate)
-			}
-			// Token-versioned state transitions must be compared with the authoritative row.
-			// Failing open could cool a refreshed token or let an older success clear its cooldown.
-			if isTokenVersionFencedResult(result) {
-				return
-			}
-			m.mu.Lock()
-			if local := m.resultAuthLocked(result); local != nil {
-				transition = m.applyResultTransition(local, result, resultModel, now)
-				authSnapshot = local.Clone()
-			}
-			m.mu.Unlock()
-			m.enqueueResultPersist(ctx, authSnapshot)
-		} else {
-			if transitionVersion > 0 && persisted.StateVersion > transitionVersion {
-				transition = markResultTransition{}
-			}
-			var adopted bool
-			authSnapshot, adopted = m.adoptPersistedResultState(result, resultModel, persisted, now)
-			if !adopted {
-				transition = markResultTransition{}
-			}
+		if errMutate != nil {
+			log.Warnf("auth manager: persisted result transition failed for %s: %v", resultAuthID, errMutate)
+			return
+		}
+		if persisted == nil {
+			log.Warnf("auth manager: persisted result transition returned no auth for %s", resultAuthID)
+			return
+		}
+		if transitionVersion > 0 && persisted.StateVersion > transitionVersion {
+			transition = markResultTransition{}
+		}
+		var adopted bool
+		authSnapshot, adopted = m.adoptPersistedResultState(result, resultModel, persisted, now)
+		if !adopted {
+			transition = markResultTransition{}
 		}
 	} else {
 		m.enqueueResultPersist(ctx, authSnapshot)
@@ -170,109 +164,93 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 	}
 
 	if result.Success {
-		if resultModel != "" {
-			state := ensureModelState(auth, resultModel)
-			resetModelState(state, now)
-			updateAggregatedAvailability(auth, now)
-			if !hasModelError(auth, now) {
-				auth.LastError = nil
-				auth.StatusMessage = ""
-				auth.Status = StatusActive
-			}
-			auth.UpdatedAt = now
-			transition.shouldResumeModel = true
-			transition.clearModelQuota = true
-		} else {
-			clearAuthStateOnSuccess(auth, now)
-		}
-		return transition
-	}
-
-	preservedUnauthorized, preserveUnauthorized := snapshotAuthUnauthorizedCooldown(auth, now)
-	if resultModel != "" {
-		if isRequestScopedNotFoundResultError(result.Error) {
-			return transition
-		}
-		disableCooling := m.quotaCooldownDisabledForAuth(auth)
 		state := ensureModelState(auth, resultModel)
-		state.Unavailable = true
-		state.Status = StatusError
-		state.UpdatedAt = now
-		if result.Error != nil {
-			state.LastError = cloneError(result.Error)
-			state.StatusMessage = result.Error.Message
-			auth.LastError = cloneError(result.Error)
-			auth.StatusMessage = result.Error.Message
-		}
-
-		statusCode := statusCodeFromResult(result.Error)
-		if isModelSupportResultError(result.Error) {
-			next := now.Add(12 * time.Hour)
-			state.NextRetryAfter = next
-			transition.suspendReason = "model_not_supported"
-			transition.shouldSuspendModel = true
-		} else {
-			switch statusCode {
-			case http.StatusUnauthorized:
-				state.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
-			case http.StatusPaymentRequired, http.StatusForbidden:
-				if disableCooling {
-					state.NextRetryAfter = time.Time{}
-				} else {
-					next := now.Add(30 * time.Minute)
-					state.NextRetryAfter = next
-					transition.suspendReason = "payment_required"
-					transition.shouldSuspendModel = true
-				}
-			case http.StatusNotFound:
-				if disableCooling {
-					state.NextRetryAfter = time.Time{}
-				} else {
-					next := now.Add(12 * time.Hour)
-					state.NextRetryAfter = next
-					transition.suspendReason = "not_found"
-					transition.shouldSuspendModel = true
-				}
-			case http.StatusTooManyRequests:
-				next, backoffLevel := nextQuotaRecoverAt(now, result.RetryAfter, state.Quota, disableCooling)
-				state.NextRetryAfter = next
-				state.Quota = QuotaState{
-					Exceeded:      true,
-					Reason:        "quota",
-					NextRecoverAt: next,
-					BackoffLevel:  backoffLevel,
-				}
-				if !disableCooling {
-					transition.suspendReason = "quota"
-					transition.shouldSuspendModel = true
-					transition.setModelQuota = true
-				}
-			case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-				if disableCooling {
-					state.NextRetryAfter = time.Time{}
-				} else {
-					state.NextRetryAfter = now.Add(time.Minute)
-				}
-			default:
-				state.NextRetryAfter = time.Time{}
-			}
-		}
-
-		auth.Status = StatusError
-		auth.UpdatedAt = now
+		resetModelState(state, now)
 		updateAggregatedAvailability(auth, now)
-		if statusCode == http.StatusUnauthorized {
-			applyAuthUnauthorizedCooldown(auth, result.Error, now)
-		} else if preserveUnauthorized {
-			restoreAuthUnauthorizedCooldown(auth, preservedUnauthorized)
+		if !hasModelError(auth, now) {
+			auth.LastError = nil
+			auth.StatusMessage = ""
+			auth.Status = StatusActive
 		}
+		auth.UpdatedAt = now
+		transition.shouldResumeModel = true
+		transition.clearModelQuota = true
 		return transition
 	}
 
-	applyAuthFailureState(m, auth, result.Error, result.RetryAfter, now)
-	if statusCodeFromResult(result.Error) != http.StatusUnauthorized && preserveUnauthorized {
-		restoreAuthUnauthorizedCooldown(auth, preservedUnauthorized)
+	if isRequestScopedNotFoundResultError(result.Error) {
+		return transition
 	}
+	disableCooling := m.quotaCooldownDisabledForAuth(auth)
+	state := ensureModelState(auth, resultModel)
+	state.Unavailable = true
+	state.Status = StatusError
+	state.UpdatedAt = now
+	if result.Error != nil {
+		state.LastError = cloneError(result.Error)
+		state.StatusMessage = result.Error.Message
+		auth.LastError = cloneError(result.Error)
+		auth.StatusMessage = result.Error.Message
+	}
+
+	statusCode := statusCodeFromResult(result.Error)
+	if isModelSupportResultError(result.Error) {
+		next := now.Add(12 * time.Hour)
+		state.NextRetryAfter = next
+		transition.suspendReason = "model_not_supported"
+		transition.shouldSuspendModel = true
+	} else {
+		switch statusCode {
+		case http.StatusUnauthorized:
+			state.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
+		case http.StatusPaymentRequired, http.StatusForbidden:
+			if disableCooling {
+				state.NextRetryAfter = time.Time{}
+			} else {
+				next := now.Add(30 * time.Minute)
+				state.NextRetryAfter = next
+				transition.suspendReason = "payment_required"
+				transition.shouldSuspendModel = true
+			}
+		case http.StatusNotFound:
+			if disableCooling {
+				state.NextRetryAfter = time.Time{}
+			} else {
+				next := now.Add(12 * time.Hour)
+				state.NextRetryAfter = next
+				transition.suspendReason = "not_found"
+				transition.shouldSuspendModel = true
+			}
+		case http.StatusTooManyRequests:
+			next, backoffLevel := nextQuotaRecoverAt(now, result.RetryAfter, state.Quota, disableCooling)
+			state.NextRetryAfter = next
+			state.QuotaResetAt = time.Time{}
+			state.Quota = QuotaState{
+				Exceeded:      true,
+				Scope:         quotaScopeModel,
+				Reason:        "quota",
+				NextRecoverAt: next,
+				BackoffLevel:  backoffLevel,
+			}
+			if !disableCooling {
+				transition.suspendReason = "quota"
+				transition.shouldSuspendModel = true
+				transition.setModelQuota = true
+			}
+		case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			if disableCooling {
+				state.NextRetryAfter = time.Time{}
+			} else {
+				state.NextRetryAfter = now.Add(time.Minute)
+			}
+		default:
+			state.NextRetryAfter = time.Time{}
+		}
+	}
+
+	auth.Status = StatusError
+	auth.UpdatedAt = now
+	updateAggregatedAvailability(auth, now)
 	return transition
 }
 
@@ -303,8 +281,7 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 	}
 	// A locally visible open window means the shared row already carries this
 	// cooldown, so the failure can be absorbed without a database round-trip.
-	// Provider retry hints still go through to extend the persisted window.
-	if result.RetryAfter == nil && authQuotaWindowOpen(auth, resultModel, now) {
+	if authQuotaWindowOpen(auth, resultModel, now) {
 		return false
 	}
 	return true
@@ -313,57 +290,31 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 // authQuotaWindowOpen reports whether the auth (or the given model state)
 // already tracks an unexpired quota cooldown window.
 func authQuotaWindowOpen(auth *Auth, resultModel string, now time.Time) bool {
-	if auth == nil {
+	if auth == nil || resultModel == "" {
 		return false
 	}
-	if resultModel != "" {
-		state := auth.ModelStates[resultModel]
-		return state != nil && state.Quota.Exceeded && state.Quota.NextRecoverAt.After(now)
-	}
-	return auth.Quota.Exceeded && auth.Quota.NextRecoverAt.After(now)
+	state := auth.ModelStates[resultModel]
+	return state != nil && state.Quota.Exceeded && state.Quota.NextRecoverAt.After(now)
 }
 
 // authHasClearableAvailabilityState reports whether a success outcome would
 // clear availability state that other Home nodes can observe.
 func authHasClearableAvailabilityState(auth *Auth, resultModel string, now time.Time) bool {
-	if auth == nil {
+	if auth == nil || resultModel == "" {
 		return false
 	}
-	if resultModel != "" {
-		if state := auth.ModelStates[resultModel]; state != nil {
-			if state.Unavailable || state.Quota.Exceeded || !state.NextRetryAfter.IsZero() || state.Status == StatusError {
-				return true
-			}
-		}
-		// A success can also clear auth-scoped failure state that no model
-		// state explains (for example a model-less 429 recorded earlier).
-		if auth.Unavailable || !auth.NextRetryAfter.IsZero() {
-			return true
-		}
-		if auth.Quota.Exceeded && !anyModelQuotaExceeded(auth) {
-			return true
-		}
-		return auth.Status == StatusError && !hasModelError(auth, now)
-	}
-	return auth.Unavailable || auth.Quota.Exceeded || !auth.NextRetryAfter.IsZero() || auth.Status == StatusError
-}
-
-// anyModelQuotaExceeded reports whether any model state tracks an exceeded quota.
-func anyModelQuotaExceeded(auth *Auth) bool {
-	if auth == nil {
-		return false
-	}
-	for _, state := range auth.ModelStates {
-		if state != nil && state.Quota.Exceeded {
+	if state := auth.ModelStates[resultModel]; state != nil {
+		if state.Unavailable || state.Quota.Exceeded || !state.NextRetryAfter.IsZero() || state.Status == StatusError || !state.QuotaResetAt.IsZero() {
 			return true
 		}
 	}
-	return false
+	return auth.Status == StatusError && !hasModelError(auth, now)
 }
 
 // quotaFingerprint condenses the scheduling-relevant fields of a QuotaState.
 type quotaFingerprint struct {
 	exceeded    bool
+	scope       string
 	reason      string
 	recoverUnix int64
 	level       int
@@ -384,6 +335,7 @@ type availabilityFingerprintValue struct {
 	modelStatus    Status
 	modelUnavail   bool
 	modelRetryUnix int64
+	modelResetUnix int64
 	modelQuota     quotaFingerprint
 }
 
@@ -399,6 +351,7 @@ func fingerprintUnix(t time.Time) int64 {
 func fingerprintQuota(quota QuotaState) quotaFingerprint {
 	return quotaFingerprint{
 		exceeded:    quota.Exceeded,
+		scope:       quota.Scope,
 		reason:      quota.Reason,
 		recoverUnix: fingerprintUnix(quota.NextRecoverAt),
 		level:       quota.BackoffLevel,
@@ -422,6 +375,7 @@ func availabilityFingerprint(auth *Auth, resultModel string) availabilityFingerp
 			fp.modelStatus = state.Status
 			fp.modelUnavail = state.Unavailable
 			fp.modelRetryUnix = fingerprintUnix(state.NextRetryAfter)
+			fp.modelResetUnix = fingerprintUnix(state.QuotaResetAt)
 			fp.modelQuota = fingerprintQuota(state.Quota)
 		}
 	}
@@ -474,38 +428,22 @@ func (m *Manager) adoptPersistedResultState(result Result, resultModel string, p
 	local.Disabled = persisted.Disabled
 	local.UpdatedAt = persisted.UpdatedAt
 	local.StateVersion = persisted.StateVersion
-	if resultModel != "" {
-		if state := persisted.ModelStates[resultModel]; state != nil {
-			if local.ModelStates == nil {
-				local.ModelStates = make(map[string]*ModelState)
-			}
-			local.ModelStates[resultModel] = state.Clone()
-		} else if local.ModelStates != nil {
-			delete(local.ModelStates, resultModel)
+	if state := persisted.ModelStates[resultModel]; state != nil {
+		if local.ModelStates == nil {
+			local.ModelStates = make(map[string]*ModelState)
 		}
-		// Recompute the aggregate from the merged local view so cooldowns that
-		// only exist locally (non-persisted transitions) are preserved.
-		updateAggregatedAvailability(local, now)
-		persistedUnauthorized, hasPersistedUnauthorized := snapshotAuthUnauthorizedCooldown(persisted, now)
-		if hasPersistedUnauthorized {
-			restoreAuthUnauthorizedCooldown(local, persistedUnauthorized)
-		}
-		// The persisted copy can report a clean active state even though this
-		// node still tracks a model error that was never persisted (for
-		// example a transient 5xx). Mirror the hasModelError guard of the
-		// local success path and keep the local error view in that case.
-		if hasPersistedUnauthorized || persisted.Status != StatusActive || !hasModelError(local, now) {
-			local.Status = persisted.Status
-			local.StatusMessage = persisted.StatusMessage
-			local.LastError = cloneError(persisted.LastError)
-		}
-	} else {
+		local.ModelStates[resultModel] = state.Clone()
+	} else if local.ModelStates != nil {
+		delete(local.ModelStates, resultModel)
+	}
+	updateAggregatedAvailability(local, now)
+	// The persisted copy can report a clean active state even though this
+	// node still tracks a model error that was never persisted (for example a
+	// transient 5xx). Keep the local error view in that case.
+	if persisted.Status != StatusActive || !hasModelError(local, now) {
 		local.Status = persisted.Status
 		local.StatusMessage = persisted.StatusMessage
 		local.LastError = cloneError(persisted.LastError)
-		local.Unavailable = persisted.Unavailable
-		local.NextRetryAfter = persisted.NextRetryAfter
-		local.Quota = persisted.Quota
 	}
 	return local.Clone(), true
 }
@@ -519,66 +457,6 @@ func isTokenVersionedSuccessResult(result Result) bool {
 func isTokenVersionFencedResult(result Result) bool {
 	_, validHash := normalizeSHA256Hex(result.AccessTokenSHA256)
 	return validHash && (result.Success || statusCodeFromResult(result.Error) == http.StatusUnauthorized)
-}
-
-type authUnauthorizedCooldownState struct {
-	status         Status
-	statusMessage  string
-	lastError      *Error
-	nextRetryAfter time.Time
-	updatedAt      time.Time
-}
-
-func authUnauthorizedCooldownOpen(auth *Auth, now time.Time) bool {
-	return auth != nil && auth.Unavailable && auth.NextRetryAfter.After(now) && isUnauthorizedAuthState(auth)
-}
-
-func snapshotAuthUnauthorizedCooldown(auth *Auth, now time.Time) (authUnauthorizedCooldownState, bool) {
-	if !authUnauthorizedCooldownOpen(auth, now) {
-		return authUnauthorizedCooldownState{}, false
-	}
-	return authUnauthorizedCooldownState{
-		status:         auth.Status,
-		statusMessage:  auth.StatusMessage,
-		lastError:      cloneError(auth.LastError),
-		nextRetryAfter: auth.NextRetryAfter,
-		updatedAt:      auth.UpdatedAt,
-	}, true
-}
-
-func restoreAuthUnauthorizedCooldown(auth *Auth, state authUnauthorizedCooldownState) {
-	if auth == nil || state.nextRetryAfter.IsZero() {
-		return
-	}
-	auth.Unavailable = true
-	auth.Status = state.status
-	if auth.Status == "" {
-		auth.Status = StatusError
-	}
-	auth.StatusMessage = state.statusMessage
-	if strings.TrimSpace(auth.StatusMessage) == "" {
-		auth.StatusMessage = "unauthorized"
-	}
-	auth.LastError = cloneError(state.lastError)
-	auth.NextRetryAfter = state.nextRetryAfter
-	if auth.UpdatedAt.Before(state.updatedAt) {
-		auth.UpdatedAt = state.updatedAt
-	}
-}
-
-func applyAuthUnauthorizedCooldown(auth *Auth, resultErr *Error, now time.Time) {
-	if auth == nil {
-		return
-	}
-	auth.Unavailable = true
-	auth.Status = StatusError
-	auth.StatusMessage = "unauthorized"
-	auth.LastError = cloneError(resultErr)
-	if auth.LastError == nil {
-		auth.LastError = &Error{Code: "unauthorized", Message: http.StatusText(http.StatusUnauthorized), HTTPStatus: http.StatusUnauthorized}
-	}
-	auth.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
-	auth.UpdatedAt = now
 }
 
 func (m *Manager) resultAuthLocked(result Result) *Auth {
@@ -635,6 +513,7 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.LastError = nil
 	state.Quota = QuotaState{}
 	state.UpdatedAt = now
+	state.QuotaResetAt = time.Time{}
 }
 
 // updateAggregatedAvailability updates an aggregated availability.
@@ -698,15 +577,15 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		auth.NextRetryAfter = time.Time{}
 	}
 	if quotaExceeded {
-		auth.Quota.Exceeded = true
-		auth.Quota.Reason = "quota"
-		auth.Quota.NextRecoverAt = quotaRecover
-		auth.Quota.BackoffLevel = maxBackoffLevel
+		auth.Quota = QuotaState{
+			Exceeded:      true,
+			Scope:         quotaScopeModel,
+			Reason:        "quota",
+			NextRecoverAt: quotaRecover,
+			BackoffLevel:  maxBackoffLevel,
+		}
 	} else {
-		auth.Quota.Exceeded = false
-		auth.Quota.Reason = ""
-		auth.Quota.NextRecoverAt = time.Time{}
-		auth.Quota.BackoffLevel = 0
+		auth.Quota = QuotaState{}
 	}
 }
 
@@ -739,23 +618,6 @@ func hasModelError(auth *Auth, now time.Time) bool {
 		}
 	}
 	return false
-}
-
-// clearAuthStateOnSuccess clears an auth state on success.
-func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
-	if auth == nil {
-		return
-	}
-	auth.Unavailable = false
-	auth.Status = StatusActive
-	auth.StatusMessage = ""
-	auth.Quota.Exceeded = false
-	auth.Quota.Reason = ""
-	auth.Quota.NextRecoverAt = time.Time{}
-	auth.Quota.BackoffLevel = 0
-	auth.LastError = nil
-	auth.NextRetryAfter = time.Time{}
-	auth.UpdatedAt = now
 }
 
 // cloneError clones an error.
@@ -837,66 +699,6 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 	return isRequestScopedNotFoundMessage(err.Message)
 }
 
-// applyAuthFailureState applies an auth failure state.
-func applyAuthFailureState(m *Manager, auth *Auth, resultErr *Error, retryAfter *time.Duration, now time.Time) {
-	// Normalize auth state before updating runtime indexes.
-	if auth == nil {
-		return
-	}
-	if isRequestScopedNotFoundResultError(resultErr) {
-		return
-	}
-	disableCooling := m.quotaCooldownDisabledForAuth(auth)
-	auth.Unavailable = true
-	auth.Status = StatusError
-	auth.UpdatedAt = now
-	if resultErr != nil {
-		auth.LastError = cloneError(resultErr)
-		if resultErr.Message != "" {
-			auth.StatusMessage = resultErr.Message
-		}
-	}
-	statusCode := statusCodeFromResult(resultErr)
-	switch statusCode {
-	case http.StatusUnauthorized:
-		auth.StatusMessage = "unauthorized"
-		auth.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
-	case http.StatusPaymentRequired, http.StatusForbidden:
-		auth.StatusMessage = "payment_required"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(30 * time.Minute)
-		}
-	case http.StatusNotFound:
-		auth.StatusMessage = "not_found"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(12 * time.Hour)
-		}
-	case http.StatusTooManyRequests:
-		auth.StatusMessage = "quota exhausted"
-		auth.Quota.Exceeded = true
-		auth.Quota.Reason = "quota"
-		next, backoffLevel := nextQuotaRecoverAt(now, retryAfter, auth.Quota, disableCooling)
-		auth.Quota.BackoffLevel = backoffLevel
-		auth.Quota.NextRecoverAt = next
-		auth.NextRetryAfter = next
-	case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-		auth.StatusMessage = "transient upstream error"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = now.Add(time.Minute)
-		}
-	default:
-		if auth.StatusMessage == "" {
-			auth.StatusMessage = "request failed"
-		}
-	}
-}
-
 // disableAuthAfterUnauthorized permanently disables a credential after a terminal refresh failure.
 func disableAuthAfterUnauthorized(auth *Auth, state *ModelState, resultErr *Error, now time.Time) {
 	if auth == nil {
@@ -949,12 +751,9 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 	return cooldown, prevLevel + 1
 }
 
-func nextQuotaRecoverAt(now time.Time, retryAfter *time.Duration, quota QuotaState, disableCooling bool) (time.Time, int) {
+func nextQuotaRecoverAt(now time.Time, _ *time.Duration, quota QuotaState, disableCooling bool) (time.Time, int) {
 	if disableCooling {
 		return time.Time{}, quota.BackoffLevel
-	}
-	if retryAfter != nil && *retryAfter > 0 {
-		return now.Add(*retryAfter), quota.BackoffLevel
 	}
 	return quotaCooldownAfterFailure(quota, now)
 }

--- a/internal/cliproxy/auth/result_mutator_test.go
+++ b/internal/cliproxy/auth/result_mutator_test.go
@@ -14,6 +14,7 @@ import (
 type fakeMutatorStore struct {
 	mu        sync.Mutex
 	persisted *Auth
+	mutateErr error
 	mutations int
 	saves     int
 }
@@ -35,6 +36,9 @@ func (s *fakeMutatorStore) Delete(context.Context, string) error { return nil }
 func (s *fakeMutatorStore) MutateAuthState(_ context.Context, id string, mutate func(auth *Auth) bool) (*Auth, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.mutateErr != nil {
+		return nil, s.mutateErr
+	}
 	if s.persisted == nil || s.persisted.ID != id {
 		return nil, fmt.Errorf("auth %s not found", id)
 	}
@@ -141,6 +145,38 @@ func TestMarkResultQuotaEscalationIsAtomicAcrossManagers(t *testing.T) {
 
 	if store.saves != 0 {
 		t.Fatalf("expected no Save calls on the mutator path, got %d", store.saves)
+	}
+}
+
+func TestMarkResultMutationFailureDoesNotApplyLocalPenalty(t *testing.T) {
+	for _, statusCode := range []int{http.StatusUnauthorized, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			const authID = "auth-mutation-failure"
+			store := &fakeMutatorStore{
+				persisted: &Auth{ID: authID, Index: authID, Provider: "codex", Status: StatusActive},
+				mutateErr: fmt.Errorf("database temporarily unavailable"),
+			}
+			manager := newHomeNodeManager(t, store, authID)
+
+			manager.MarkResult(context.Background(), Result{
+				AuthID:   authID,
+				Provider: "codex",
+				Model:    "gpt-5",
+				Error:    &Error{Message: http.StatusText(statusCode), HTTPStatus: statusCode},
+			})
+
+			persisted := store.persistedSnapshot()
+			if persisted.ModelStates["gpt-5"] != nil || store.mutationCount() != 0 {
+				t.Fatalf("persisted state/mutations = %#v/%d, want unchanged", persisted.ModelStates["gpt-5"], store.mutationCount())
+			}
+			local, ok := manager.GetByID(authID)
+			if !ok || local == nil {
+				t.Fatal("GetByID() missing auth")
+			}
+			if state := local.ModelStates["gpt-5"]; state != nil && (state.Quota.Exceeded || state.Unavailable) {
+				t.Fatalf("local state = %#v, database failure must not apply cooldown", state)
+			}
+		})
 	}
 }
 

--- a/internal/cliproxy/auth/result_test.go
+++ b/internal/cliproxy/auth/result_test.go
@@ -157,6 +157,33 @@ func TestMarkResultUnauthorizedUsesRecoverableCooldown(t *testing.T) {
 	if blocked, reason, _ := isAuthBlockedForModel(updated, "gpt-5", time.Now()); !blocked || reason == blockReasonDisabled {
 		t.Fatalf("isAuthBlockedForModel() = blocked %v reason %v, want non-disabled cooldown", blocked, reason)
 	}
+	if blocked, reason, next := isAuthBlockedForModel(updated, "gpt-5-mini", time.Now()); blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("unrelated model blocked/reason/next = %v/%v/%v", blocked, reason, next)
+	}
+}
+
+func TestMarkResultIgnoresMissingCanonicalModel(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-missing-model", Index: "auth-missing-model", Provider: "codex", Status: StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:  auth.ID,
+		Model:   " ",
+		Success: false,
+		Error:   &Error{Message: "quota", HTTPStatus: http.StatusTooManyRequests},
+	})
+	manager.MarkResult(context.Background(), Result{AuthID: auth.ID, Success: true})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("updated auth not found")
+	}
+	if updated.Success != 0 || updated.Failed != 0 || updated.Status != StatusActive || updated.Unavailable || updated.Quota.Exceeded || len(updated.ModelStates) != 0 {
+		t.Fatalf("model-less result changed auth: %#v", updated)
+	}
 }
 
 func TestAuthRefreshBackoffDoesNotBlockModels(t *testing.T) {

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -312,9 +312,6 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
-	if authUnauthorizedCooldownOpen(auth, now) {
-		return true, blockReasonOther, auth.NextRetryAfter
-	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			state, ok := auth.ModelStates[model]
@@ -350,19 +347,6 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			}
 		}
 		return false, blockReasonNone, time.Time{}
-	}
-	if auth.Unavailable && auth.NextRetryAfter.After(now) {
-		next := auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) {
-			next = auth.Quota.NextRecoverAt
-		}
-		if next.Before(now) {
-			next = now
-		}
-		if auth.Quota.Exceeded {
-			return true, blockReasonCooldown, next
-		}
-		return true, blockReasonOther, next
 	}
 	return false, blockReasonNone, time.Time{}
 }

--- a/internal/cliproxy/auth/types.go
+++ b/internal/cliproxy/auth/types.go
@@ -103,6 +103,8 @@ type RecentRequestBucket struct {
 type QuotaState struct {
 	// Exceeded indicates the credential recently hit a quota error.
 	Exceeded bool `json:"exceeded"`
+	// Scope records that this quota is model-scoped or aggregated from models.
+	Scope string `json:"scope,omitempty"`
 	// Reason provides an optional provider specific human readable description.
 	Reason string `json:"reason,omitempty"`
 	// NextRecoverAt is when the credential may become available again.
@@ -127,6 +129,9 @@ type ModelState struct {
 	Quota QuotaState `json:"quota"`
 	// UpdatedAt tracks the last update timestamp for this model state.
 	UpdatedAt time.Time `json:"updated_at"`
+	// QuotaResetAt marks an operator reset so peers can merge it without
+	// discarding unrelated local execution errors.
+	QuotaResetAt time.Time `json:"quota_reset_at,omitzero"`
 }
 
 // recentRequestBucketID handles a recent request bucket id.

--- a/internal/cluster/config_snapshot.go
+++ b/internal/cluster/config_snapshot.go
@@ -185,7 +185,7 @@ func RuntimeConfigFromRoot(root map[string]any) (*appconfig.Config, []byte, erro
 	if cfg.RemoteManagement.PanelGitHubRepository == "" {
 		cfg.RemoteManagement.PanelGitHubRepository = appconfig.DefaultPanelGitHubRepository
 	}
-	appconfig.ForceDownstreamHomeModeConfig(cfg)
+	appconfig.ForceHomeRuntimeConfig(cfg)
 	return cfg, data, nil
 }
 

--- a/internal/cluster/config_snapshot_test.go
+++ b/internal/cluster/config_snapshot_test.go
@@ -2,10 +2,14 @@ package cluster
 
 import (
 	"context"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
 	"gopkg.in/yaml.v3"
 )
 
@@ -48,11 +52,11 @@ func TestRuntimeConfigFromRootPreservesConcurrencyLimiterConfig(t *testing.T) {
 	}
 }
 
-func TestRuntimeConfigFromRootAppliesHomeModeScalarsAndPreservesRemoteManagement(t *testing.T) {
+func TestRuntimeConfigFromRootEnablesCentralCoolingAndHomeInvariants(t *testing.T) {
 	root := map[string]any{
 		"api-keys":                 []any{"local-key"},
 		"usage-statistics-enabled": false,
-		"disable-cooling":          false,
+		"disable-cooling":          true,
 		"ws-auth":                  true,
 		"remote-management": map[string]any{
 			"allow-remote":          true,
@@ -70,8 +74,8 @@ func TestRuntimeConfigFromRootAppliesHomeModeScalarsAndPreservesRemoteManagement
 	if !cfg.UsageStatisticsEnabled {
 		t.Fatal("UsageStatisticsEnabled = false, want true")
 	}
-	if !cfg.DisableCooling {
-		t.Fatal("DisableCooling = false, want true")
+	if cfg.DisableCooling {
+		t.Fatal("DisableCooling = true, want Home central cooling enabled")
 	}
 	if cfg.WebsocketAuth {
 		t.Fatal("WebsocketAuth = true, want false")
@@ -81,6 +85,40 @@ func TestRuntimeConfigFromRootAppliesHomeModeScalarsAndPreservesRemoteManagement
 	}
 	if cfg.RemoteManagement.DisableControlPanel {
 		t.Fatal("RemoteManagement.DisableControlPanel = true, want preserved false")
+	}
+}
+
+func TestRuntimeConfigFromRootEnablesCentralQuotaCooldown(t *testing.T) {
+	cfg, _, errConfig := RuntimeConfigFromRoot(map[string]any{"disable-cooling": true})
+	if errConfig != nil {
+		t.Fatalf("RuntimeConfigFromRoot() error = %v", errConfig)
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	auth := &coreauth.Auth{ID: "central-cooling-auth", Index: "central-cooling-auth", Provider: "codex", Status: coreauth.StatusActive}
+	t.Cleanup(func() { registry.GetGlobalRegistry().ClearModelQuotaExceeded(auth.ID, "gpt-5") })
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), coreauth.Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gpt-5",
+		Success:  false,
+		Error: &coreauth.Error{
+			Message:    "quota exhausted",
+			HTTPStatus: http.StatusTooManyRequests,
+		},
+	})
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil || got.ModelStates["gpt-5"] == nil {
+		t.Fatalf("GetByID() missing quota state: %#v", got)
+	}
+	state := got.ModelStates["gpt-5"]
+	if !state.Unavailable || !state.Quota.Exceeded || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("quota state = %#v, want active central cooldown", state)
 	}
 }
 

--- a/internal/cluster/management/config.go
+++ b/internal/cluster/management/config.go
@@ -53,7 +53,7 @@ func (h *Handler) GetConfigYAML(c *gin.Context) {
 		respondError(c, http.StatusInternalServerError, "auth_load_failed", errCredential)
 		return
 	}
-	appconfig.ApplyDownstreamHomeModeScalars(root)
+	appconfig.ApplyHomeRuntimeScalars(root)
 	data, errMarshal := yaml.Marshal(root)
 	if errMarshal != nil {
 		respondError(c, http.StatusInternalServerError, "config_marshal_failed", errMarshal)
@@ -78,7 +78,7 @@ func (h *Handler) PutConfigYAML(c *gin.Context) {
 		respondError(c, http.StatusBadRequest, "invalid_yaml", errRoot)
 		return
 	}
-	appconfig.ApplyDownstreamHomeModeScalars(fullRoot)
+	appconfig.ApplyHomeRuntimeScalars(fullRoot)
 	root := configRootWithoutCredentials(fullRoot)
 	if _, errConfig := configFromRoot(root); errConfig != nil {
 		respondError(c, http.StatusUnprocessableEntity, "invalid_config", errConfig)

--- a/internal/cluster/management/config_test.go
+++ b/internal/cluster/management/config_test.go
@@ -529,7 +529,7 @@ func stringSliceContains(values []string, target string) bool {
 	return false
 }
 
-func TestPutConfigYAMLForcesHomeModeScalarsAndPreservesRemoteManagement(t *testing.T) {
+func TestPutConfigYAMLEnablesCentralCoolingAndHomeInvariants(t *testing.T) {
 	db, cleanup := openManagementLogTestDB(t)
 	defer cleanup()
 
@@ -542,7 +542,7 @@ func TestPutConfigYAMLForcesHomeModeScalarsAndPreservesRemoteManagement(t *testi
 
 	payload := `port: 8327
 usage-statistics-enabled: false
-disable-cooling: false
+disable-cooling: true
 ws-auth: true
 remote-management:
   allow-remote: true
@@ -587,8 +587,8 @@ plugins:
 	if cfg["usage-statistics-enabled"] != true {
 		t.Fatalf("usage-statistics-enabled = %v, want true", cfg["usage-statistics-enabled"])
 	}
-	if cfg["disable-cooling"] != true {
-		t.Fatalf("disable-cooling = %v, want true", cfg["disable-cooling"])
+	if cfg["disable-cooling"] != false {
+		t.Fatalf("disable-cooling = %v, want Home central cooling enabled", cfg["disable-cooling"])
 	}
 	if cfg["ws-auth"] != false {
 		t.Fatalf("ws-auth = %v, want false", cfg["ws-auth"])
@@ -627,6 +627,15 @@ plugins:
 	engine.ServeHTTP(yamlResp, yamlReq)
 	if yamlResp.Code != http.StatusOK {
 		t.Fatalf("yaml status = %d, body = %s", yamlResp.Code, yamlResp.Body.String())
+	}
+	if !strings.Contains(yamlResp.Body.String(), "usage-statistics-enabled: true") {
+		t.Fatalf("config yaml = %s, want Home usage statistics forced true", yamlResp.Body.String())
+	}
+	if !strings.Contains(yamlResp.Body.String(), "disable-cooling: false") {
+		t.Fatalf("config yaml = %s, want Home central cooling enabled", yamlResp.Body.String())
+	}
+	if !strings.Contains(yamlResp.Body.String(), "ws-auth: false") {
+		t.Fatalf("config yaml = %s, want Home ws-auth forced false", yamlResp.Body.String())
 	}
 	if !strings.Contains(yamlResp.Body.String(), "allow-remote: true") {
 		t.Fatalf("config yaml = %s, want allow-remote preserved true", yamlResp.Body.String())

--- a/internal/cluster/management/cooldown.go
+++ b/internal/cluster/management/cooldown.go
@@ -1,0 +1,62 @@
+package management
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"gorm.io/gorm"
+)
+
+// ClearCredentialCooldown clears Home-owned quota cooldown state for one
+// credential, optionally limited to one model.
+func (h *Handler) ClearCredentialCooldown(c *gin.Context) {
+	credentialID := strings.TrimSpace(c.Param("credential_id"))
+	if credentialID == "" {
+		respondError(c, http.StatusBadRequest, "credential_id_required", errors.New("credential_id is required"))
+		return
+	}
+
+	rawModel, modelProvided := c.GetQuery("model")
+	model := strings.TrimSpace(rawModel)
+	if modelProvided && model == "" {
+		respondError(c, http.StatusBadRequest, "model_required", errors.New("model must not be empty when provided"))
+		return
+	}
+	if h == nil || h.runtime == nil || h.runtime.CoreManager() == nil {
+		respondError(c, http.StatusServiceUnavailable, "cooldown_reset_unavailable", coreauth.ErrCooldownMutationUnsupported)
+		return
+	}
+
+	ctx, cancel := h.requestContext(c)
+	defer cancel()
+	result, errClear := h.runtime.CoreManager().ClearQuotaCooldown(ctx, credentialID, model)
+	if errClear != nil {
+		status := quotaReadErrorStatus(errClear)
+		switch {
+		case errors.Is(errClear, gorm.ErrRecordNotFound):
+			respondError(c, http.StatusNotFound, "credential_not_found", errClear)
+		case errors.Is(errClear, coreauth.ErrCooldownMutationUnsupported), status == http.StatusServiceUnavailable:
+			respondError(c, http.StatusServiceUnavailable, "cooldown_reset_unavailable", errClear)
+		default:
+			respondError(c, http.StatusInternalServerError, "cooldown_reset_failed", errClear)
+		}
+		return
+	}
+
+	scope := "all"
+	response := gin.H{
+		"status":         "ok",
+		"credential_id":  result.CredentialID,
+		"scope":          scope,
+		"cleared":        result.Cleared,
+		"cleared_models": append([]string{}, result.ClearedModels...),
+	}
+	if modelProvided {
+		response["scope"] = "model"
+		response["model"] = result.Model
+	}
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/cluster/management/cooldown_test.go
+++ b/internal/cluster/management/cooldown_test.go
@@ -1,0 +1,193 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
+)
+
+type clearCredentialCooldownResponse struct {
+	Status        string   `json:"status"`
+	CredentialID  string   `json:"credential_id"`
+	Scope         string   `json:"scope"`
+	Model         string   `json:"model"`
+	Cleared       bool     `json:"cleared"`
+	ClearedModels []string `json:"cleared_models"`
+}
+
+func newCooldownManagementHandler(t *testing.T, auth *coreauth.Auth) (*Handler, *cluster.Repository) {
+	t.Helper()
+	db, cleanup := openManagementLogTestDB(t)
+	t.Cleanup(cleanup)
+	repo := cluster.NewRepository(db)
+	if _, errUpsert := repo.UpsertAuth(context.Background(), auth, "register"); errUpsert != nil {
+		t.Fatalf("UpsertAuth() error = %v", errUpsert)
+	}
+	runtime, errRuntime := home.NewRuntime(&appconfig.Config{AuthDir: t.TempDir()})
+	if errRuntime != nil {
+		t.Fatalf("home.NewRuntime() error = %v", errRuntime)
+	}
+	t.Cleanup(runtime.Stop)
+	runtime.SetClusterAdapter(cluster.NewRuntimeAdapter(repo, "127.0.0.1"))
+	if errReload := runtime.ReloadAuths(context.Background()); errReload != nil {
+		t.Fatalf("ReloadAuths() error = %v", errReload)
+	}
+	return NewHandler(repo, runtime, "127.0.0.1", 0), repo
+}
+
+func managementQuotaState(now time.Time, delay time.Duration) *coreauth.ModelState {
+	next := now.Add(delay)
+	return &coreauth.ModelState{
+		Status:         coreauth.StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+		Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: next, BackoffLevel: 2},
+		UpdatedAt:      now,
+	}
+}
+
+func TestClearCredentialCooldownForModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	now := time.Now().UTC()
+	modelA := managementQuotaState(now, 10*time.Minute)
+	modelB := managementQuotaState(now, 20*time.Minute)
+	auth := &coreauth.Auth{
+		ID:             "credential-model-clear",
+		Index:          "credential-model-clear",
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: modelA.NextRetryAfter,
+		Quota:          modelA.Quota,
+		Metadata:       map[string]any{"type": "codex"},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-a": modelA,
+			"gpt-b": modelB,
+		},
+	}
+	handler, repo := newCooldownManagementHandler(t, auth)
+	engine := gin.New()
+	engine.DELETE("/credentials/:credential_id/cooldown", handler.ClearCredentialCooldown)
+
+	path := "/credentials/credential-model-clear/cooldown?model=" + url.QueryEscape("gpt-a(high)")
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodDelete, path, nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload clearCredentialCooldownResponse
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	var fields map[string]json.RawMessage
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &fields); errDecode != nil {
+		t.Fatalf("decode response fields: %v", errDecode)
+	}
+	if _, exists := fields["credential_cooldown_cleared"]; exists {
+		t.Fatalf("response contains removed credential-wide field: %s", response.Body.String())
+	}
+	if payload.Status != "ok" || payload.CredentialID != auth.ID || payload.Scope != "model" || payload.Model != "gpt-a" || !payload.Cleared || !reflect.DeepEqual(payload.ClearedModels, []string{"gpt-a"}) {
+		t.Fatalf("response = %#v", payload)
+	}
+
+	persisted, _, errGet := repo.GetAuth(context.Background(), auth.ID)
+	if errGet != nil {
+		t.Fatalf("GetAuth() error = %v", errGet)
+	}
+	if persisted.ModelStates["gpt-a"].Quota.Exceeded || persisted.ModelStates["gpt-a"].Unavailable {
+		t.Fatalf("gpt-a state = %#v, want cleared", persisted.ModelStates["gpt-a"])
+	}
+	if !persisted.ModelStates["gpt-b"].Quota.Exceeded || !persisted.ModelStates["gpt-b"].Unavailable {
+		t.Fatalf("gpt-b state = %#v, want preserved", persisted.ModelStates["gpt-b"])
+	}
+}
+
+func TestClearCredentialCooldownForAllModels(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	now := time.Now().UTC()
+	modelA := managementQuotaState(now, 10*time.Minute)
+	modelB := managementQuotaState(now, 20*time.Minute)
+	auth := &coreauth.Auth{
+		ID:             "credential-all-clear",
+		Index:          "credential-all-clear",
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: modelA.NextRetryAfter,
+		Quota:          modelA.Quota,
+		Metadata:       map[string]any{"type": "codex"},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-a": modelA,
+			"gpt-b": modelB,
+		},
+	}
+	handler, repo := newCooldownManagementHandler(t, auth)
+	engine := gin.New()
+	engine.DELETE("/credentials/:credential_id/cooldown", handler.ClearCredentialCooldown)
+
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodDelete, "/credentials/credential-all-clear/cooldown", nil))
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload clearCredentialCooldownResponse
+	if errDecode := json.Unmarshal(response.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if payload.Scope != "all" || payload.Model != "" || !payload.Cleared || !reflect.DeepEqual(payload.ClearedModels, []string{"gpt-a", "gpt-b"}) {
+		t.Fatalf("response = %#v", payload)
+	}
+
+	persisted, _, errGet := repo.GetAuth(context.Background(), auth.ID)
+	if errGet != nil {
+		t.Fatalf("GetAuth() error = %v", errGet)
+	}
+	for _, model := range []string{"gpt-a", "gpt-b"} {
+		state := persisted.ModelStates[model]
+		if state == nil || state.Quota.Exceeded || state.Unavailable {
+			t.Fatalf("%s state = %#v, want cleared", model, state)
+		}
+	}
+}
+
+func TestClearCredentialCooldownValidationAndNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	auth := &coreauth.Auth{ID: "credential-validation", Index: "credential-validation", Provider: "codex", Metadata: map[string]any{"type": "codex"}}
+	handler, _ := newCooldownManagementHandler(t, auth)
+	engine := gin.New()
+	engine.DELETE("/credentials/:credential_id/cooldown", handler.ClearCredentialCooldown)
+
+	emptyModel := httptest.NewRecorder()
+	engine.ServeHTTP(emptyModel, httptest.NewRequest(http.MethodDelete, "/credentials/credential-validation/cooldown?model=", nil))
+	if emptyModel.Code != http.StatusBadRequest {
+		t.Fatalf("empty model status = %d, body = %s", emptyModel.Code, emptyModel.Body.String())
+	}
+
+	missing := httptest.NewRecorder()
+	engine.ServeHTTP(missing, httptest.NewRequest(http.MethodDelete, "/credentials/missing/cooldown", nil))
+	if missing.Code != http.StatusNotFound {
+		t.Fatalf("missing credential status = %d, body = %s", missing.Code, missing.Body.String())
+	}
+
+	ctxCanceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	canceled := httptest.NewRecorder()
+	requestCanceled := httptest.NewRequest(http.MethodDelete, "/credentials/credential-validation/cooldown", nil).WithContext(ctxCanceled)
+	engine.ServeHTTP(canceled, requestCanceled)
+	if canceled.Code != http.StatusServiceUnavailable {
+		t.Fatalf("canceled request status = %d, body = %s", canceled.Code, canceled.Body.String())
+	}
+}

--- a/internal/cluster/management/usage_observability.go
+++ b/internal/cluster/management/usage_observability.go
@@ -71,6 +71,7 @@ func (h *Handler) GetCapabilities(c *gin.Context) {
 			"credential_in_flight_snapshots":       true,
 			"credential_in_flight_snapshot_cursor": true,
 			"credential_concurrency_limits_v2":     true,
+			"credential_cooldown_reset":            true,
 		},
 		"server_info": gin.H{
 			"home_version":    buildinfo.Version,

--- a/internal/cluster/management/usage_observability_test.go
+++ b/internal/cluster/management/usage_observability_test.go
@@ -118,7 +118,7 @@ func TestGetCapabilitiesReturnsUsageObservabilityFlags(t *testing.T) {
 	if !ok {
 		t.Fatalf("capabilities = %T, want object", payload["capabilities"])
 	}
-	for _, key := range []string{"quota_snapshots", "quota_snapshot_details", "usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "usage_token_breakdown_v2", "request_log_index", "request_events", "request_event_details", "request_event_export", "request_event_filters", "request_events_details", "request_events_export", "request_events_filters", "requestEvents", "requestEventDetails", "requestEventExport", "requestEventFilters", "requestEventsDetails", "requestEventsExport", "requestEventsFilters", "oauth_usage", "logs", "request_error_logs", "model_channel_bindings", "topology"} {
+	for _, key := range []string{"quota_snapshots", "quota_snapshot_details", "usage", "usage_overview", "usage_records", "usage_record_details", "usage_aggregates", "usage_export", "usage_provider_health", "usage_credential_health", "usage_realtime", "usage_token_breakdown_v2", "request_log_index", "request_events", "request_event_details", "request_event_export", "request_event_filters", "request_events_details", "request_events_export", "request_events_filters", "requestEvents", "requestEventDetails", "requestEventExport", "requestEventFilters", "requestEventsDetails", "requestEventsExport", "requestEventsFilters", "oauth_usage", "logs", "request_error_logs", "model_channel_bindings", "topology", "credential_cooldown_reset"} {
 		if capabilities[key] != true {
 			t.Fatalf("capabilities[%s] = %v, want true", key, capabilities[key])
 		}

--- a/internal/cluster/quota_state_test.go
+++ b/internal/cluster/quota_state_test.go
@@ -171,6 +171,89 @@ func TestClusterQuotaBackoffEscalatesOncePerWindowAcrossNodes(t *testing.T) {
 	}
 }
 
+func TestClusterClearQuotaCooldownPersistsAndPublishesAuthEvent(t *testing.T) {
+	const authID = "auth-cluster-clear"
+	const clearedModel = "gpt-a"
+	const preservedModel = "gpt-b"
+	repo := newQuotaTestRepository(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	clearedAt := now.Add(10 * time.Minute)
+	preservedAt := now.Add(20 * time.Minute)
+	seed := &coreauth.Auth{
+		ID:             authID,
+		Index:          authID,
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		Unavailable:    true,
+		NextRetryAfter: clearedAt,
+		Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: clearedAt, BackoffLevel: 2},
+		Metadata:       map[string]any{"type": "codex"},
+		ModelStates: map[string]*coreauth.ModelState{
+			clearedModel: {
+				Status:         coreauth.StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: clearedAt,
+				LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+				Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: clearedAt, BackoffLevel: 2},
+			},
+			preservedModel: {
+				Status:         coreauth.StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: preservedAt,
+				LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+				Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: preservedAt, BackoffLevel: 4},
+			},
+		},
+	}
+	seedRecord, errUpsert := repo.UpsertAuth(ctx, seed, "register")
+	if errUpsert != nil {
+		t.Fatalf("UpsertAuth returned error: %v", errUpsert)
+	}
+	manager := newQuotaTestNode(t, repo, authID)
+
+	result, errClear := manager.ClearQuotaCooldown(ctx, authID, clearedModel)
+	if errClear != nil {
+		t.Fatalf("ClearQuotaCooldown returned error: %v", errClear)
+	}
+	if !result.Cleared || len(result.ClearedModels) != 1 || result.ClearedModels[0] != clearedModel {
+		t.Fatalf("ClearQuotaCooldown result = %#v", result)
+	}
+
+	persisted, record, errGet := repo.GetAuth(ctx, authID)
+	if errGet != nil {
+		t.Fatalf("GetAuth returned error: %v", errGet)
+	}
+	if record.Version != seedRecord.Version+1 {
+		t.Fatalf("auth version = %d, want %d", record.Version, seedRecord.Version+1)
+	}
+	if state := persisted.ModelStates[clearedModel]; state == nil || state.Quota.Exceeded || state.Unavailable || !state.NextRetryAfter.IsZero() || state.QuotaResetAt.IsZero() {
+		t.Fatalf("cleared model state = %#v", state)
+	}
+	if state := persisted.ModelStates[preservedModel]; state == nil || !state.Quota.Exceeded || !state.Unavailable {
+		t.Fatalf("preserved model state = %#v", state)
+	}
+
+	var event ClusterEventRecord
+	if errEvent := repo.db.Where("scope = ? AND entity_uuid = ? AND version = ?", "auth", authID, record.Version).Order("id DESC").First(&event).Error; errEvent != nil {
+		t.Fatalf("load auth event: %v", errEvent)
+	}
+	if event.Op != "update" {
+		t.Fatalf("event op = %q, want update", event.Op)
+	}
+
+	peerAdapter := NewRuntimeAdapter(repo, "127.0.0.2")
+	if errApply := peerAdapter.ApplyEvent(ctx, event); errApply != nil {
+		t.Fatalf("ApplyEvent returned error: %v", errApply)
+	}
+	peerAuths := peerAdapter.ListMinimalAuths()
+	if len(peerAuths) != 1 || peerAuths[0].ModelStates[clearedModel] == nil || peerAuths[0].ModelStates[clearedModel].Quota.Exceeded || peerAuths[0].ModelStates[clearedModel].QuotaResetAt.IsZero() {
+		t.Fatalf("peer auth index = %#v, want cleared model state", peerAuths)
+	}
+}
+
 func TestClusterAuthIndexCarriesCooldownState(t *testing.T) {
 	const authID = "auth-cluster-index"
 	const model = "gpt-5"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -783,7 +783,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 
-	ForceDownstreamHomeModeConfig(&cfg)
+	ForceHomeRuntimeConfig(&cfg)
 
 	// Return the populated configuration struct.
 	return &cfg, nil

--- a/internal/config/home_mode.go
+++ b/internal/config/home_mode.go
@@ -1,15 +1,24 @@
 package config
 
-// ForceDownstreamHomeModeConfig applies runtime overrides that downstream CPA
-// nodes enforce when operating in Home mode.
-func ForceDownstreamHomeModeConfig(cfg *Config) {
+// ForceHomeRuntimeConfig applies invariants owned by the Home runtime.
+func ForceHomeRuntimeConfig(cfg *Config) {
 	if cfg == nil {
 		return
 	}
 	cfg.APIKeys = nil
 	cfg.UsageStatisticsEnabled = true
-	cfg.DisableCooling = true
+	cfg.DisableCooling = false
 	cfg.WebsocketAuth = false
+}
+
+// ApplyHomeRuntimeScalars applies scalar invariants owned by Home.
+func ApplyHomeRuntimeScalars(root map[string]any) {
+	if len(root) == 0 {
+		return
+	}
+	root["usage-statistics-enabled"] = true
+	root["disable-cooling"] = false
+	root["ws-auth"] = false
 }
 
 // ApplyDownstreamHomeModeScalars only applies scalar Home-mode overrides.
@@ -17,10 +26,9 @@ func ForceDownstreamHomeModeConfig(cfg *Config) {
 // remote-management, auth-dir, tls, or credential roots. Callers that build
 // downstream CPA YAML must filter those roots separately first.
 func ApplyDownstreamHomeModeScalars(root map[string]any) {
+	ApplyHomeRuntimeScalars(root)
 	if len(root) == 0 {
 		return
 	}
-	root["usage-statistics-enabled"] = true
 	root["disable-cooling"] = true
-	root["ws-auth"] = false
 }

--- a/internal/config/home_mode_test.go
+++ b/internal/config/home_mode_test.go
@@ -1,17 +1,21 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestForceDownstreamHomeModeConfigPreservesRemoteManagement(t *testing.T) {
+func TestForceHomeRuntimeConfigEnablesCentralCooling(t *testing.T) {
 	cfg := &Config{}
 	cfg.APIKeys = []string{"local-key"}
 	cfg.UsageStatisticsEnabled = false
-	cfg.DisableCooling = false
+	cfg.DisableCooling = true
 	cfg.WebsocketAuth = true
 	cfg.RemoteManagement.AllowRemote = true
 	cfg.RemoteManagement.DisableControlPanel = false
 
-	ForceDownstreamHomeModeConfig(cfg)
+	ForceHomeRuntimeConfig(cfg)
 
 	if len(cfg.APIKeys) != 0 {
 		t.Fatalf("APIKeys = %#v, want nil/empty", cfg.APIKeys)
@@ -19,8 +23,8 @@ func TestForceDownstreamHomeModeConfigPreservesRemoteManagement(t *testing.T) {
 	if !cfg.UsageStatisticsEnabled {
 		t.Fatal("UsageStatisticsEnabled = false, want true")
 	}
-	if !cfg.DisableCooling {
-		t.Fatal("DisableCooling = false, want true")
+	if cfg.DisableCooling {
+		t.Fatal("DisableCooling = true, want Home central cooling enabled")
 	}
 	if cfg.WebsocketAuth {
 		t.Fatal("WebsocketAuth = true, want false")
@@ -30,6 +34,55 @@ func TestForceDownstreamHomeModeConfigPreservesRemoteManagement(t *testing.T) {
 	}
 	if cfg.RemoteManagement.DisableControlPanel {
 		t.Fatal("RemoteManagement.DisableControlPanel = true, want preserved false")
+	}
+}
+
+func TestLoadConfigOptionalEnablesCentralCooling(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(path, []byte(`api-keys:
+  - local-key
+usage-statistics-enabled: false
+disable-cooling: true
+ws-auth: true
+`), 0o600); errWrite != nil {
+		t.Fatalf("write config: %v", errWrite)
+	}
+
+	cfg, errLoad := LoadConfigOptional(path, false)
+	if errLoad != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", errLoad)
+	}
+	if len(cfg.APIKeys) != 0 {
+		t.Fatalf("APIKeys = %#v, want nil/empty", cfg.APIKeys)
+	}
+	if !cfg.UsageStatisticsEnabled {
+		t.Fatal("UsageStatisticsEnabled = false, want true")
+	}
+	if cfg.DisableCooling {
+		t.Fatal("DisableCooling = true, want Home central cooling enabled")
+	}
+	if cfg.WebsocketAuth {
+		t.Fatal("WebsocketAuth = true, want false")
+	}
+}
+
+func TestApplyHomeRuntimeScalarsEnablesCentralCooling(t *testing.T) {
+	root := map[string]any{
+		"usage-statistics-enabled": false,
+		"disable-cooling":          true,
+		"ws-auth":                  true,
+	}
+
+	ApplyHomeRuntimeScalars(root)
+
+	if root["usage-statistics-enabled"] != true {
+		t.Fatalf("usage-statistics-enabled = %v, want true", root["usage-statistics-enabled"])
+	}
+	if root["disable-cooling"] != false {
+		t.Fatalf("disable-cooling = %v, want Home central cooling enabled", root["disable-cooling"])
+	}
+	if root["ws-auth"] != false {
+		t.Fatalf("ws-auth = %v, want false", root["ws-auth"])
 	}
 }
 

--- a/internal/home/auth_apply.go
+++ b/internal/home/auth_apply.go
@@ -50,11 +50,8 @@ func (r *Runtime) applyCoreAuthAddOrUpdate(ctx context.Context, auth *coreauth.A
 	r.coreManager.RefreshSchedulerEntry(auth.ID)
 }
 
-// mergeModelStates merges the locally accumulated model states into the
-// incoming cluster view, keeping whichever per-model state is fresher. Local
-// states cover transitions that are not persisted to the cluster row (for
-// example transient 5xx cooldowns), while incoming states carry cooldowns
-// recorded by other Home nodes.
+// mergeModelStates merges locally accumulated execution state into the
+// incoming cluster view while keeping persisted quota state authoritative.
 func mergeModelStates(incoming, local map[string]*coreauth.ModelState) map[string]*coreauth.ModelState {
 	if len(local) == 0 {
 		return incoming
@@ -66,10 +63,7 @@ func mergeModelStates(incoming, local map[string]*coreauth.ModelState) map[strin
 		if state == nil {
 			continue
 		}
-		current, ok := incoming[model]
-		if !ok || current == nil || state.UpdatedAt.After(current.UpdatedAt) {
-			incoming[model] = state
-		}
+		incoming[model] = coreauth.MergePersistedModelState(incoming[model], state)
 	}
 	return incoming
 }

--- a/internal/home/auth_apply_test.go
+++ b/internal/home/auth_apply_test.go
@@ -1,0 +1,134 @@
+package home
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPIHome/internal/cliproxy/auth"
+)
+
+func TestMergeModelStatesQuotaResetPreservesLocalNonQuotaError(t *testing.T) {
+	now := time.Now().UTC()
+	resetAt := now.Add(time.Minute)
+	incoming := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:       coreauth.StatusActive,
+			UpdatedAt:    resetAt,
+			QuotaResetAt: resetAt,
+		},
+	}
+	localRetry := now.Add(2 * time.Minute)
+	local := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:         coreauth.StatusError,
+			StatusMessage:  "transient upstream error",
+			Unavailable:    true,
+			NextRetryAfter: localRetry,
+			LastError:      &coreauth.Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+			Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(10 * time.Minute), BackoffLevel: 3},
+			UpdatedAt:      now,
+		},
+	}
+
+	merged := mergeModelStates(incoming, local)
+	state := merged["gpt-a"]
+	if state == nil || state.LastError == nil || state.LastError.HTTPStatus != http.StatusServiceUnavailable || !state.NextRetryAfter.Equal(localRetry) {
+		t.Fatalf("merged state = %#v, want local 5xx preserved", state)
+	}
+	if state.Quota.Exceeded || !state.QuotaResetAt.Equal(resetAt) {
+		t.Fatalf("merged quota/reset = %#v/%v, want quota cleared at %v", state.Quota, state.QuotaResetAt, resetAt)
+	}
+}
+
+func TestMergeModelStatesQuotaResetOverridesNewerLocalQuota(t *testing.T) {
+	now := time.Now().UTC()
+	resetAt := now.Add(2 * time.Minute)
+	incoming := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:       coreauth.StatusActive,
+			UpdatedAt:    now,
+			QuotaResetAt: resetAt,
+		},
+	}
+	local := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:         coreauth.StatusError,
+			StatusMessage:  "quota exhausted",
+			Unavailable:    true,
+			NextRetryAfter: now.Add(10 * time.Minute),
+			LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+			Quota:          coreauth.QuotaState{Exceeded: true, Scope: "model", Reason: "quota", NextRecoverAt: now.Add(10 * time.Minute), BackoffLevel: 3},
+			UpdatedAt:      now.Add(time.Minute),
+		},
+	}
+
+	merged := mergeModelStates(incoming, local)
+	state := merged["gpt-a"]
+	if state == nil || state.Status != coreauth.StatusActive || state.Unavailable || state.LastError != nil || state.Quota.Exceeded {
+		t.Fatalf("merged state = %#v, want persisted quota reset", state)
+	}
+	if !state.QuotaResetAt.Equal(resetAt) {
+		t.Fatalf("QuotaResetAt = %v, want %v", state.QuotaResetAt, resetAt)
+	}
+}
+
+func TestMergeModelStatesPreservesSharedQuotaWithNewerLocalError(t *testing.T) {
+	now := time.Now().UTC()
+	quotaRecover := now.Add(10 * time.Minute)
+	incoming := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:         coreauth.StatusError,
+			StatusMessage:  "quota exhausted",
+			Unavailable:    true,
+			NextRetryAfter: quotaRecover,
+			LastError:      &coreauth.Error{Message: "quota exhausted", HTTPStatus: http.StatusTooManyRequests},
+			Quota:          coreauth.QuotaState{Exceeded: true, Scope: "model", Reason: "quota", NextRecoverAt: quotaRecover, BackoffLevel: 3},
+			UpdatedAt:      now,
+		},
+	}
+	localUpdated := now.Add(2 * time.Minute)
+	local := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:         coreauth.StatusError,
+			StatusMessage:  "transient upstream error",
+			Unavailable:    true,
+			NextRetryAfter: now.Add(time.Minute),
+			LastError:      &coreauth.Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+			UpdatedAt:      localUpdated,
+		},
+	}
+
+	merged := mergeModelStates(incoming, local)
+	state := merged["gpt-a"]
+	if state == nil || state.LastError == nil || state.LastError.HTTPStatus != http.StatusServiceUnavailable {
+		t.Fatalf("merged state = %#v, want newer local 5xx", state)
+	}
+	if !state.Quota.Exceeded || state.Quota.Scope != "model" || !state.Quota.NextRecoverAt.Equal(quotaRecover) {
+		t.Fatalf("merged quota = %#v, want shared quota preserved", state.Quota)
+	}
+	if !state.Unavailable || !state.NextRetryAfter.Equal(quotaRecover) || !state.UpdatedAt.Equal(localUpdated) {
+		t.Fatalf("merged availability/timestamp = %v/%v/%v", state.Unavailable, state.NextRetryAfter, state.UpdatedAt)
+	}
+}
+
+func TestMergeModelStatesNewerSuccessSupersedesLocalErrorWithoutResetMarker(t *testing.T) {
+	now := time.Now().UTC()
+	incoming := map[string]*coreauth.ModelState{
+		"gpt-a": {Status: coreauth.StatusActive, UpdatedAt: now.Add(time.Minute)},
+	}
+	local := map[string]*coreauth.ModelState{
+		"gpt-a": {
+			Status:      coreauth.StatusError,
+			Unavailable: true,
+			LastError:   &coreauth.Error{Message: "upstream unavailable", HTTPStatus: http.StatusServiceUnavailable},
+			UpdatedAt:   now,
+		},
+	}
+
+	merged := mergeModelStates(incoming, local)
+	state := merged["gpt-a"]
+	if state == nil || state.Status != coreauth.StatusActive || state.Unavailable || state.LastError != nil {
+		t.Fatalf("merged state = %#v, want newer successful state", state)
+	}
+}

--- a/internal/home/config_yaml_test.go
+++ b/internal/home/config_yaml_test.go
@@ -12,6 +12,7 @@ func TestSanitizeConfigYAMLForDownstream_RemovesSensitiveKeys(t *testing.T) {
 # head comment
 host: ""
 port: 8327
+disable-cooling: false
 tls:
   enable: false
 remote-management:

--- a/internal/home/usage_result.go
+++ b/internal/home/usage_result.go
@@ -26,8 +26,8 @@ func (r *Runtime) RecordUsagePayload(ctx context.Context, payload string) {
 
 	provider := strings.TrimSpace(gjson.Get(payload, "provider").String())
 	model := strings.TrimSpace(gjson.Get(payload, "model").String())
-	if model == "" {
-		model = strings.TrimSpace(gjson.Get(payload, "alias").String())
+	if coreauth.CanonicalModelID(model) == "" {
+		return
 	}
 
 	statusCode := int(gjson.Get(payload, "fail.status_code").Int())

--- a/internal/home/usage_result_test.go
+++ b/internal/home/usage_result_test.go
@@ -54,7 +54,7 @@ func TestRecordUsagePayloadUsesModelAsUpstreamKey(t *testing.T) {
 	}
 }
 
-func TestRecordUsagePayloadUsesRetryDelayFromFailBody(t *testing.T) {
+func TestRecordUsagePayloadUsesExponentialBackoffDespiteRetryDelay(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "usage-retry-delay-auth",
 		Index:    "usage-retry-delay-index",
@@ -84,14 +84,14 @@ func TestRecordUsagePayloadUsesRetryDelayFromFailBody(t *testing.T) {
 		t.Fatalf("ModelStates[gemini-3-pro-preview] missing after usage payload: %#v", got.ModelStates)
 	}
 	delay := state.NextRetryAfter.Sub(before)
-	if delay < 45*time.Minute || delay > 46*time.Minute {
-		t.Fatalf("ModelStates[gemini-3-pro-preview].NextRetryAfter delay = %v, want about 45m7s", delay)
+	if delay < 500*time.Millisecond || delay > 2*time.Second {
+		t.Fatalf("ModelStates[gemini-3-pro-preview].NextRetryAfter delay = %v, want first exponential backoff", delay)
 	}
 	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
 		t.Fatalf("Quota.NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
 	}
-	if state.Quota.BackoffLevel != 0 {
-		t.Fatalf("Quota.BackoffLevel = %d, want 0 when explicit retry delay is used", state.Quota.BackoffLevel)
+	if state.Quota.BackoffLevel != 1 {
+		t.Fatalf("Quota.BackoffLevel = %d, want first exponential level", state.Quota.BackoffLevel)
 	}
 }
 
@@ -124,7 +124,32 @@ func TestRecordUsagePayloadIgnoresUnauthorizedFromOlderToken(t *testing.T) {
 	}
 }
 
-func TestRecordUsagePayloadFallsBackToAliasWhenModelEmpty(t *testing.T) {
+func TestRecordUsagePayloadIgnoresMissingModel(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "usage-missing-model-auth",
+		Index:    "usage-missing-model-index",
+		Provider: "gemini",
+		Status:   coreauth.StatusActive,
+	}
+	rt := newUsageResultTestRuntime(t, auth)
+
+	rt.RecordUsagePayload(context.Background(), `{
+		"auth_index": "usage-missing-model-index",
+		"provider": "gemini",
+		"failed": true,
+		"fail": {"status_code": 429, "body": "quota exhausted"}
+	}`)
+
+	got, ok := rt.coreManager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatalf("GetByID(%s) missing auth", auth.ID)
+	}
+	if len(got.ModelStates) != 0 || got.Status != coreauth.StatusActive || got.Unavailable || got.Quota.Exceeded {
+		t.Fatalf("auth changed for model-less result: %#v", got)
+	}
+}
+
+func TestRecordUsagePayloadIgnoresAliasWithoutModel(t *testing.T) {
 	auth := &coreauth.Auth{
 		ID:       "usage-alias-auth",
 		Index:    "usage-alias-index",
@@ -149,11 +174,7 @@ func TestRecordUsagePayloadFallsBackToAliasWhenModelEmpty(t *testing.T) {
 	if !ok || got == nil {
 		t.Fatalf("GetByID(%s) missing auth after usage payload", auth.ID)
 	}
-	state := got.ModelStates["alias-model"]
-	if state == nil {
-		t.Fatalf("ModelStates[alias-model] missing after usage payload: %#v", got.ModelStates)
-	}
-	if !state.Unavailable || !state.Quota.Exceeded || state.NextRetryAfter.IsZero() {
-		t.Fatalf("ModelStates[alias-model] = %#v, want 429 cooldown state", state)
+	if len(got.ModelStates) != 0 || got.Status != coreauth.StatusActive || got.Unavailable || got.Quota.Exceeded {
+		t.Fatalf("alias-only result changed auth: %#v", got)
 	}
 }

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -212,6 +212,7 @@ func registerClusterManagementRoutes(r *RouteRegistry, handler *clustermanagemen
 	r.Set(http.MethodGet, "/credentials/concurrency", handler.GetCredentialConcurrency)
 	r.Set(http.MethodGet, "/credentials/:credential_id/concurrency-policy", handler.GetCredentialConcurrencyPolicy)
 	r.Set(http.MethodPatch, "/credentials/:credential_id/concurrency-policy", handler.PatchCredentialConcurrencyPolicy)
+	r.Set(http.MethodDelete, "/credentials/:credential_id/cooldown", handler.ClearCredentialCooldown)
 	r.Set(http.MethodGet, "/quota/credentials", handler.ListQuotaCredentials)
 	r.Set(http.MethodGet, "/quota/credentials/:credential_id", handler.GetQuotaCredential)
 	r.Set(http.MethodPost, "/quota/collect", handler.CollectQuota)

--- a/internal/managementhttp/server_test.go
+++ b/internal/managementhttp/server_test.go
@@ -168,6 +168,7 @@ func TestClusterManagementInFlightRoutesRegistered(t *testing.T) {
 		{Method: http.MethodGet, Path: "/credentials/concurrency"},
 		{Method: http.MethodGet, Path: "/credentials/:credential_id/concurrency-policy"},
 		{Method: http.MethodPatch, Path: "/credentials/:credential_id/concurrency-policy"},
+		{Method: http.MethodDelete, Path: "/credentials/:credential_id/cooldown"},
 	} {
 		if reg.routes[route] == nil {
 			t.Fatalf("route %s %s was not registered", route.Method, route.Path)


### PR DESCRIPTION
## Motivation

Home was disabling its own credential cooldown. `ForceDownstreamHomeModeConfig` exists to describe what a **downstream CPA node** must do in Home mode, and it sets `disable-cooling: true`. But Home also called it on **its own** runtime config, in two places:

- `internal/config/config.go` when loading `config.yaml`
- `internal/cluster/config_snapshot.go` when building the runtime config from the cluster database

The consequence was that `quotaCooldownDisabledForAuth` always returned true on Home, so every failure branch in the result state machine took the `disableCooling` path and cleared `NextRetryAfter` instead of setting it. Home never suspended a model, never set a quota marker, and never applied backoff. A credential that returned HTTP 429 was immediately eligible for reselection, for every model, until the provider hard-blocked it.

That is the root cause of #57.

Fixing only the flag is not sufficient. Once cooldown actually takes effect, the pre-existing state machine cooled **the whole credential** on a single model's 429, which is worse than no cooldown for multi-model credentials. So this PR also narrows the cooldown key to `(credential, model)`, makes that state converge across Home instances, and gives operators a way to release it.

## Ownership contract

| Layer | `disable-cooling` | Owns credential lifecycle |
| --- | --- | --- |
| Home runtime | forced `false` | yes — sole scheduler, cooldown, quota backoff |
| Config pushed to CPA nodes | forced `true` | no — execution and reporting only |

With this PR, Home owns the general credential/model execution cooldown. On the CPA side in Home mode the general cooldown machinery is already fully suppressed: `forceHomeRuntimeConfig` pins `disable-cooling: true` and `save-cooldown-status: false`, local credential selection is rejected outright (`SelectAuth` returns `home_unavailable`), the auto-refresh loop does not start, per-request 401 refresh goes back to Home, the cooldown file store is disabled, and Home-dispatched results go through `reportHomeResult`, which observes the result without touching local auth state.

One provider-specific path is a known exception and is out of scope here: the Antigravity executor keeps its own short rate-limit cooldown and credits hints, and those paths do not consult `disable-cooling`. They are stored in Home's KV rather than locally, and they only cause CPA to return 429 so the request is re-dispatched by Home, but the decision itself is still made by CPA. Aligning that path belongs in CLIProxyAPI, not here.

## Changes

### 1. Split config normalization into Home-owned and downstream-owned

`internal/config/home_mode.go`:

| Function | Applies to | `disable-cooling` |
| --- | --- | --- |
| `ForceHomeRuntimeConfig(cfg)` | Home's own runtime config | `false` |
| `ApplyHomeRuntimeScalars(root)` | Home's YAML root | `false` |
| `ApplyDownstreamHomeModeScalars(root)` | config pushed to CPA nodes | `true` |

Applied at four points:

- `internal/config/config.go` — local `config.yaml` load
- `internal/cluster/config_snapshot.go` — cluster database config snapshot and hot reload
- `internal/cluster/management/config.go` — Management `GET`/`PUT /config.yaml`, so a `true` already persisted in the database can no longer disable Home cooldown and cannot be written back
- `internal/home/config_yaml.go` — unchanged behavior; CPA nodes still receive `true`

`disable-cooling` is now a compatibility field on Home. It is silently normalized to `false` rather than rejected, so existing configs and existing control-panel clients keep working.

### 2. Scope every execution cooldown to `(credential, model)`

Removed the credential-wide penalty paths: `applyAuthFailureState`, the credential-level unauthorized cooldown (`authUnauthorizedCooldownOpen` plus its snapshot/restore/apply helpers), `clearAuthStateOnSuccess`, and the two credential-level blocking branches in `isAuthBlockedForModel`.

`applyResultTransition` now writes only `auth.ModelStates[model]`. `auth.Unavailable` and `auth.Quota` are derived by `updateAggregatedAvailability` and are **display/aggregation fields only** — no scheduling path reads them anymore.

Per-model penalties:

| Result | model `NextRetryAfter` | registry effect |
| --- | --- | --- |
| 400/422 + model-not-supported message | +12h | suspend `model_not_supported` |
| 401 | +1m | none |
| 402/403 | +30m | suspend `payment_required` |
| 404 (not request-scoped) | +12h | suspend `not_found` |
| 429 | exponential `1s` → `30m` cap | suspend `quota`, set model quota marker |
| 408/500/502/503/504 | +1m | none |
| other | cleared | none |

A 429 that lands while a previous quota window is still open reuses that window instead of escalating, so a burst of concurrent failures advances the backoff ladder at most once per window.

### 3. Management API to release quota cooldown

```http
DELETE /v0/management/credentials/:credential_id/cooldown
DELETE /v0/management/credentials/:credential_id/cooldown?model=gpt-5
```

Idempotent. Clears only Home-owned HTTP 429 quota cooldown state: quota flags, retry deadline, and backoff level. It preserves manually disabled credentials, model-level 401/403/404/5xx state, refresh scheduling, and provider quota snapshots. `?model=` is canonicalized, so request-option suffixes such as `(high)` are stripped before lookup.

The operation requires an atomic state store and is applied inside a `SELECT ... FOR UPDATE` transaction on the credential row, so concurrent resets and concurrent result transitions on other Home instances cannot overwrite each other. Without an atomic store the endpoint returns `503 cooldown_reset_unavailable` rather than performing a lossy read-modify-write.

Capability discovery exposes `credential_cooldown_reset: true`.

### 4. Persist quota provenance and reset markers

Two new fields:

- `QuotaState.Scope` (`"model"` / `"credential"`) — records whether a credential-level quota is an aggregate of model states or an independent credential-level quota. Rows written before model-only scheduling have no scope, so `hasLegacyCredentialQuota` reconstructs it by comparing the credential aggregate against the model states.
- `ModelState.QuotaResetAt` — an operator-reset marker.

`QuotaResetAt` exists because merging on `UpdatedAt` alone cannot express a reset. If a reset advanced `UpdatedAt`, a rolling upgrade would let the cleared snapshot overwrite a newer local 401/403/404/5xx state on a peer. If it did not advance `UpdatedAt`, a repeated in-window 429 on a peer would overwrite the reset. So `clearModelQuotaCooldown` deliberately leaves `UpdatedAt` untouched and carries the mutation time in `QuotaResetAt`.

`MergePersistedModelState` resolves merges in three tiers: a persisted reset marker wins but preserves a local non-429 error; otherwise a persisted open quota window stays authoritative and is never shortened by a newer local non-quota error; otherwise `UpdatedAt` decides. It is reused by cooldown adoption and by `internal/home/auth_apply.go` when cluster auth events land.

The marker participates in `availabilityFingerprint` and in `authHasClearableAvailabilityState`, so the first success after a reset is treated as a real transition, persists, and broadcasts marker removal instead of being dropped as a no-op.

### 5. Implement `ReconcileRegistryModelStates`

It was a no-op stub, so the derived model registry was only ever updated by the inline side effects of a local `MarkResult`. Peer state arriving through cluster events and operator resets never updated the local model catalog.

It now recomputes registry quota/suspend state for the union of `auth.ModelStates` and the models registered for that credential, using the final adopted scheduler state. `shouldSuspendRegistryModel` restricts suspension to terminal error classes, so a transient 5xx does not remove a model from the public catalog. It runs after operator resets, after every cluster auth apply, and after model-refresh callbacks.

### 6. Do not apply a local penalty when persistence fails

`MarkResult` previously fell back to a local transition plus a background save when the atomic mutation failed. A transient database error therefore cooled a credential/model locally on one node only. It now returns without applying any penalty.

## Behavior changes and compatibility

Deliberate, test-pinned changes that reviewers should look at:

1. **Upstream retry hints no longer influence quota scheduling.** `nextQuotaRecoverAt` previously honored `Retry-After` / Google `RetryInfo.retryDelay` / `resets in ...` text and returned `now.Add(hint)` **without advancing the backoff level**, so a provider reporting a small delay pinned Home at level 0 forever. 429 now always uses the capped exponential ladder. The parsing helpers and `Result.RetryAfter` are retained but currently unused, pending the authoritative reset-hint work in #89. Covered by `TestRecordUsagePayloadUsesExponentialBackoffDespiteRetryDelay`.

2. **Execution results without a canonical model are ignored.** There is no credential-wide execution cooldown to fall back to, so a model-less result has nothing to key. CPA always sends a non-empty `model` (it substitutes `"unknown"` when its own record has none), which is why the `alias` fallback in `RecordUsagePayload` was also removed as dead. Covered by `TestMarkResultIgnoresMissingCanonicalModel`, `TestRecordUsagePayloadIgnoresMissingModel`, `TestRecordUsagePayloadIgnoresAliasWithoutModel`.

3. **A legacy credential-wide quota is preserved but no longer blocks dispatch.** A model-scoped reset will not erase it, and it still appears in Management API and plugin snapshots, but since credential-level availability is no longer consulted by the scheduler this is a data-preservation guarantee, not a scheduling one. Covered by `TestLegacyCredentialWideStateDoesNotBlockDispatch` and `TestClearQuotaCooldownPreservesLegacyCredentialQuota`.

4. **`disable-cooling` is silently normalized on Home**, including on Management `PUT /config.yaml`. It is not rejected, to avoid breaking existing clients.

Wire compatibility: `QuotaState.Scope` and `ModelState.QuotaResetAt` are additive and omitted when empty. Older peers that merge only on `UpdatedAt` still converge, because resets intentionally do not advance `UpdatedAt`.

A reset is authoritative in the database immediately, but a peer still holding an unexpired pre-reset local quota window absorbs 429s on its fast path and adopts the reset when the cluster auth event lands, or when its local window expires (bounded by the 30 minute cap).

## Verification

```text
gofmt -l .
go build ./...
go test ./internal/config ./internal/cliproxy/auth ./internal/home ./internal/cluster ./internal/cluster/management ./internal/managementhttp
go test -race -run 'Test(ClearQuotaCooldown|ModelSuccessPersistsQuotaResetMarkerRemoval|ReconcileRegistryModelStates|ClearCredentialCooldown|ClusterClearQuotaCooldown|MergeModelStates)' ./internal/cliproxy/auth ./internal/home ./internal/cluster ./internal/cluster/management
go build -o test-output ./cmd/home && rm test-output
git diff --check
```

All clean. `go vet ./...` reports one pre-existing `internal/cluster/refresh.go:171: unreachable code` warning that predates this branch and is untouched here.

Management API handler tests run against a real repository, a real `home.Runtime`, and a real `RuntimeAdapter` rather than mocks. `TestClusterClearQuotaCooldownPersistsAndPublishesAuthEvent` additionally asserts that the reset increments the row version, emits an `auth`/`update` cluster event, and that a peer adopting that event observes the cleared model with its reset marker intact.

English and Chinese Management API documentation are updated, including the route table, the endpoint reference, the capability flag, and the `disable-cooling` field description.

## Out of scope

Codex-specific `resets_at` / `resets_in_seconds` parsing is tracked by #89. Until an authoritative retry hint exists, Home uses the capped exponential ladder described above.

Closes #57.
