### PR TITLE
fix(auth): fail closed on unbounded credential unavailability

### DIFF
--- a/internal/cliproxy/auth/manager.go
+++ b/internal/cliproxy/auth/manager.go
@@ -613,7 +613,10 @@ func shouldSuspendRegistryModel(auth *Auth, model string, reason blockReason) bo
 	if state == nil {
 		return false
 	}
-	if isModelSupportResultError(state.LastError) {
+	// A revoked grant blocks dispatch for 30 minutes, so the registry must keep the
+	// model suspended for the same window. Otherwise the next reconcile would resume a
+	// model Home still refuses to dispatch.
+	if isModelSupportResultError(state.LastError) || isInvalidGrantResultError(state.LastError) {
 		return true
 	}
 	switch statusCodeFromResult(state.LastError) {

--- a/internal/cliproxy/auth/options.go
+++ b/internal/cliproxy/auth/options.go
@@ -19,6 +19,21 @@ const AllowedModelIDsMetadataKey = "allowed_model_ids"
 // concurrency admission during this dispatch attempt.
 const ExcludedConcurrencyCandidatesMetadataKey = "excluded_concurrency_candidates"
 
+// DownstreamWebsocketMetadataKey records that the CPA node is serving this request over
+// a downstream websocket. CPA knows this from its own request context, so it can only
+// reach Home by travelling with the dispatch request.
+const DownstreamWebsocketMetadataKey = "downstream_websocket"
+
+// downstreamWebsocketFromOptions reports whether the requesting node is serving a
+// downstream websocket connection.
+func downstreamWebsocketFromOptions(opts Options) bool {
+	if opts.Metadata == nil {
+		return false
+	}
+	enabled, _ := opts.Metadata[DownstreamWebsocketMetadataKey].(bool)
+	return enabled
+}
+
 // ExcludedConcurrencyCandidate identifies a credential-wide or model-scoped exclusion.
 type ExcludedConcurrencyCandidate struct {
 	CredentialID string

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -206,9 +206,10 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 		transition.suspendReason = "model_not_supported"
 		transition.shouldSuspendModel = true
 	} else if isCloudflareChallengeResultError(result.Error) {
-		next, backoffLevel := nextCloudflareCooldown(state.Quota.BackoffLevel, disableCooling, now)
+		next, backoffLevel := nextCloudflareCooldown(state.Quota, disableCooling, now)
 		state.NextRetryAfter = next
 		state.StatusMessage = cloudflareChallengeReason
+		state.QuotaResetAt = time.Time{}
 		if auth.LastError != nil {
 			auth.StatusMessage = cloudflareChallengeReason
 		}
@@ -310,13 +311,22 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 		return authHasClearableAvailabilityState(auth, resultModel, now)
 	}
 	statusCode := statusCodeFromResult(result.Error)
+	if isModelSupportResultError(result.Error) {
+		return false
+	}
+	// A Cloudflare challenge writes quota state, so it needs the same shared row the
+	// 429 path uses: without it every Home node would advance its own backoff ladder
+	// for one incident and the last writer would win.
+	if isCloudflareChallengeResultError(result.Error) {
+		if m.quotaCooldownDisabledForAuth(auth) {
+			return false
+		}
+		return !authQuotaWindowOpen(auth, resultModel, now)
+	}
 	if statusCode == http.StatusUnauthorized {
 		return true
 	}
 	if statusCode != http.StatusTooManyRequests {
-		return false
-	}
-	if isModelSupportResultError(result.Error) {
 		return false
 	}
 	if m.quotaCooldownDisabledForAuth(auth) {
@@ -836,19 +846,23 @@ func isCloudflareChallengeResultError(err *Error) bool {
 
 // nextCloudflareCooldown reuses the quota backoff ladder with a floor so a challenge
 // page cannot be retried in a tight loop.
-func nextCloudflareCooldown(backoffLevel int, disableCooling bool, now time.Time) (time.Time, int) {
-	var next time.Time
-	if !disableCooling {
-		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, disableCooling)
-		if cooldown < cloudflareChallengeMinCooldown {
-			cooldown = cloudflareChallengeMinCooldown
-		}
-		if cooldown > 0 {
-			next = now.Add(cooldown)
-		}
-		backoffLevel = nextLevel
+//
+// Home aggregates results from every CPA node, so a single challenge is reported many
+// times over. Failures landing inside an open window reuse that window instead of
+// escalating, exactly like the quota path, so one incident advances the ladder at most
+// once no matter how many nodes observe it.
+func nextCloudflareCooldown(quota QuotaState, disableCooling bool, now time.Time) (time.Time, int) {
+	if disableCooling {
+		return time.Time{}, quota.BackoffLevel
 	}
-	return next, backoffLevel
+	if quota.NextRecoverAt.After(now) {
+		return quota.NextRecoverAt, quota.BackoffLevel
+	}
+	cooldown, nextLevel := nextQuotaCooldown(quota.BackoffLevel, false)
+	if cooldown < cloudflareChallengeMinCooldown {
+		cooldown = cloudflareChallengeMinCooldown
+	}
+	return now.Add(cooldown), nextLevel
 }
 
 // recoverableFailureRetryAfter returns the cooldown deadline for a recoverable

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -199,6 +199,8 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 
 	statusCode := statusCodeFromResult(result.Error)
 	if isModelSupportResultError(result.Error) {
+		// A model the credential cannot serve is a capability verdict, not a cooldown,
+		// so disable_cooling does not shorten it.
 		next := now.Add(12 * time.Hour)
 		state.NextRetryAfter = next
 		transition.suspendReason = "model_not_supported"
@@ -228,7 +230,13 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 	} else {
 		switch statusCode {
 		case http.StatusUnauthorized:
-			state.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
+			// Home refreshes tokens centrally, so a 401 only parks the model long enough
+			// for the refresh to land. disable_cooling opts out of that wait as well.
+			if disableCooling {
+				state.NextRetryAfter = time.Time{}
+			} else {
+				state.NextRetryAfter = now.Add(unauthorizedRetryBackoff)
+			}
 		case http.StatusPaymentRequired, http.StatusForbidden:
 			if disableCooling {
 				state.NextRetryAfter = time.Time{}

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -575,15 +575,19 @@ func updateAggregatedAvailability(auth *Auth, now time.Time) {
 		stateUnavailable := false
 		if state.Status == StatusDisabled {
 			stateUnavailable = true
-		} else if state.Unavailable {
-			if state.NextRetryAfter.IsZero() {
-				stateUnavailable = false
-			} else if state.NextRetryAfter.After(now) {
+		} else {
+			// Reuse the dispatch decision so the aggregate an operator sees can never
+			// disagree with the scheduler.
+			blocked, _, next := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+			if blocked {
 				stateUnavailable = true
-				if earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry) {
-					earliestRetry = state.NextRetryAfter
+				if earliestRetry.IsZero() || next.Before(earliestRetry) {
+					earliestRetry = next
 				}
-			} else {
+			} else if state.Unavailable {
+				// The deadline elapsed, or a legacy snapshot never carried one. Normalize
+				// the stored flags so nothing keeps reporting a cooldown that dispatch
+				// already ignores.
 				state.Unavailable = false
 				state.NextRetryAfter = time.Time{}
 			}

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -31,6 +31,28 @@ const (
 
 var usageRetryDelayPattern = regexp.MustCompile(`(?i)\b(?:resets in|after)\s+([0-9]+(?:\.[0-9]+)?(?:h|m|s)(?:[0-9]+(?:\.[0-9]+)?(?:h|m|s))*)`)
 
+// requestFaultCodes and requestFaultTypes mirror CPA's internal/clienterror so both
+// sides agree on which upstream rejections belong to the request rather than the
+// credential.
+var requestFaultCodes = map[string]struct{}{
+	"cyber_policy":                {},
+	"context_length_exceeded":     {},
+	"message_too_big":             {},
+	"string_above_max_length":     {},
+	"invalid_prompt":              {},
+	"invalid_value":               {},
+	"unsupported_value":           {},
+	"invalid_request_error":       {},
+	"previous_response_not_found": {},
+}
+
+var requestFaultTypes = map[string]struct{}{
+	"invalid_request":       {},
+	"invalid_request_error": {},
+	"bad_request_error":     {},
+	"invalid_prompt":        {},
+}
+
 // Result captures an upstream execution result reported by a downstream CPA node.
 type Result struct {
 	AuthID            string
@@ -191,7 +213,7 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 		return transition
 	}
 
-	if isRequestScopedNotFoundResultError(result.Error) || isClientCanceledResult(result) {
+	if resultSkipsCredentialCooldown(result) {
 		return transition
 	}
 	disableCooling := m.quotaCooldownDisabledForAuth(auth)
@@ -319,7 +341,7 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 	if result.Success {
 		return authHasClearableAvailabilityState(auth, resultModel, now)
 	}
-	if isClientCanceledResult(result) {
+	if resultSkipsCredentialCooldown(result) {
 		return false
 	}
 	statusCode := statusCodeFromResult(result.Error)
@@ -766,6 +788,72 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 		return false
 	}
 	return isRequestScopedNotFoundMessage(err.Message)
+}
+
+// resultSkipsCredentialCooldown reports failures that say nothing about the credential
+// and therefore must not cool the credential/model pair down.
+//
+// Order matters. Several provider verdicts arrive on the very status codes a request
+// fault uses (invalid_grant on 400/401, an unsupported model on 400/422), so each of
+// them is settled before the generic request-fault test runs. Getting this backwards
+// would let a revoked grant masquerade as a bad request and never cool down.
+func resultSkipsCredentialCooldown(result Result) bool {
+	if result.Success {
+		return false
+	}
+	if isClientCanceledResult(result) {
+		return true
+	}
+	err := result.Error
+	if isRequestScopedNotFoundResultError(err) {
+		return true
+	}
+	if isCloudflareChallengeResultError(err) || isInvalidGrantResultError(err) || isModelSupportResultError(err) {
+		return false
+	}
+	return isRequestFaultResultError(err)
+}
+
+// isRequestFaultResultError reports whether an upstream rejection was caused by the
+// request itself. Every credential would produce the same answer for the same input,
+// so cooling one down only shrinks the pool while the caller keeps replaying a request
+// that cannot succeed until it is rebuilt.
+func isRequestFaultResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	if hasRequestFaultBody(err.Message) {
+		return true
+	}
+	switch statusCodeFromResult(err) {
+	case http.StatusBadRequest,
+		http.StatusConflict,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity:
+		return true
+	default:
+		return false
+	}
+}
+
+// hasRequestFaultBody matches the structured identifiers providers use to say the
+// request was malformed, oversized, or rejected by policy.
+func hasRequestFaultBody(body string) bool {
+	body = strings.TrimSpace(body)
+	if body == "" || !gjson.Valid(body) {
+		return false
+	}
+	for _, path := range []string{"error.code", "code", "response.error.code", "body.error.code"} {
+		if _, ok := requestFaultCodes[strings.ToLower(strings.TrimSpace(gjson.Get(body, path).String()))]; ok {
+			return true
+		}
+	}
+	for _, path := range []string{"error.type", "type", "response.error.type", "body.error.type"} {
+		if _, ok := requestFaultTypes[strings.ToLower(strings.TrimSpace(gjson.Get(body, path).String()))]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // isClientCanceledResult reports whether a failed attempt was aborted by the caller

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -18,6 +18,7 @@ const (
 	quotaBackoffBase         = time.Second
 	quotaBackoffMax          = 30 * time.Minute
 	unauthorizedRetryBackoff = time.Minute
+	transientErrorCooldown   = time.Minute
 	quotaScopeModel          = "model"
 )
 
@@ -238,14 +239,23 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 				transition.setModelQuota = true
 			}
 		case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-			if disableCooling {
-				state.NextRetryAfter = time.Time{}
-			} else {
-				state.NextRetryAfter = now.Add(time.Minute)
-			}
+			state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+			state.Unavailable = !state.NextRetryAfter.IsZero()
 		default:
-			state.NextRetryAfter = time.Time{}
+			// An unmapped upstream failure is recoverable: park the model for a short
+			// window so dispatch moves to another credential, then let it return on
+			// its own. Leaving a zero deadline here would block the model forever.
+			state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+			state.Unavailable = !state.NextRetryAfter.IsZero()
 		}
+	}
+
+	// disable_cooling means "keep retrying", not "park the credential forever".
+	// Without any recovery deadline the unavailable and quota flags would be
+	// unbounded, so clear them instead of leaving a state nothing can expire.
+	if disableCooling && state.NextRetryAfter.IsZero() && state.Quota.NextRecoverAt.IsZero() {
+		state.Unavailable = false
+		state.Quota.Exceeded = false
 	}
 
 	auth.Status = StatusError
@@ -749,6 +759,16 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 		return quotaBackoffMax, prevLevel
 	}
 	return cooldown, prevLevel + 1
+}
+
+// recoverableFailureRetryAfter returns the cooldown deadline for a recoverable
+// upstream failure. Disabled cooling yields a zero deadline so the credential is
+// retried immediately rather than parked.
+func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
+	if disableCooling {
+		return time.Time{}
+	}
+	return now.Add(transientErrorCooldown)
 }
 
 func nextQuotaRecoverAt(now time.Time, _ *time.Duration, quota QuotaState, disableCooling bool) (time.Time, int) {

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -237,19 +237,16 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 		transition.suspendReason = "model_not_supported"
 		transition.shouldSuspendModel = true
 	} else if isCloudflareChallengeResultError(result.Error) {
-		next, backoffLevel := nextCloudflareCooldown(state.Quota, disableCooling, now)
+		// A challenge is an edge-level temporary restriction on this credential/model
+		// pair, not a provider quota. Recording it as quota made dispatch answer with a
+		// quota cooldown error and pointed every investigation at the wrong subsystem.
+		next, backoffLevel := nextCloudflareCooldown(state.NextRetryAfter, state.RetryBackoffLevel, disableCooling, now)
 		state.NextRetryAfter = next
+		state.RetryBackoffLevel = backoffLevel
+		state.Unavailable = !next.IsZero()
 		state.StatusMessage = cloudflareChallengeReason
-		state.QuotaResetAt = time.Time{}
 		if auth.LastError != nil {
 			auth.StatusMessage = cloudflareChallengeReason
-		}
-		state.Quota = QuotaState{
-			Exceeded:      true,
-			Scope:         quotaScopeModel,
-			Reason:        cloudflareChallengeReason,
-			NextRecoverAt: next,
-			BackoffLevel:  backoffLevel,
 		}
 	} else if isInvalidGrantResultError(result.Error) {
 		if disableCooling {
@@ -348,14 +345,14 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 	if isModelSupportResultError(result.Error) {
 		return false
 	}
-	// A Cloudflare challenge writes quota state, so it needs the same shared row the
-	// 429 path uses: without it every Home node would advance its own backoff ladder
-	// for one incident and the last writer would win.
+	// A Cloudflare challenge advances a backoff ladder, so it needs the same shared row
+	// the 429 path uses: without it every Home node would advance its own ladder for one
+	// incident and the last writer would win.
 	if isCloudflareChallengeResultError(result.Error) {
 		if m.quotaCooldownDisabledForAuth(auth) {
 			return false
 		}
-		return !authQuotaWindowOpen(auth, resultModel, now)
+		return !authRetryWindowOpen(auth, resultModel, now)
 	}
 	if statusCode == http.StatusUnauthorized {
 		return true
@@ -382,6 +379,16 @@ func authQuotaWindowOpen(auth *Auth, resultModel string, now time.Time) bool {
 	}
 	state := auth.ModelStates[resultModel]
 	return state != nil && state.Quota.Exceeded && state.Quota.NextRecoverAt.After(now)
+}
+
+// authRetryWindowOpen reports whether a non-quota cooldown window is still live for
+// this model, which means the shared row already carries the restriction.
+func authRetryWindowOpen(auth *Auth, resultModel string, now time.Time) bool {
+	if auth == nil || resultModel == "" {
+		return false
+	}
+	state := auth.ModelStates[resultModel]
+	return state != nil && state.NextRetryAfter.After(now)
 }
 
 // authHasClearableAvailabilityState reports whether a success outcome would
@@ -423,6 +430,7 @@ type availabilityFingerprintValue struct {
 	modelUnavail   bool
 	modelRetryUnix int64
 	modelResetUnix int64
+	modelRetryLvl  int
 	modelQuota     quotaFingerprint
 }
 
@@ -463,6 +471,7 @@ func availabilityFingerprint(auth *Auth, resultModel string) availabilityFingerp
 			fp.modelUnavail = state.Unavailable
 			fp.modelRetryUnix = fingerprintUnix(state.NextRetryAfter)
 			fp.modelResetUnix = fingerprintUnix(state.QuotaResetAt)
+			fp.modelRetryLvl = state.RetryBackoffLevel
 			fp.modelQuota = fingerprintQuota(state.Quota)
 		}
 	}
@@ -601,6 +610,7 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.Quota = QuotaState{}
 	state.UpdatedAt = now
 	state.QuotaResetAt = time.Time{}
+	state.RetryBackoffLevel = 0
 }
 
 // updateAggregatedAvailability updates an aggregated availability.
@@ -997,14 +1007,14 @@ func isCloudflareChallengeResultError(err *Error) bool {
 // times over. Failures landing inside an open window reuse that window instead of
 // escalating, exactly like the quota path, so one incident advances the ladder at most
 // once no matter how many nodes observe it.
-func nextCloudflareCooldown(quota QuotaState, disableCooling bool, now time.Time) (time.Time, int) {
+func nextCloudflareCooldown(nextRetryAfter time.Time, backoffLevel int, disableCooling bool, now time.Time) (time.Time, int) {
 	if disableCooling {
-		return time.Time{}, quota.BackoffLevel
+		return time.Time{}, backoffLevel
 	}
-	if quota.NextRecoverAt.After(now) {
-		return quota.NextRecoverAt, quota.BackoffLevel
+	if nextRetryAfter.After(now) {
+		return nextRetryAfter, backoffLevel
 	}
-	cooldown, nextLevel := nextQuotaCooldown(quota.BackoffLevel, false)
+	cooldown, nextLevel := nextQuotaCooldown(backoffLevel, false)
 	if cooldown < cloudflareChallengeMinCooldown {
 		cooldown = cloudflareChallengeMinCooldown
 	}

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -20,6 +20,9 @@ const (
 	unauthorizedRetryBackoff = time.Minute
 	transientErrorCooldown   = time.Minute
 	quotaScopeModel          = "model"
+
+	cloudflareChallengeReason      = "cloudflare challenge"
+	cloudflareChallengeMinCooldown = 10 * time.Second
 )
 
 var usageRetryDelayPattern = regexp.MustCompile(`(?i)\b(?:resets in|after)\s+([0-9]+(?:\.[0-9]+)?(?:h|m|s)(?:[0-9]+(?:\.[0-9]+)?(?:h|m|s))*)`)
@@ -200,6 +203,28 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 		state.NextRetryAfter = next
 		transition.suspendReason = "model_not_supported"
 		transition.shouldSuspendModel = true
+	} else if isCloudflareChallengeResultError(result.Error) {
+		next, backoffLevel := nextCloudflareCooldown(state.Quota.BackoffLevel, disableCooling, now)
+		state.NextRetryAfter = next
+		state.StatusMessage = cloudflareChallengeReason
+		if auth.LastError != nil {
+			auth.StatusMessage = cloudflareChallengeReason
+		}
+		state.Quota = QuotaState{
+			Exceeded:      true,
+			Scope:         quotaScopeModel,
+			Reason:        cloudflareChallengeReason,
+			NextRecoverAt: next,
+			BackoffLevel:  backoffLevel,
+		}
+	} else if isInvalidGrantResultError(result.Error) {
+		if disableCooling {
+			state.NextRetryAfter = time.Time{}
+		} else {
+			state.NextRetryAfter = now.Add(30 * time.Minute)
+			transition.suspendReason = "invalid_grant"
+			transition.shouldSuspendModel = true
+		}
 	} else {
 		switch statusCode {
 		case http.StatusUnauthorized:
@@ -759,6 +784,59 @@ func nextQuotaCooldown(prevLevel int, disableCooling bool) (time.Duration, int) 
 		return quotaBackoffMax, prevLevel
 	}
 	return cooldown, prevLevel + 1
+}
+
+// isInvalidGrantErrorMessage reports whether a message identifies a revoked,
+// expired, or reused refresh token.
+func isInvalidGrantErrorMessage(message string) bool {
+	return strings.Contains(strings.ToLower(message), "invalid_grant")
+}
+
+// isInvalidGrantResultError reports whether an execution result failed because the
+// credential's grant is no longer valid. Retrying the same token cannot fix it, so
+// only 400 and 401 responses qualify: other statuses stay on the transient path.
+func isInvalidGrantResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	status := statusCodeFromResult(err)
+	if status != http.StatusBadRequest && status != http.StatusUnauthorized {
+		return false
+	}
+	return isInvalidGrantErrorMessage(err.Code) || isInvalidGrantErrorMessage(err.Message)
+}
+
+// isCloudflareChallengeResultError reports whether the upstream returned a
+// Cloudflare interstitial instead of a provider response.
+func isCloudflareChallengeResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Message))
+	if lower == "" {
+		return false
+	}
+	return strings.Contains(lower, "challenge-platform") ||
+		strings.Contains(lower, "cf-mitigated") ||
+		strings.Contains(lower, cloudflareChallengeReason) ||
+		(strings.Contains(lower, "cloudflare") && strings.Contains(lower, "<html"))
+}
+
+// nextCloudflareCooldown reuses the quota backoff ladder with a floor so a challenge
+// page cannot be retried in a tight loop.
+func nextCloudflareCooldown(backoffLevel int, disableCooling bool, now time.Time) (time.Time, int) {
+	var next time.Time
+	if !disableCooling {
+		cooldown, nextLevel := nextQuotaCooldown(backoffLevel, disableCooling)
+		if cooldown < cloudflareChallengeMinCooldown {
+			cooldown = cloudflareChallengeMinCooldown
+		}
+		if cooldown > 0 {
+			next = now.Add(cooldown)
+		}
+		backoffLevel = nextLevel
+	}
+	return next, backoffLevel
 }
 
 // recoverableFailureRetryAfter returns the cooldown deadline for a recoverable

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strings"
 	"time"
 
@@ -28,8 +27,6 @@ const (
 	cloudflareChallengeReason      = "cloudflare challenge"
 	cloudflareChallengeMinCooldown = 10 * time.Second
 )
-
-var usageRetryDelayPattern = regexp.MustCompile(`(?i)\b(?:resets in|after)\s+([0-9]+(?:\.[0-9]+)?(?:h|m|s)(?:[0-9]+(?:\.[0-9]+)?(?:h|m|s))*)`)
 
 // requestFaultCodes and requestFaultTypes mirror CPA's internal/clienterror so both
 // sides agree on which upstream rejections belong to the request rather than the
@@ -61,7 +58,6 @@ type Result struct {
 	Model             string
 	Success           bool
 	Error             *Error
-	RetryAfter        *time.Duration
 	AccessTokenSHA256 string
 }
 
@@ -82,6 +78,10 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	}
 	// A client that walked away says nothing about the credential. Drop the result
 	// entirely so the attempt is neither counted as a failure nor cooled down.
+	//
+	// This deliberately skips the recent-request counters too. A cancellation is
+	// neither a success nor a failure, and folding it into either would distort the
+	// health rate that operators read to judge a credential.
 	if isClientCanceledResult(result) {
 		return
 	}
@@ -276,6 +276,9 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 				transition.shouldSuspendModel = true
 			}
 		case http.StatusNotFound:
+			// Unlike an explicit model-not-supported verdict, a bare 404 can also mean a
+			// misrouted or briefly missing endpoint, so it stays a cooldown that
+			// disable_cooling is allowed to waive.
 			if disableCooling {
 				state.NextRetryAfter = time.Time{}
 			} else {
@@ -285,7 +288,7 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 				transition.shouldSuspendModel = true
 			}
 		case http.StatusTooManyRequests:
-			next, backoffLevel := nextQuotaRecoverAt(now, result.RetryAfter, state.Quota, disableCooling)
+			next, backoffLevel := nextQuotaRecoverAt(now, state.Quota, disableCooling)
 			state.NextRetryAfter = next
 			state.QuotaResetAt = time.Time{}
 			state.Quota = QuotaState{
@@ -709,13 +712,14 @@ func hasModelError(auth *Auth, now time.Time) bool {
 		if state == nil {
 			continue
 		}
-		if state.LastError != nil {
+		if state.Status == StatusDisabled {
 			return true
 		}
-		if state.Status == StatusError {
-			if state.Unavailable && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.After(now)) {
-				return true
-			}
+		// Only a model that is still blocked counts. A recorded LastError outlives the
+		// cooldown it came from, so treating it as current kept a credential marked
+		// unhealthy long after every one of its models had recovered.
+		if blocked, _, _ := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now); blocked {
+			return true
 		}
 	}
 	return false
@@ -1031,7 +1035,7 @@ func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time 
 	return now.Add(transientErrorCooldown)
 }
 
-func nextQuotaRecoverAt(now time.Time, _ *time.Duration, quota QuotaState, disableCooling bool) (time.Time, int) {
+func nextQuotaRecoverAt(now time.Time, quota QuotaState, disableCooling bool) (time.Time, int) {
 	if disableCooling {
 		return time.Time{}, quota.BackoffLevel
 	}
@@ -1079,81 +1083,13 @@ func NewUsageResult(authIndex, provider, model string, statusCode int, body stri
 		message = fmt.Sprintf("request failed with status %d", statusCode)
 	}
 	return Result{
-		AuthIndex:  authIndex,
-		Provider:   provider,
-		Model:      model,
-		Success:    false,
-		RetryAfter: parseUsageRetryAfter(body, statusCode),
+		AuthIndex: authIndex,
+		Provider:  provider,
+		Model:     model,
+		Success:   false,
 		Error: &Error{
 			Message:    message,
 			HTTPStatus: statusCode,
 		},
 	}
-}
-
-func parseUsageRetryAfter(body string, statusCode int) *time.Duration {
-	if statusCode != http.StatusTooManyRequests {
-		return nil
-	}
-	body = strings.TrimSpace(body)
-	if body == "" {
-		return nil
-	}
-	if gjson.Valid(body) {
-		if retryAfter := parseGoogleRetryDelay(body); retryAfter != nil {
-			return retryAfter
-		}
-		if retryAfter := parseRetryDelayFromMessage(gjson.Get(body, "error.message").String()); retryAfter != nil {
-			return retryAfter
-		}
-	}
-	return parseRetryDelayFromMessage(body)
-}
-
-func parseGoogleRetryDelay(body string) *time.Duration {
-	details := gjson.Get(body, "error.details")
-	if !details.Exists() || !details.IsArray() {
-		return nil
-	}
-	for _, detail := range details.Array() {
-		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.RetryInfo" {
-			continue
-		}
-		if retryAfter := parseDurationPointer(detail.Get("retryDelay").String()); retryAfter != nil {
-			return retryAfter
-		}
-	}
-	for _, detail := range details.Array() {
-		if detail.Get("@type").String() != "type.googleapis.com/google.rpc.ErrorInfo" {
-			continue
-		}
-		if retryAfter := parseDurationPointer(detail.Get("metadata.quotaResetDelay").String()); retryAfter != nil {
-			return retryAfter
-		}
-	}
-	return nil
-}
-
-func parseRetryDelayFromMessage(message string) *time.Duration {
-	message = strings.TrimSpace(message)
-	if message == "" {
-		return nil
-	}
-	matches := usageRetryDelayPattern.FindStringSubmatch(message)
-	if len(matches) < 2 {
-		return nil
-	}
-	return parseDurationPointer(matches[1])
-}
-
-func parseDurationPointer(value string) *time.Duration {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	duration, errParse := time.ParseDuration(value)
-	if errParse != nil || duration <= 0 {
-		return nil
-	}
-	return &duration
 }

--- a/internal/cliproxy/auth/result.go
+++ b/internal/cliproxy/auth/result.go
@@ -21,6 +21,10 @@ const (
 	transientErrorCooldown   = time.Minute
 	quotaScopeModel          = "model"
 
+	// statusClientClosedRequest is the non-standard status proxies use when the caller
+	// disconnects before the upstream answered.
+	statusClientClosedRequest = 499
+
 	cloudflareChallengeReason      = "cloudflare challenge"
 	cloudflareChallengeMinCooldown = 10 * time.Second
 )
@@ -52,6 +56,11 @@ type markResultTransition struct {
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	// Keep validation before state changes so failures leave existing data intact.
 	if m == nil || (strings.TrimSpace(result.AuthID) == "" && strings.TrimSpace(result.AuthIndex) == "") {
+		return
+	}
+	// A client that walked away says nothing about the credential. Drop the result
+	// entirely so the attempt is neither counted as a failure nor cooled down.
+	if isClientCanceledResult(result) {
 		return
 	}
 	if ctx == nil {
@@ -182,7 +191,7 @@ func (m *Manager) applyResultTransition(auth *Auth, result Result, resultModel s
 		return transition
 	}
 
-	if isRequestScopedNotFoundResultError(result.Error) {
+	if isRequestScopedNotFoundResultError(result.Error) || isClientCanceledResult(result) {
 		return transition
 	}
 	disableCooling := m.quotaCooldownDisabledForAuth(auth)
@@ -309,6 +318,9 @@ func (m *Manager) resultNeedsGlobalTransition(auth *Auth, result Result, resultM
 	}
 	if result.Success {
 		return authHasClearableAvailabilityState(auth, resultModel, now)
+	}
+	if isClientCanceledResult(result) {
+		return false
 	}
 	statusCode := statusCodeFromResult(result.Error)
 	if isModelSupportResultError(result.Error) {
@@ -754,6 +766,52 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 		return false
 	}
 	return isRequestScopedNotFoundMessage(err.Message)
+}
+
+// isClientCanceledResult reports whether a failed attempt was aborted by the caller
+// rather than rejected by the provider. Such a result carries no information about the
+// credential, so Home must not cool it down or count the attempt against it.
+func isClientCanceledResult(result Result) bool {
+	if result.Success {
+		return false
+	}
+	return isClientCanceledResultError(result.Error)
+}
+
+// isClientCanceledResultError reports whether an execution error describes a caller
+// that went away.
+func isClientCanceledResultError(err *Error) bool {
+	if err == nil {
+		return false
+	}
+	if statusCodeFromResult(err) == statusClientClosedRequest {
+		return true
+	}
+	return isClientCanceledMessage(err.Code) || isClientCanceledMessage(err.Message)
+}
+
+// isClientCanceledMessage matches the cancellation vocabulary produced by Go, net/http,
+// and the CPA executors when a caller disconnects mid-flight.
+//
+// Timeouts are deliberately excluded. A deadline says the upstream stopped responding,
+// which is exactly the signal the transient cooldown exists for, and "Client.Timeout
+// exceeded" phrases the same thing with the word canceled.
+func isClientCanceledMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if lower == "" {
+		return false
+	}
+	if strings.Contains(lower, "timeout") || strings.Contains(lower, "deadline exceeded") {
+		return false
+	}
+	return strings.Contains(lower, "context canceled") ||
+		strings.Contains(lower, "context cancelled") ||
+		strings.Contains(lower, "request canceled") ||
+		strings.Contains(lower, "request cancelled") ||
+		strings.Contains(lower, "client disconnected") ||
+		strings.Contains(lower, "client closed request") ||
+		strings.Contains(lower, "operation was canceled") ||
+		strings.Contains(lower, "operation was cancelled")
 }
 
 // disableAuthAfterUnauthorized permanently disables a credential after a terminal refresh failure.

--- a/internal/cliproxy/auth/result_availability_test.go
+++ b/internal/cliproxy/auth/result_availability_test.go
@@ -189,3 +189,37 @@ func TestModelNotSupportedKeepsLongCooldown(t *testing.T) {
 		t.Fatal("unsupported model stayed available")
 	}
 }
+
+// TestRecoveredModelStopsMarkingTheCredentialUnhealthy keeps a stale error record from
+// outliving the cooldown it came from. A recorded LastError used to count as a current
+// fault forever, so one transient failure left the credential reported as unhealthy
+// even after every model had recovered and dispatch was using it normally.
+func TestRecoveredModelStopsMarkingTheCredentialUnhealthy(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-recovered", false)
+
+	applyFailure(auth, "gpt-5", http.StatusServiceUnavailable, "service unavailable", now)
+	if !hasModelError(auth, now) {
+		t.Fatal("an active cooldown was not reported as a model error")
+	}
+
+	afterWindow := now.Add(transientErrorCooldown + time.Second)
+	if hasModelError(auth, afterWindow) {
+		t.Fatal("an expired cooldown still reported the credential as unhealthy")
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", afterWindow); blocked {
+		t.Fatal("dispatch and health disagree after the cooldown expired")
+	}
+}
+
+// TestDisabledModelKeepsCredentialUnhealthy keeps an operator disable visible, since it
+// carries no deadline and must not be mistaken for a recovered model.
+func TestDisabledModelKeepsCredentialUnhealthy(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-disabled-model", false)
+	auth.ModelStates = map[string]*ModelState{"gpt-5": {Status: StatusDisabled}}
+
+	if !hasModelError(auth, now.Add(24*time.Hour)) {
+		t.Fatal("a disabled model stopped counting as a fault")
+	}
+}

--- a/internal/cliproxy/auth/result_availability_test.go
+++ b/internal/cliproxy/auth/result_availability_test.go
@@ -64,7 +64,7 @@ func TestUnmappedStatusParksModelBriefly(t *testing.T) {
 	now := time.Now().UTC()
 	auth := failingAuth("auth-unmapped", false)
 
-	applyFailure(auth, "gpt-5", http.StatusConflict, "conflict", now)
+	applyFailure(auth, "gpt-5", http.StatusNotImplemented, "not implemented", now)
 
 	state := auth.ModelStates["gpt-5"]
 	if state == nil {
@@ -91,7 +91,7 @@ func TestUnmappedStatusWithDisableCoolingStaysAvailable(t *testing.T) {
 	now := time.Now().UTC()
 	auth := failingAuth("auth-unmapped-nocool", true)
 
-	applyFailure(auth, "gpt-5", http.StatusBadRequest, "bad request", now)
+	applyFailure(auth, "gpt-5", http.StatusNotImplemented, "not implemented", now)
 
 	state := auth.ModelStates["gpt-5"]
 	if state == nil {

--- a/internal/cliproxy/auth/result_availability_test.go
+++ b/internal/cliproxy/auth/result_availability_test.go
@@ -1,0 +1,191 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// failingAuth builds a credential ready to receive a failure transition.
+func failingAuth(id string, disableCooling bool) *Auth {
+	auth := &Auth{
+		ID:       id,
+		Provider: "antigravity",
+		Status:   StatusActive,
+	}
+	if disableCooling {
+		auth.Metadata = map[string]any{"disable_cooling": true}
+	}
+	return auth
+}
+
+// applyFailure records a failed execution result against the credential.
+func applyFailure(auth *Auth, model string, status int, message string, now time.Time) {
+	NewManager(nil, nil, nil).applyResultTransition(auth, Result{
+		AuthID:  auth.ID,
+		Model:   model,
+		Success: false,
+		Error:   &Error{Message: message, HTTPStatus: status},
+	}, model, now)
+}
+
+// TestQuotaFailureWithDisableCoolingClearsUnboundedState reproduces the state
+// observed on the credential behind the production 503: a quota failure on a
+// credential with disable_cooling used to leave unavailable and quota-exceeded
+// set with no recovery deadline at all.
+func TestQuotaFailureWithDisableCoolingClearsUnboundedState(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-quota-nocool", true)
+
+	applyFailure(auth, "gemini-3-flash-agent", http.StatusTooManyRequests, "quota exceeded", now)
+
+	state := auth.ModelStates["gemini-3-flash-agent"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.IsZero() || !state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("disable_cooling produced deadlines: retry=%v recover=%v", state.NextRetryAfter, state.Quota.NextRecoverAt)
+	}
+	if state.Unavailable || state.Quota.Exceeded {
+		t.Fatalf("unbounded flags survived: unavailable=%v quotaExceeded=%v", state.Unavailable, state.Quota.Exceeded)
+	}
+	if state.LastError == nil || state.Status != StatusError {
+		t.Fatalf("failure detail was dropped: status=%v lastError=%v", state.Status, state.LastError)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gemini-3-flash-agent", now); blocked {
+		t.Fatal("disable_cooling credential was blocked despite having no cooldown")
+	}
+}
+
+// TestUnmappedStatusParksModelBriefly covers status codes with no dedicated
+// branch: they must cool down long enough to move dispatch onto another
+// credential, then recover without operator action.
+func TestUnmappedStatusParksModelBriefly(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-unmapped", false)
+
+	applyFailure(auth, "gpt-5", http.StatusConflict, "conflict", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(transientErrorCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", state.NextRetryAfter, now.Add(transientErrorCooldown))
+	}
+	if !state.Unavailable {
+		t.Fatal("unmapped failure left the model available")
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || reason != blockReasonOther {
+		t.Fatalf("blocked/reason = %v/%v, want a non-quota block during the cooldown", blocked, reason)
+	}
+	after := now.Add(transientErrorCooldown + time.Second)
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", after); blocked {
+		t.Fatal("model stayed blocked after the cooldown elapsed")
+	}
+}
+
+// TestUnmappedStatusWithDisableCoolingStaysAvailable keeps disable_cooling from
+// parking a credential on an unmapped status code.
+func TestUnmappedStatusWithDisableCoolingStaysAvailable(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-unmapped-nocool", true)
+
+	applyFailure(auth, "gpt-5", http.StatusBadRequest, "bad request", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.IsZero() || state.Unavailable {
+		t.Fatalf("state = %#v, want no cooldown and available", state)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", now); blocked {
+		t.Fatal("disable_cooling credential was blocked on an unmapped status")
+	}
+}
+
+// TestTransientFailureBlocksForOneMinute pins the 408/5xx cooldown window.
+func TestTransientFailureBlocksForOneMinute(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-transient", false)
+
+	applyFailure(auth, "gpt-5", http.StatusBadGateway, "bad gateway", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(transientErrorCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", state.NextRetryAfter, now.Add(transientErrorCooldown))
+	}
+	if !state.Unavailable {
+		t.Fatal("transient failure left the model available")
+	}
+	if blocked, _, next := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || !next.Equal(state.NextRetryAfter) {
+		t.Fatalf("blocked/next = %v/%v, want a block until %v", blocked, next, state.NextRetryAfter)
+	}
+}
+
+// TestTransientFailureWithDisableCoolingStaysAvailable keeps disable_cooling
+// retryable on 408/5xx instead of leaving an unbounded unavailable flag.
+func TestTransientFailureWithDisableCoolingStaysAvailable(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-transient-nocool", true)
+
+	applyFailure(auth, "gpt-5", http.StatusServiceUnavailable, "service unavailable", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.IsZero() || state.Unavailable {
+		t.Fatalf("state = %#v, want no cooldown and available", state)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", now); blocked {
+		t.Fatal("disable_cooling credential was blocked on a transient failure")
+	}
+}
+
+// TestQuotaFailureWithCoolingKeepsQuotaWindow guards the normal quota path: the
+// disable_cooling cleanup must not weaken a real cooldown.
+func TestQuotaFailureWithCoolingKeepsQuotaWindow(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-quota-cool", false)
+
+	applyFailure(auth, "gpt-5", http.StatusTooManyRequests, "quota exceeded", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.Quota.Exceeded || !state.Unavailable {
+		t.Fatalf("state = %#v, want a quota cooldown", state)
+	}
+	if !state.Quota.NextRecoverAt.After(now) {
+		t.Fatalf("NextRecoverAt = %v, want a future quota window", state.Quota.NextRecoverAt)
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || reason != blockReasonCooldown {
+		t.Fatalf("blocked/reason = %v/%v, want blockReasonCooldown", blocked, reason)
+	}
+}
+
+// TestModelNotSupportedKeepsLongCooldown ensures the disable_cooling cleanup runs
+// after the model-support branch and cannot erase its 12h deadline.
+func TestModelNotSupportedKeepsLongCooldown(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-unsupported-nocool", true)
+
+	applyFailure(auth, "gpt-5", http.StatusBadRequest, "requested model is not supported", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(12 * time.Hour)) {
+		t.Fatalf("NextRetryAfter = %v, want a 12h cooldown", state.NextRetryAfter)
+	}
+	if !state.Unavailable {
+		t.Fatal("unsupported model stayed available")
+	}
+}

--- a/internal/cliproxy/auth/result_cancellation_test.go
+++ b/internal/cliproxy/auth/result_cancellation_test.go
@@ -1,0 +1,108 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// canceledManagerAuth registers a credential ready to receive execution results.
+func canceledManagerAuth(t *testing.T, id string) (*Manager, *Auth) {
+	t.Helper()
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       id,
+		Index:    id,
+		Provider: "antigravity",
+		Status:   StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	return manager, auth
+}
+
+// TestClientCancellationLeavesCredentialUntouched covers the caller hanging up: the
+// attempt says nothing about the credential, so it must not be counted, cooled down,
+// or recorded as an error.
+func TestClientCancellationLeavesCredentialUntouched(t *testing.T) {
+	cancellations := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "context canceled", status: http.StatusInternalServerError, body: `Post "https://upstream/v1/chat": context canceled`},
+		{name: "client closed request", status: statusClientClosedRequest, body: ""},
+		{name: "client disconnected", status: http.StatusInternalServerError, body: "client disconnected before response"},
+	}
+
+	for _, tc := range cancellations {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, auth := canceledManagerAuth(t, "auth-canceled-"+tc.name)
+
+			manager.MarkResult(context.Background(), NewUsageResult(auth.Index, "antigravity", "gpt-5", tc.status, tc.body))
+
+			updated, ok := manager.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatal("updated auth not found")
+			}
+			if updated.Failed != 0 {
+				t.Fatalf("Failed = %d, want the cancelled attempt uncounted", updated.Failed)
+			}
+			if updated.Status != StatusActive || updated.LastError != nil {
+				t.Fatalf("auth = %#v, want an untouched active credential", updated)
+			}
+			if state := updated.ModelStates["gpt-5"]; state != nil {
+				t.Fatalf("model state = %#v, want no state recorded for a cancellation", state)
+			}
+			if blocked, _, _ := isAuthBlockedForModel(updated, "gpt-5", time.Now()); blocked {
+				t.Fatal("a cancelled request cooled down the credential")
+			}
+		})
+	}
+}
+
+// TestUpstreamTimeoutStillCoolsDown keeps the cancellation guard narrow: a deadline
+// means the upstream stopped answering, which is exactly what the transient cooldown
+// is for, even when the error text says "canceled".
+func TestUpstreamTimeoutStillCoolsDown(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-timeout", false)
+
+	applyFailure(auth, "gpt-5", http.StatusInternalServerError, `net/http: request canceled (Client.Timeout exceeded while awaiting headers)`, now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(transientErrorCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want the transient cooldown %v", state.NextRetryAfter, now.Add(transientErrorCooldown))
+	}
+}
+
+// TestCancellationKeepsExistingCooldownIntact makes sure the guard drops the result
+// instead of clearing state an earlier real failure established.
+func TestCancellationKeepsExistingCooldownIntact(t *testing.T) {
+	now := time.Now().UTC()
+	manager, auth := canceledManagerAuth(t, "auth-cancel-after-quota")
+
+	manager.MarkResult(context.Background(), NewUsageResult(auth.Index, "antigravity", "gpt-5", http.StatusTooManyRequests, "quota exceeded"))
+	cooled, _ := manager.GetByID(auth.ID)
+	state := cooled.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded {
+		t.Fatalf("model state = %#v, want a quota cooldown", state)
+	}
+	recoverAt := state.Quota.NextRecoverAt
+
+	manager.MarkResult(context.Background(), NewUsageResult(auth.Index, "antigravity", "gpt-5", http.StatusInternalServerError, "context canceled"))
+
+	after, _ := manager.GetByID(auth.ID)
+	afterState := after.ModelStates["gpt-5"]
+	if afterState == nil || !afterState.Quota.NextRecoverAt.Equal(recoverAt) {
+		t.Fatalf("quota window = %#v, want it preserved at %v", afterState, recoverAt)
+	}
+	if blocked, _, _ := isAuthBlockedForModel(after, "gpt-5", now); !blocked {
+		t.Fatal("the cancellation released an open quota cooldown")
+	}
+}

--- a/internal/cliproxy/auth/result_disable_cooling_test.go
+++ b/internal/cliproxy/auth/result_disable_cooling_test.go
@@ -31,7 +31,7 @@ func TestDisableCoolingKeepsEveryFailureDispatchable(t *testing.T) {
 		{name: "not found", status: http.StatusNotFound, body: "model not found"},
 		{name: "quota", status: http.StatusTooManyRequests, body: "quota exceeded"},
 		{name: "transient", status: http.StatusBadGateway, body: "bad gateway"},
-		{name: "unmapped", status: http.StatusConflict, body: "conflict"},
+		{name: "unmapped", status: http.StatusNotImplemented, body: "not implemented"},
 		{name: "invalid grant", status: http.StatusBadRequest, body: "invalid_grant"},
 		{name: "cloudflare challenge", status: http.StatusForbidden, body: "cf-mitigated"},
 	}

--- a/internal/cliproxy/auth/result_disable_cooling_test.go
+++ b/internal/cliproxy/auth/result_disable_cooling_test.go
@@ -1,0 +1,125 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// noCoolingModelAuth builds a credential carrying the per-credential disable_cooling
+// override, which is the only way Home can turn cooldowns off: the runtime forces the
+// global flag to false because Home is the sole scheduler.
+func noCoolingModelAuth(id, priority, model string) *Auth {
+	auth := modelStateAuth(id, priority, model, &ModelState{Status: StatusActive})
+	auth.Metadata = map[string]any{"disable_cooling": true}
+	return auth
+}
+
+// TestDisableCoolingKeepsEveryFailureDispatchable covers the operator choice of running
+// a credential without cooldowns: failures still record why they happened, but no branch
+// may park the credential, because scheduling is expected to stay under the control of
+// credential priority and session affinity alone.
+func TestDisableCoolingKeepsEveryFailureDispatchable(t *testing.T) {
+	failures := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, body: "expired access token"},
+		{name: "payment required", status: http.StatusPaymentRequired, body: "payment required"},
+		{name: "forbidden", status: http.StatusForbidden, body: "permission denied"},
+		{name: "not found", status: http.StatusNotFound, body: "model not found"},
+		{name: "quota", status: http.StatusTooManyRequests, body: "quota exceeded"},
+		{name: "transient", status: http.StatusBadGateway, body: "bad gateway"},
+		{name: "unmapped", status: http.StatusConflict, body: "conflict"},
+		{name: "invalid grant", status: http.StatusBadRequest, body: "invalid_grant"},
+		{name: "cloudflare challenge", status: http.StatusForbidden, body: "cf-mitigated"},
+	}
+
+	for _, tc := range failures {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			auth := failingAuth("auth-nocool-"+tc.name, true)
+
+			applyFailure(auth, "gpt-5", tc.status, tc.body, now)
+
+			state := auth.ModelStates["gpt-5"]
+			if state == nil {
+				t.Fatal("model state was not recorded")
+			}
+			if !state.NextRetryAfter.IsZero() || !state.Quota.NextRecoverAt.IsZero() {
+				t.Fatalf("disable_cooling produced deadlines: retry=%v recover=%v", state.NextRetryAfter, state.Quota.NextRecoverAt)
+			}
+			if state.Unavailable || state.Quota.Exceeded {
+				t.Fatalf("state = %#v, want no availability flags left behind", state)
+			}
+			if state.LastError == nil {
+				t.Fatal("failure detail was dropped")
+			}
+			if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", now); blocked {
+				t.Fatal("disable_cooling credential was parked")
+			}
+		})
+	}
+}
+
+// TestDisableCoolingKeepsPrioritySchedulingInCharge pins the scheduling contract behind
+// disable_cooling: repeated failures never remove a credential from the candidate set,
+// so the highest priority tier keeps winning.
+func TestDisableCoolingKeepsPrioritySchedulingInCharge(t *testing.T) {
+	now := time.Now().UTC()
+	model := "gemini-3-flash-agent"
+	high := noCoolingModelAuth("auth-nocool-high", "4", model)
+	low := noCoolingModelAuth("auth-nocool-low", "0", model)
+
+	for range 3 {
+		applyFailure(high, model, http.StatusTooManyRequests, "quota exceeded", now)
+	}
+
+	available, err := getAvailableAuths([]*Auth{low, high}, "antigravity", model, now)
+	if err != nil {
+		t.Fatalf("getAvailableAuths() error = %v", err)
+	}
+	if len(available) != 1 || available[0].ID != high.ID {
+		t.Fatalf("available = %v, want only the highest priority credential %s", available, high.ID)
+	}
+}
+
+// TestDisableCoolingKeepsSessionBindingStable keeps session affinity in charge for a
+// credential that never cools down: a bound session must not drift to another
+// credential just because the bound one keeps failing.
+func TestDisableCoolingKeepsSessionBindingStable(t *testing.T) {
+	now := time.Now().UTC()
+	model := sessionPriorityModel
+	high := noCoolingModelAuth("auth-nocool-session-high", "4", model)
+	low := noCoolingModelAuth("auth-nocool-session-low", "0", model)
+
+	selector := newSessionSelector()
+	defer selector.Stop()
+	opts := sessionOptions("sess-nocool")
+
+	// Park the high tier with a real cooldown so the cold binding lands on the low tier.
+	blockModel(high, now)
+	bound, err := selector.Pick(t.Context(), "antigravity", model, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if bound.ID != low.ID {
+		t.Fatalf("initial pick = %s, want %s", bound.ID, low.ID)
+	}
+
+	// The bound credential keeps failing, but disable_cooling means it stays available,
+	// so the established binding must survive both the failures and the high tier
+	// recovering.
+	unblockModel(high)
+	applyFailure(low, model, http.StatusTooManyRequests, "quota exceeded", now)
+	applyFailure(low, model, http.StatusBadGateway, "bad gateway", now)
+
+	reused, err := selector.Pick(t.Context(), "antigravity", model, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("second Pick() error = %v", err)
+	}
+	if reused.ID != low.ID {
+		t.Fatalf("second pick = %s, want the established binding %s", reused.ID, low.ID)
+	}
+}

--- a/internal/cliproxy/auth/result_request_fault_test.go
+++ b/internal/cliproxy/auth/result_request_fault_test.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestRequestFaultLeavesCredentialUntouched covers rejections caused by the request
+// itself. Every credential would answer the same way, so cooling one down only shrinks
+// the pool while the caller replays a request that cannot succeed until it is rebuilt.
+func TestRequestFaultLeavesCredentialUntouched(t *testing.T) {
+	faults := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "bad request", status: http.StatusBadRequest, body: "invalid argument"},
+		{name: "conflict", status: http.StatusConflict, body: "conflict"},
+		{name: "payload too large", status: http.StatusRequestEntityTooLarge, body: "too large"},
+		{name: "unprocessable", status: http.StatusUnprocessableEntity, body: "unprocessable"},
+		{name: "context length", status: http.StatusInternalServerError, body: `{"error":{"code":"context_length_exceeded"}}`},
+		{name: "invalid request type", status: http.StatusInternalServerError, body: `{"error":{"type":"invalid_request_error"}}`},
+		{name: "nested response body", status: http.StatusInternalServerError, body: `{"response":{"error":{"code":"invalid_prompt"}}}`},
+		{name: "cyber policy", status: http.StatusInternalServerError, body: `{"code":"cyber_policy"}`},
+	}
+
+	for _, fault := range faults {
+		t.Run(fault.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			auth := failingAuth("auth-request-fault", false)
+
+			applyFailure(auth, "gpt-5", fault.status, fault.body, now)
+
+			if state := auth.ModelStates["gpt-5"]; state != nil {
+				t.Fatalf("a request fault recorded model state: %#v", state)
+			}
+			if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", now); blocked {
+				t.Fatal("a request fault blocked the credential/model pair")
+			}
+			if auth.Unavailable || auth.Status == StatusError {
+				t.Fatalf("a request fault touched credential state: unavailable=%v status=%v", auth.Unavailable, auth.Status)
+			}
+		})
+	}
+}
+
+// TestProviderVerdictsOutrankRequestFaultCodes locks the classification order. Several
+// provider verdicts arrive on the same status codes a request fault uses, so treating
+// the status code as decisive would let a revoked grant or an unsupported model slip
+// through without ever cooling down.
+func TestProviderVerdictsOutrankRequestFaultCodes(t *testing.T) {
+	verdicts := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "invalid grant on 400", status: http.StatusBadRequest, body: "invalid_grant"},
+		{name: "model not supported on 400", status: http.StatusBadRequest, body: "model not supported"},
+		{name: "model not supported on 422", status: http.StatusUnprocessableEntity, body: "model not supported"},
+		{name: "cloudflare challenge on 400", status: http.StatusBadRequest, body: "cf-mitigated"},
+	}
+
+	for _, verdict := range verdicts {
+		t.Run(verdict.name, func(t *testing.T) {
+			now := time.Now().UTC()
+			auth := failingAuth("auth-verdict", false)
+
+			applyFailure(auth, "gpt-5", verdict.status, verdict.body, now)
+
+			state := auth.ModelStates["gpt-5"]
+			if state == nil {
+				t.Fatal("a provider verdict was mistaken for a request fault")
+			}
+			blocked, _, next := isAuthBlockedForModel(auth, "gpt-5", now)
+			if !blocked {
+				t.Fatal("a provider verdict left the model dispatchable")
+			}
+			if !next.After(now) {
+				t.Fatalf("deadline = %v, want a bounded window after %v", next, now)
+			}
+		})
+	}
+}
+
+// TestRequestFaultKeepsExistingCooldown makes sure a request fault cannot be used to
+// wipe a real cooldown recorded moments earlier by a genuine provider rejection.
+func TestRequestFaultKeepsExistingCooldown(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-request-fault-after-block", false)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "payment required", now)
+	blockedBefore, _, deadlineBefore := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blockedBefore {
+		t.Fatal("forbidden failure did not block the model")
+	}
+
+	applyFailure(auth, "gpt-5", http.StatusBadRequest, "invalid argument", now.Add(time.Second))
+
+	blockedAfter, _, deadlineAfter := isAuthBlockedForModel(auth, "gpt-5", now.Add(time.Second))
+	if !blockedAfter {
+		t.Fatal("a request fault cleared an active cooldown")
+	}
+	if !deadlineAfter.Equal(deadlineBefore) {
+		t.Fatalf("deadline moved from %v to %v", deadlineBefore, deadlineAfter)
+	}
+}

--- a/internal/cliproxy/auth/result_terminal_failure_test.go
+++ b/internal/cliproxy/auth/result_terminal_failure_test.go
@@ -161,6 +161,24 @@ func TestCloudflareChallengeEscalatesAfterWindowExpires(t *testing.T) {
 	}
 }
 
+// TestInvalidGrantKeepsRegistryModelSuspended keeps the published model list in step
+// with dispatch: a revoked grant blocks dispatch for 30 minutes, so a registry
+// reconcile must not resume the model in the meantime.
+func TestInvalidGrantKeepsRegistryModelSuspended(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-invalid-grant-registry", false)
+
+	applyFailureWithCode(auth, "gpt-5", http.StatusBadRequest, "invalid_grant", "token has been revoked", now)
+
+	blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blocked {
+		t.Fatal("invalid_grant left the model dispatchable")
+	}
+	if !shouldSuspendRegistryModel(auth, "gpt-5", reason) {
+		t.Fatal("registry would resume a model dispatch still refuses")
+	}
+}
+
 // TestCloudflareChallengeWithDisableCoolingStaysAvailable keeps disable_cooling from
 // leaving a quota flag nothing can expire.
 func TestCloudflareChallengeWithDisableCoolingStaysAvailable(t *testing.T) {

--- a/internal/cliproxy/auth/result_terminal_failure_test.go
+++ b/internal/cliproxy/auth/result_terminal_failure_test.go
@@ -117,25 +117,47 @@ func TestCloudflareChallengeUsesQuotaBackoffWithFloor(t *testing.T) {
 	}
 }
 
-// TestCloudflareChallengeEscalatesBackoffLevel keeps repeated challenges backing off.
-func TestCloudflareChallengeEscalatesBackoffLevel(t *testing.T) {
+// TestCloudflareChallengeReusesOpenWindow keeps one incident from being punished once
+// per reporting node. Home aggregates results from every CPA node, so the same
+// challenge arrives repeatedly and must not walk the backoff ladder each time.
+func TestCloudflareChallengeReusesOpenWindow(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-cloudflare-window", false)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now)
+	first := auth.ModelStates["gpt-5"].Quota
+	if first.BackoffLevel == 0 {
+		t.Fatalf("first BackoffLevel = %d, want the ladder to advance once", first.BackoffLevel)
+	}
+
+	// A second node reporting the same challenge inside the open window changes nothing.
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now.Add(time.Second))
+	second := auth.ModelStates["gpt-5"].Quota
+	if second.BackoffLevel != first.BackoffLevel {
+		t.Fatalf("BackoffLevel advanced inside the open window: %d -> %d", first.BackoffLevel, second.BackoffLevel)
+	}
+	if !second.NextRecoverAt.Equal(first.NextRecoverAt) {
+		t.Fatalf("NextRecoverAt moved inside the open window: %v -> %v", first.NextRecoverAt, second.NextRecoverAt)
+	}
+}
+
+// TestCloudflareChallengeEscalatesAfterWindowExpires keeps a persistent challenge
+// backing off once the previous window actually elapsed.
+func TestCloudflareChallengeEscalatesAfterWindowExpires(t *testing.T) {
 	now := time.Now().UTC()
 	auth := failingAuth("auth-cloudflare-escalate", false)
 
 	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now)
 	first := auth.ModelStates["gpt-5"].Quota
-	if first.BackoffLevel == 0 {
-		t.Fatalf("first BackoffLevel = %d, want the ladder to advance", first.BackoffLevel)
-	}
 
-	// The open window must be reused rather than restarted while it is still live.
-	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now.Add(time.Second))
+	afterWindow := first.NextRecoverAt.Add(time.Second)
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", afterWindow)
 	second := auth.ModelStates["gpt-5"].Quota
-	if second.BackoffLevel < first.BackoffLevel {
-		t.Fatalf("BackoffLevel regressed: %d -> %d", first.BackoffLevel, second.BackoffLevel)
+	if second.BackoffLevel <= first.BackoffLevel {
+		t.Fatalf("BackoffLevel = %d, want it to advance past %d once the window elapsed", second.BackoffLevel, first.BackoffLevel)
 	}
-	if second.NextRecoverAt.Before(first.NextRecoverAt) {
-		t.Fatalf("NextRecoverAt moved earlier: %v -> %v", first.NextRecoverAt, second.NextRecoverAt)
+	if !second.NextRecoverAt.After(afterWindow) {
+		t.Fatalf("NextRecoverAt = %v, want a fresh window after %v", second.NextRecoverAt, afterWindow)
 	}
 }
 

--- a/internal/cliproxy/auth/result_terminal_failure_test.go
+++ b/internal/cliproxy/auth/result_terminal_failure_test.go
@@ -87,9 +87,11 @@ func TestInvalidGrantWithDisableCoolingStaysAvailable(t *testing.T) {
 	}
 }
 
-// TestCloudflareChallengeUsesQuotaBackoffWithFloor keeps a challenge page from being
-// retried in a tight loop.
-func TestCloudflareChallengeUsesQuotaBackoffWithFloor(t *testing.T) {
+// TestCloudflareChallengeIsATemporaryRestrictionNotQuota keeps a challenge page from
+// being retried in a tight loop while making sure it is never reported as a provider
+// quota. Recording it as quota made dispatch answer with a quota cooldown error and
+// pointed every investigation at the wrong subsystem.
+func TestCloudflareChallengeIsATemporaryRestrictionNotQuota(t *testing.T) {
 	now := time.Now().UTC()
 	auth := failingAuth("auth-cloudflare", false)
 
@@ -99,21 +101,28 @@ func TestCloudflareChallengeUsesQuotaBackoffWithFloor(t *testing.T) {
 	if state == nil {
 		t.Fatal("model state was not recorded")
 	}
-	if !state.Quota.Exceeded || state.Quota.Reason != cloudflareChallengeReason {
-		t.Fatalf("quota = %#v, want a cloudflare challenge cooldown", state.Quota)
+	if state.Quota.Exceeded || !state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("quota = %#v, want a challenge to leave quota state untouched", state.Quota)
 	}
 	if state.StatusMessage != cloudflareChallengeReason {
 		t.Fatalf("StatusMessage = %q, want %q", state.StatusMessage, cloudflareChallengeReason)
+	}
+	if !state.Unavailable {
+		t.Fatal("a challenge left the model dispatchable")
 	}
 	minDeadline := now.Add(cloudflareChallengeMinCooldown)
 	if state.NextRetryAfter.Before(minDeadline) {
 		t.Fatalf("NextRetryAfter = %v, want at least %v", state.NextRetryAfter, minDeadline)
 	}
-	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
-		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	blocked, reason, next := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blocked || reason != blockReasonOther {
+		t.Fatalf("blocked/reason = %v/%v, want a non-quota block", blocked, reason)
 	}
-	if blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || reason != blockReasonCooldown {
-		t.Fatalf("blocked/reason = %v/%v, want blockReasonCooldown", blocked, reason)
+	if !next.After(now) {
+		t.Fatalf("deadline = %v, want a bounded window after %v", next, now)
+	}
+	if blockedAfter, _, _ := isAuthBlockedForModel(auth, "gpt-5", next.Add(time.Second)); blockedAfter {
+		t.Fatal("a challenge cooldown did not expire on its own")
 	}
 }
 
@@ -125,19 +134,19 @@ func TestCloudflareChallengeReusesOpenWindow(t *testing.T) {
 	auth := failingAuth("auth-cloudflare-window", false)
 
 	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now)
-	first := auth.ModelStates["gpt-5"].Quota
-	if first.BackoffLevel == 0 {
-		t.Fatalf("first BackoffLevel = %d, want the ladder to advance once", first.BackoffLevel)
+	first := *auth.ModelStates["gpt-5"]
+	if first.RetryBackoffLevel == 0 {
+		t.Fatalf("first RetryBackoffLevel = %d, want the ladder to advance once", first.RetryBackoffLevel)
 	}
 
 	// A second node reporting the same challenge inside the open window changes nothing.
 	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now.Add(time.Second))
-	second := auth.ModelStates["gpt-5"].Quota
-	if second.BackoffLevel != first.BackoffLevel {
-		t.Fatalf("BackoffLevel advanced inside the open window: %d -> %d", first.BackoffLevel, second.BackoffLevel)
+	second := *auth.ModelStates["gpt-5"]
+	if second.RetryBackoffLevel != first.RetryBackoffLevel {
+		t.Fatalf("RetryBackoffLevel advanced inside the open window: %d -> %d", first.RetryBackoffLevel, second.RetryBackoffLevel)
 	}
-	if !second.NextRecoverAt.Equal(first.NextRecoverAt) {
-		t.Fatalf("NextRecoverAt moved inside the open window: %v -> %v", first.NextRecoverAt, second.NextRecoverAt)
+	if !second.NextRetryAfter.Equal(first.NextRetryAfter) {
+		t.Fatalf("NextRetryAfter moved inside the open window: %v -> %v", first.NextRetryAfter, second.NextRetryAfter)
 	}
 }
 
@@ -148,16 +157,19 @@ func TestCloudflareChallengeEscalatesAfterWindowExpires(t *testing.T) {
 	auth := failingAuth("auth-cloudflare-escalate", false)
 
 	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now)
-	first := auth.ModelStates["gpt-5"].Quota
+	first := *auth.ModelStates["gpt-5"]
 
-	afterWindow := first.NextRecoverAt.Add(time.Second)
+	afterWindow := first.NextRetryAfter.Add(time.Second)
 	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", afterWindow)
-	second := auth.ModelStates["gpt-5"].Quota
-	if second.BackoffLevel <= first.BackoffLevel {
-		t.Fatalf("BackoffLevel = %d, want it to advance past %d once the window elapsed", second.BackoffLevel, first.BackoffLevel)
+	second := *auth.ModelStates["gpt-5"]
+	if second.RetryBackoffLevel <= first.RetryBackoffLevel {
+		t.Fatalf("RetryBackoffLevel = %d, want it to advance past %d once the window elapsed", second.RetryBackoffLevel, first.RetryBackoffLevel)
 	}
-	if !second.NextRecoverAt.After(afterWindow) {
-		t.Fatalf("NextRecoverAt = %v, want a fresh window after %v", second.NextRecoverAt, afterWindow)
+	if !second.NextRetryAfter.After(afterWindow) {
+		t.Fatalf("NextRetryAfter = %v, want a fresh window after %v", second.NextRetryAfter, afterWindow)
+	}
+	if second.NextRetryAfter.Sub(afterWindow) > quotaBackoffMax {
+		t.Fatalf("window = %v, want it capped at %v", second.NextRetryAfter.Sub(afterWindow), quotaBackoffMax)
 	}
 }
 

--- a/internal/cliproxy/auth/result_terminal_failure_test.go
+++ b/internal/cliproxy/auth/result_terminal_failure_test.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// applyFailureWithCode records a failed execution result carrying an error code.
+func applyFailureWithCode(auth *Auth, model string, status int, code, message string, now time.Time) {
+	NewManager(nil, nil, nil).applyResultTransition(auth, Result{
+		AuthID:  auth.ID,
+		Model:   model,
+		Success: false,
+		Error:   &Error{Code: code, Message: message, HTTPStatus: status},
+	}, model, now)
+}
+
+// TestInvalidGrantSuspendsModelForThirtyMinutes keeps a revoked grant off the
+// dispatch path instead of retrying it every minute on the transient path.
+func TestInvalidGrantSuspendsModelForThirtyMinutes(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-invalid-grant", false)
+
+	applyFailureWithCode(auth, "gpt-5", http.StatusBadRequest, "invalid_grant", "token has been revoked", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want %v", state.NextRetryAfter, now.Add(30*time.Minute))
+	}
+	if !state.Unavailable {
+		t.Fatal("invalid_grant left the model available")
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || reason != blockReasonOther {
+		t.Fatalf("blocked/reason = %v/%v, want a non-quota block", blocked, reason)
+	}
+}
+
+// TestInvalidGrantMatchesMessageWithoutCode covers providers that only surface the
+// reason in the message body.
+func TestInvalidGrantMatchesMessageWithoutCode(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-invalid-grant-msg", false)
+
+	applyFailure(auth, "gpt-5", http.StatusUnauthorized, `{"error":"invalid_grant"}`, now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil || !state.NextRetryAfter.Equal(now.Add(30*time.Minute)) {
+		t.Fatalf("state = %#v, want a 30m invalid_grant cooldown", state)
+	}
+}
+
+// TestInvalidGrantIgnoredForUnrelatedStatus keeps the long cooldown scoped to the
+// statuses that actually carry a grant failure.
+func TestInvalidGrantIgnoredForUnrelatedStatus(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-invalid-grant-5xx", false)
+
+	applyFailureWithCode(auth, "gpt-5", http.StatusInternalServerError, "invalid_grant", "upstream blew up", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.Equal(now.Add(transientErrorCooldown)) {
+		t.Fatalf("NextRetryAfter = %v, want the transient cooldown %v", state.NextRetryAfter, now.Add(transientErrorCooldown))
+	}
+}
+
+// TestInvalidGrantWithDisableCoolingStaysAvailable keeps disable_cooling retryable
+// rather than leaving an unbounded unavailable flag.
+func TestInvalidGrantWithDisableCoolingStaysAvailable(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-invalid-grant-nocool", true)
+
+	applyFailureWithCode(auth, "gpt-5", http.StatusBadRequest, "invalid_grant", "token has been revoked", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.IsZero() || state.Unavailable {
+		t.Fatalf("state = %#v, want no cooldown and available", state)
+	}
+}
+
+// TestCloudflareChallengeUsesQuotaBackoffWithFloor keeps a challenge page from being
+// retried in a tight loop.
+func TestCloudflareChallengeUsesQuotaBackoffWithFloor(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-cloudflare", false)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "<html>cf-mitigated challenge</html>", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.Quota.Exceeded || state.Quota.Reason != cloudflareChallengeReason {
+		t.Fatalf("quota = %#v, want a cloudflare challenge cooldown", state.Quota)
+	}
+	if state.StatusMessage != cloudflareChallengeReason {
+		t.Fatalf("StatusMessage = %q, want %q", state.StatusMessage, cloudflareChallengeReason)
+	}
+	minDeadline := now.Add(cloudflareChallengeMinCooldown)
+	if state.NextRetryAfter.Before(minDeadline) {
+		t.Fatalf("NextRetryAfter = %v, want at least %v", state.NextRetryAfter, minDeadline)
+	}
+	if !state.Quota.NextRecoverAt.Equal(state.NextRetryAfter) {
+		t.Fatalf("NextRecoverAt = %v, want %v", state.Quota.NextRecoverAt, state.NextRetryAfter)
+	}
+	if blocked, reason, _ := isAuthBlockedForModel(auth, "gpt-5", now); !blocked || reason != blockReasonCooldown {
+		t.Fatalf("blocked/reason = %v/%v, want blockReasonCooldown", blocked, reason)
+	}
+}
+
+// TestCloudflareChallengeEscalatesBackoffLevel keeps repeated challenges backing off.
+func TestCloudflareChallengeEscalatesBackoffLevel(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-cloudflare-escalate", false)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now)
+	first := auth.ModelStates["gpt-5"].Quota
+	if first.BackoffLevel == 0 {
+		t.Fatalf("first BackoffLevel = %d, want the ladder to advance", first.BackoffLevel)
+	}
+
+	// The open window must be reused rather than restarted while it is still live.
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cloudflare challenge", now.Add(time.Second))
+	second := auth.ModelStates["gpt-5"].Quota
+	if second.BackoffLevel < first.BackoffLevel {
+		t.Fatalf("BackoffLevel regressed: %d -> %d", first.BackoffLevel, second.BackoffLevel)
+	}
+	if second.NextRecoverAt.Before(first.NextRecoverAt) {
+		t.Fatalf("NextRecoverAt moved earlier: %v -> %v", first.NextRecoverAt, second.NextRecoverAt)
+	}
+}
+
+// TestCloudflareChallengeWithDisableCoolingStaysAvailable keeps disable_cooling from
+// leaving a quota flag nothing can expire.
+func TestCloudflareChallengeWithDisableCoolingStaysAvailable(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-cloudflare-nocool", true)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "cf-mitigated", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if !state.NextRetryAfter.IsZero() || state.Unavailable || state.Quota.Exceeded {
+		t.Fatalf("state = %#v, want no cooldown and available", state)
+	}
+}
+
+// TestCloudflareChallengeIgnoresUnrelatedMessage keeps ordinary 403 responses on the
+// payment_required path.
+func TestCloudflareChallengeIgnoresUnrelatedMessage(t *testing.T) {
+	now := time.Now().UTC()
+	auth := failingAuth("auth-plain-403", false)
+
+	applyFailure(auth, "gpt-5", http.StatusForbidden, "permission denied", now)
+
+	state := auth.ModelStates["gpt-5"]
+	if state == nil {
+		t.Fatal("model state was not recorded")
+	}
+	if state.Quota.Exceeded {
+		t.Fatalf("quota = %#v, want no quota cooldown for a plain 403", state.Quota)
+	}
+	if !state.NextRetryAfter.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("NextRetryAfter = %v, want the 30m payment_required cooldown", state.NextRetryAfter)
+	}
+}

--- a/internal/cliproxy/auth/scheduler.go
+++ b/internal/cliproxy/auth/scheduler.go
@@ -217,8 +217,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
 	modelKey := canonicalModelKey(model)
 	_ = ctx
-	_ = opts
-	preferWebsocket := false
+	preferWebsocket := downstreamWebsocketFromOptions(opts) && providerPrefersWebsocketTransport(providerKey)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -238,6 +237,18 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 		return picked, nil
 	}
 	return nil, shard.unavailableErrorLocked(provider, model, predicate)
+}
+
+// providerPrefersWebsocketTransport reports whether a provider can carry a request over
+// a websocket upstream, which is what makes a websocket-enabled credential worth
+// preferring across priority tiers.
+func providerPrefersWebsocketTransport(providerKey string) bool {
+	switch strings.ToLower(strings.TrimSpace(providerKey)) {
+	case "codex", "xai":
+		return true
+	default:
+		return false
+	}
 }
 
 // pickMixed returns the next auth and provider for a mixed-provider request.

--- a/internal/cliproxy/auth/scheduler_websocket_test.go
+++ b/internal/cliproxy/auth/scheduler_websocket_test.go
@@ -1,0 +1,99 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPIHome/internal/registry"
+)
+
+const websocketModel = "gpt-5-codex"
+
+// websocketAuth builds a codex credential at the given priority with an explicit
+// websocket capability flag.
+func websocketAuth(id, priority string, websockets bool) *Auth {
+	auth := &Auth{
+		ID:       id,
+		Provider: "codex",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"priority":   priority,
+			"websockets": "false",
+		},
+		ModelStates: map[string]*ModelState{websocketModel: {Status: StatusActive}},
+	}
+	if websockets {
+		auth.Attributes["websockets"] = "true"
+	}
+	return auth
+}
+
+// newWebsocketScheduler registers the credentials with the shared model registry, which
+// is what makes a model shard eligible, and then loads them into a scheduler.
+func newWebsocketScheduler(t *testing.T, auths ...*Auth) *authScheduler {
+	t.Helper()
+	modelRegistry := registry.GetGlobalRegistry()
+	scheduler := newAuthScheduler(&FillFirstSelector{}, nil)
+	for _, auth := range auths {
+		modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: websocketModel, Object: "model", Type: "openai"}})
+		authID := auth.ID
+		t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+		scheduler.upsertAuth(auth)
+	}
+	return scheduler
+}
+
+// TestDownstreamWebsocketPrefersWebsocketCredentialAcrossPriorities covers the
+// preference CPA relies on for Codex: a websocket-capable credential is worth more
+// than a higher priority HTTP-only one, because keeping the transport intact matters
+// more than the tier. The signal reaches Home only through dispatch metadata, so
+// without it this preference silently does nothing.
+func TestDownstreamWebsocketPrefersWebsocketCredentialAcrossPriorities(t *testing.T) {
+	httpOnly := websocketAuth("auth-http-high", "9", false)
+	websocketCapable := websocketAuth("auth-ws-low", "1", true)
+	scheduler := newWebsocketScheduler(t, httpOnly, websocketCapable)
+
+	opts := Options{Metadata: map[string]any{DownstreamWebsocketMetadataKey: true}}
+	picked, err := scheduler.pickSingle(context.Background(), "codex", websocketModel, opts, nil)
+	if err != nil {
+		t.Fatalf("pick failed: %v", err)
+	}
+	if picked.ID != websocketCapable.ID {
+		t.Fatalf("picked %s, want the websocket credential %s", picked.ID, websocketCapable.ID)
+	}
+}
+
+// TestWithoutDownstreamWebsocketPriorityWins keeps the preference scoped to websocket
+// requests: an ordinary request must still follow credential priority.
+func TestWithoutDownstreamWebsocketPriorityWins(t *testing.T) {
+	httpOnly := websocketAuth("auth-http-high", "9", false)
+	websocketCapable := websocketAuth("auth-ws-low", "1", true)
+	scheduler := newWebsocketScheduler(t, httpOnly, websocketCapable)
+
+	picked, err := scheduler.pickSingle(context.Background(), "codex", websocketModel, Options{}, nil)
+	if err != nil {
+		t.Fatalf("pick failed: %v", err)
+	}
+	if picked.ID != httpOnly.ID {
+		t.Fatalf("picked %s, want the highest priority credential %s", picked.ID, httpOnly.ID)
+	}
+}
+
+// TestDownstreamWebsocketIgnoredForOtherProviders keeps the preference limited to
+// providers that can actually carry a websocket upstream.
+func TestDownstreamWebsocketIgnoredForOtherProviders(t *testing.T) {
+	httpOnly := websocketAuth("auth-http-high", "9", false)
+	websocketCapable := websocketAuth("auth-ws-low", "1", true)
+	httpOnly.Provider = "gemini"
+	websocketCapable.Provider = "gemini"
+	scheduler := newWebsocketScheduler(t, httpOnly, websocketCapable)
+
+	opts := Options{Metadata: map[string]any{DownstreamWebsocketMetadataKey: true}}
+	picked, err := scheduler.pickSingle(context.Background(), "gemini", websocketModel, opts, nil)
+	if err != nil {
+		t.Fatalf("pick failed: %v", err)
+	}
+	if picked.ID != httpOnly.ID {
+		t.Fatalf("picked %s, want the highest priority credential %s", picked.ID, httpOnly.ID)
+	}
+}

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -325,30 +325,46 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
 				}
-				if state.Unavailable {
-					if state.NextRetryAfter.IsZero() {
-						return false, blockReasonNone, time.Time{}
-					}
-					if state.NextRetryAfter.After(now) {
-						next := state.NextRetryAfter
-						if !state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.After(now) {
-							next = state.Quota.NextRecoverAt
-						}
-						if next.Before(now) {
-							next = now
-						}
-						if state.Quota.Exceeded {
-							return true, blockReasonCooldown, next
-						}
-						return true, blockReasonOther, next
-					}
-				}
-				return false, blockReasonNone, time.Time{}
+				return availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
 			}
 		}
+		// Credential-wide aggregates are advisory only: legacy Home versions recorded
+		// quota state with a "credential" scope, and honouring it here would block every
+		// model instead of the one that actually failed.
 		return false, blockReasonNone, time.Time{}
 	}
 	return false, blockReasonNone, time.Time{}
+}
+
+// availabilityBlock reports whether an availability snapshot blocks dispatch.
+//
+// A snapshot marked unavailable or quota-exceeded without any recovery deadline is
+// treated as blocked. Such a state is unbounded, so failing closed is the only way to
+// stop the scheduler from handing the same broken credential out forever. Deadlines
+// that already elapsed restore availability so a recovered credential returns on its own.
+func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextRecoverAt, now time.Time) (bool, blockReason, time.Time) {
+	if !unavailable && !quotaExceeded {
+		return false, blockReasonNone, time.Time{}
+	}
+	next := time.Time{}
+	for _, candidate := range []time.Time{nextRetryAfter, nextRecoverAt} {
+		if candidate.IsZero() || !candidate.After(now) {
+			continue
+		}
+		if next.IsZero() || candidate.After(next) {
+			next = candidate
+		}
+	}
+	if !next.IsZero() {
+		if quotaExceeded {
+			return true, blockReasonCooldown, next
+		}
+		return true, blockReasonOther, next
+	}
+	if !nextRetryAfter.IsZero() || !nextRecoverAt.IsZero() {
+		return false, blockReasonNone, time.Time{}
+	}
+	return true, blockReasonOther, time.Time{}
 }
 
 // sessionPattern matches Claude Code user_id format:

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -205,8 +205,19 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 	return available, cooldownCount, earliest
 }
 
-// getAvailableAuths returns an available auths.
+// getAvailableAuths returns the highest available priority tier.
 func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
+	return getAvailableAuthsWithPriorityMode(auths, provider, model, now, false)
+}
+
+// getAvailableAuthsAcrossPriorities returns every available candidate regardless of
+// priority. Use it for membership checks such as validating an established session
+// binding, never as a priority-ordered selection order.
+func getAvailableAuthsAcrossPriorities(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
+	return getAvailableAuthsWithPriorityMode(auths, provider, model, now, true)
+}
+
+func getAvailableAuthsWithPriorityMode(auths []*Auth, provider, model string, now time.Time, allPriorities bool) ([]*Auth, error) {
 	// Build the candidate view before applying availability rules.
 	if len(auths) == 0 {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
@@ -228,20 +239,72 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 		return nil, &Error{Code: "auth_unavailable", Message: "no auth available"}
 	}
 
+	return availableAuthsFromPriorityBuckets(availableByPriority, allPriorities), nil
+}
+
+// availableAuthsFromPriorityBuckets flattens availability buckets into a stable,
+// ID-sorted slice. With allPriorities false only the highest available tier is
+// returned; with allPriorities true every tier is merged and the result therefore
+// carries no priority ordering.
+func availableAuthsFromPriorityBuckets(availableByPriority map[int][]*Auth, allPriorities bool) []*Auth {
+	var candidates []*Auth
+	if allPriorities {
+		total := 0
+		for _, bucket := range availableByPriority {
+			total += len(bucket)
+		}
+		candidates = make([]*Auth, 0, total)
+		for _, bucket := range availableByPriority {
+			candidates = append(candidates, bucket...)
+		}
+	} else {
+		bestPriority := 0
+		found := false
+		for priority := range availableByPriority {
+			if !found || priority > bestPriority {
+				bestPriority = priority
+				found = true
+			}
+		}
+		bucket := availableByPriority[bestPriority]
+		candidates = make([]*Auth, 0, len(bucket))
+		candidates = append(candidates, bucket...)
+	}
+	if len(candidates) > 1 {
+		sort.Slice(candidates, func(i, j int) bool { return candidates[i].ID < candidates[j].ID })
+	}
+	return candidates
+}
+
+// highestPriorityAuths narrows an availability slice to its highest priority tier
+// while preserving the input order. The input slice is returned unchanged when every
+// candidate already shares the highest priority.
+func highestPriorityAuths(auths []*Auth) []*Auth {
+	if len(auths) <= 1 {
+		return auths
+	}
 	bestPriority := 0
-	found := false
-	for priority := range availableByPriority {
-		if !found || priority > bestPriority {
+	bestCount := 0
+	for _, auth := range auths {
+		priority := authPriority(auth)
+		switch {
+		case bestCount == 0 || priority > bestPriority:
 			bestPriority = priority
-			found = true
+			bestCount = 1
+		case priority == bestPriority:
+			bestCount++
 		}
 	}
-
-	available := availableByPriority[bestPriority]
-	if len(available) > 1 {
-		sort.Slice(available, func(i, j int) bool { return available[i].ID < available[j].ID })
+	if bestCount == len(auths) {
+		return auths
 	}
-	return available, nil
+	highest := make([]*Auth, 0, bestCount)
+	for _, auth := range auths {
+		if authPriority(auth) == bestPriority {
+			highest = append(highest, auth)
+		}
+	}
+	return highest
 }
 
 func filterConcurrencyExcludedAuths(auths []*Auth, model string, opts Options) []*Auth {
@@ -409,6 +472,12 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 //  6. conversation_id field in request body
 //  7. Stable hash from first few messages content (fallback)
 //
+// An established binding outranks credential priority: a bound credential that is
+// still available is reused even when a higher-priority credential recovers.
+// Credential priority applies to cold bindings, requests without a session, and
+// genuine bound-credential failover, so the fallback selector only ever receives the
+// highest available priority tier.
+//
 // Note: The cache key includes provider, session ID, and model to handle cases where
 // a session uses multiple models (e.g., gemini-2.5-pro and gemini-3-flash-preview)
 // that may be supported by different auth credentials, and to avoid cross-provider conflicts.
@@ -422,10 +491,14 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 
 	now := time.Now()
 	auths = filterConcurrencyExcludedAuths(auths, model, opts)
-	available, err := getAvailableAuths(auths, provider, model, now)
+	// A single availability pass serves both lookups: the bound credential is validated
+	// against every priority tier, while the fallback selector keeps seeing only the
+	// highest tier.
+	available, err := getAvailableAuthsAcrossPriorities(auths, provider, model, now)
 	if err != nil {
 		return nil, err
 	}
+	fallbackAuths := highestPriorityAuths(available)
 
 	cacheKey := provider + "::" + primaryID + "::" + model
 
@@ -437,7 +510,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 			}
 		}
 		// Cached auth not available, reselect via fallback selector for even distribution
-		auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
+		auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 		if err != nil {
 			return nil, err
 		}
@@ -459,7 +532,7 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		}
 	}
 
-	auth, err := s.fallback.Pick(ctx, provider, model, opts, auths)
+	auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -211,8 +211,9 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 }
 
 // getAvailableAuthsAcrossPriorities returns every available candidate regardless of
-// priority. Use it for membership checks such as validating an established session
-// binding, never as a priority-ordered selection order.
+// priority, sorted by ID. Use it for membership checks such as validating an established
+// session binding, or feed it to highestPriorityAuths; the order carries no priority
+// meaning and must never be treated as a selection order.
 func getAvailableAuthsAcrossPriorities(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
 	return getAvailableAuthsWithPriorityMode(auths, provider, model, now, true)
 }
@@ -244,8 +245,8 @@ func getAvailableAuthsWithPriorityMode(auths []*Auth, provider, model string, no
 
 // availableAuthsFromPriorityBuckets flattens availability buckets into a stable,
 // ID-sorted slice. With allPriorities false only the highest available tier is
-// returned; with allPriorities true every tier is merged and the result therefore
-// carries no priority ordering.
+// returned; with allPriorities true every tier is merged, so the ID order of the
+// result says nothing about credential priority.
 func availableAuthsFromPriorityBuckets(availableByPriority map[int][]*Auth, allPriorities bool) []*Auth {
 	var candidates []*Auth
 	if allPriorities {
@@ -486,13 +487,19 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model string, opts Options, auths []*Auth) (*Auth, error) {
 	entry := selectorLogEntry(ctx)
 	primaryID, fallbackID := extractSessionIDs(opts.Headers, opts.OriginalRequest, opts.Metadata)
-	if primaryID == "" {
-		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
-		return s.fallback.Pick(ctx, provider, model, opts, auths)
-	}
-
 	now := time.Now()
 	auths = filterConcurrencyExcludedAuths(auths, model, opts)
+	if primaryID == "" {
+		// Keep both paths on one availability evaluation so a sessionless request cannot
+		// see a different candidate set than a session-bound one.
+		sessionlessAuths, errAvailable := getAvailableAuths(auths, provider, model, now)
+		if errAvailable != nil {
+			return nil, errAvailable
+		}
+		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
+		return s.fallback.Pick(ctx, provider, model, opts, sessionlessAuths)
+	}
+
 	// A single availability pass serves both lookups: the bound credential is validated
 	// against every priority tier, while the fallback selector keeps seeing only the
 	// highest tier.

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -500,54 +500,59 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 		return s.fallback.Pick(ctx, provider, model, opts, sessionlessAuths)
 	}
 
-	// A single availability pass serves both lookups: the bound credential is validated
-	// against every priority tier, while the fallback selector keeps seeing only the
-	// highest tier.
+	cacheKey := provider + "::" + primaryID + "::" + model
+
+	// Reusing an established binding is the common case and only needs an answer about
+	// one credential, so it is settled before any pool-wide work. Evaluating every
+	// candidate first would make the cheapest outcome the most expensive one.
+	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
+		if bound := availableAuthByID(auths, cachedAuthID, model, now); bound != nil {
+			entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), bound.ID, provider, model)
+			return bound, nil
+		}
+	} else if fallbackID != "" && fallbackID != primaryID {
+		fallbackKey := provider + "::" + fallbackID + "::" + model
+		if cachedAuthID, okFallback := s.cache.Get(fallbackKey); okFallback {
+			if bound := availableAuthByID(auths, cachedAuthID, model, now); bound != nil {
+				s.cache.Set(cacheKey, bound.ID)
+				entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), bound.ID, provider, model)
+				return bound, nil
+			}
+		}
+	}
+
+	// No usable binding: evaluate the pool and let the fallback selector choose from the
+	// highest available tier, which is what governs a cold start.
 	available, err := getAvailableAuthsAcrossPriorities(auths, provider, model, now)
 	if err != nil {
 		return nil, err
 	}
-	fallbackAuths := highestPriorityAuths(available)
-
-	cacheKey := provider + "::" + primaryID + "::" + model
-
-	if cachedAuthID, ok := s.cache.GetAndRefresh(cacheKey); ok {
-		for _, auth := range available {
-			if auth.ID == cachedAuthID {
-				entry.Infof("session-affinity: cache hit | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-				return auth, nil
-			}
-		}
-		// Cached auth not available, reselect via fallback selector for even distribution
-		auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
-		if err != nil {
-			return nil, err
-		}
-		s.cache.Set(cacheKey, auth.ID)
-		entry.Infof("session-affinity: cache hit but auth unavailable, reselected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
-		return auth, nil
-	}
-
-	if fallbackID != "" && fallbackID != primaryID {
-		fallbackKey := provider + "::" + fallbackID + "::" + model
-		if cachedAuthID, ok := s.cache.Get(fallbackKey); ok {
-			for _, auth := range available {
-				if auth.ID == cachedAuthID {
-					s.cache.Set(cacheKey, auth.ID)
-					entry.Infof("session-affinity: fallback cache hit | session=%s fallback=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), truncateSessionID(fallbackID), auth.ID, provider, model)
-					return auth, nil
-				}
-			}
-		}
-	}
-
-	auth, err := s.fallback.Pick(ctx, provider, model, opts, fallbackAuths)
+	auth, err := s.fallback.Pick(ctx, provider, model, opts, highestPriorityAuths(available))
 	if err != nil {
 		return nil, err
 	}
 	s.cache.Set(cacheKey, auth.ID)
-	entry.Infof("session-affinity: cache miss, new binding | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
+	entry.Infof("session-affinity: no usable binding, selected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+// availableAuthByID resolves one credential by ID and reports it only when it is still
+// dispatchable for the model. A bound session needs exactly this answer, and asking it
+// directly avoids evaluating every other candidate to reach a foregone conclusion.
+func availableAuthByID(auths []*Auth, authID, model string, now time.Time) *Auth {
+	if authID == "" {
+		return nil
+	}
+	for _, candidate := range auths {
+		if candidate == nil || candidate.ID != authID {
+			continue
+		}
+		if blocked, _, _ := isAuthBlockedForModel(candidate, model, now); blocked {
+			return nil
+		}
+		return candidate
+	}
+	return nil
 }
 
 // selectorLogEntry handles a selector log entry.

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -401,10 +401,15 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 
 // availabilityBlock reports whether an availability snapshot blocks dispatch.
 //
-// A snapshot marked unavailable or quota-exceeded without any recovery deadline is
-// treated as blocked. Such a state is unbounded, so failing closed is the only way to
-// stop the scheduler from handing the same broken credential out forever. Deadlines
-// that already elapsed restore availability so a recovered credential returns on its own.
+// Availability defaults to healthy: a snapshot flagged unavailable or quota exceeded
+// blocks only while a recovery deadline is still in the future. A snapshot carrying no
+// deadline at all counts as recovered rather than parked, so a legacy row, a cluster
+// merge artifact, or a credential configured with disable_cooling can never strand
+// itself in a state nothing is able to expire. Every failure transition writes a
+// bounded deadline, so a real cooldown always carries one.
+//
+// The reported deadline is the later of the retry and quota windows so Retry-After
+// cannot invite a premature retry.
 func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextRecoverAt, now time.Time) (bool, blockReason, time.Time) {
 	if !unavailable && !quotaExceeded {
 		return false, blockReasonNone, time.Time{}
@@ -418,16 +423,13 @@ func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextReco
 			next = candidate
 		}
 	}
-	if !next.IsZero() {
-		if quotaExceeded {
-			return true, blockReasonCooldown, next
-		}
-		return true, blockReasonOther, next
-	}
-	if !nextRetryAfter.IsZero() || !nextRecoverAt.IsZero() {
+	if next.IsZero() {
 		return false, blockReasonNone, time.Time{}
 	}
-	return true, blockReasonOther, time.Time{}
+	if quotaExceeded {
+		return true, blockReasonCooldown, next
+	}
+	return true, blockReasonOther, next
 }
 
 // sessionPattern matches Claude Code user_id format:

--- a/internal/cliproxy/auth/selector.go
+++ b/internal/cliproxy/auth/selector.go
@@ -492,12 +492,12 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if primaryID == "" {
 		// Keep both paths on one availability evaluation so a sessionless request cannot
 		// see a different candidate set than a session-bound one.
-		sessionlessAuths, errAvailable := getAvailableAuths(auths, provider, model, now)
+		sessionlessAuths, errAvailable := getAvailableAuthsAcrossPriorities(auths, provider, model, now)
 		if errAvailable != nil {
 			return nil, errAvailable
 		}
 		entry.Debugf("session-affinity: no session ID extracted, falling back to default selector | provider=%s model=%s", provider, model)
-		return s.fallback.Pick(ctx, provider, model, opts, sessionlessAuths)
+		return s.fallback.Pick(ctx, provider, model, opts, coldStartCandidates(sessionlessAuths, provider, opts))
 	}
 
 	cacheKey := provider + "::" + primaryID + "::" + model
@@ -527,13 +527,39 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	if err != nil {
 		return nil, err
 	}
-	auth, err := s.fallback.Pick(ctx, provider, model, opts, highestPriorityAuths(available))
+	auth, err := s.fallback.Pick(ctx, provider, model, opts, coldStartCandidates(available, provider, opts))
 	if err != nil {
 		return nil, err
 	}
 	s.cache.Set(cacheKey, auth.ID)
 	entry.Infof("session-affinity: no usable binding, selected | session=%s auth=%s provider=%s model=%s", truncateSessionID(primaryID), auth.ID, provider, model)
 	return auth, nil
+}
+
+// coldStartCandidates narrows an availability view down to what a new binding may pick.
+//
+// Credential priority governs a cold start, except for a downstream websocket: keeping
+// the transport intact outranks the tier, so a websocket-capable credential wins across
+// priorities. This mirrors the scheduler's own preference, which never runs while
+// session affinity is enabled because that path is served by the fallback selector.
+func coldStartCandidates(available []*Auth, provider string, opts Options) []*Auth {
+	if downstreamWebsocketFromOptions(opts) && providerPrefersWebsocketTransport(provider) {
+		if websocketAuths := websocketCapableAuths(available); len(websocketAuths) > 0 {
+			return highestPriorityAuths(websocketAuths)
+		}
+	}
+	return highestPriorityAuths(available)
+}
+
+// websocketCapableAuths keeps only credentials whose upstream can carry a websocket.
+func websocketCapableAuths(auths []*Auth) []*Auth {
+	capable := make([]*Auth, 0, len(auths))
+	for _, candidate := range auths {
+		if authWebsocketsEnabled(candidate) {
+			capable = append(capable, candidate)
+		}
+	}
+	return capable
 }
 
 // availableAuthByID resolves one credential by ID and reports it only when it is still

--- a/internal/cliproxy/auth/selector_availability_test.go
+++ b/internal/cliproxy/auth/selector_availability_test.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+// modelStateAuth builds a credential carrying a single model state.
+func modelStateAuth(id string, priority string, model string, state *ModelState) *Auth {
+	auth := &Auth{
+		ID:          id,
+		Provider:    "antigravity",
+		Status:      StatusActive,
+		ModelStates: map[string]*ModelState{model: state},
+	}
+	if priority != "" {
+		auth.Attributes = map[string]string{"priority": priority}
+	}
+	return auth
+}
+
+// TestZeroDeadlineUnavailableModelBlocksDispatch locks the regression behind the
+// production 503: a model marked unavailable without any recovery deadline is an
+// unbounded bad state and must fail closed instead of being dispatched.
+func TestZeroDeadlineUnavailableModelBlocksDispatch(t *testing.T) {
+	now := time.Now().UTC()
+	auth := modelStateAuth("auth-zero-deadline", "", "gemini-3-flash-agent", &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		Quota:       QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+	})
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "gemini-3-flash-agent", now)
+	if !blocked {
+		t.Fatal("unavailable model without a recovery deadline was reported dispatchable")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want blockReasonOther for an unbounded bad state", reason)
+	}
+	if !next.IsZero() {
+		t.Fatalf("next = %v, want zero: there is no deadline to report", next)
+	}
+}
+
+// TestQuotaExceededWithoutUnavailableBlocksDispatch covers state written by cluster
+// merges or the Management API where only the quota flag is set.
+func TestQuotaExceededWithoutUnavailableBlocksDispatch(t *testing.T) {
+	now := time.Now().UTC()
+	auth := modelStateAuth("auth-quota-only", "", "gpt-5", &ModelState{
+		Status: StatusError,
+		Quota:  QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+	})
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blocked {
+		t.Fatal("quota-exceeded model was reported dispatchable")
+	}
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want blockReasonOther without a recovery deadline", reason)
+	}
+	if !next.IsZero() {
+		t.Fatalf("next = %v, want zero", next)
+	}
+}
+
+// TestOpenQuotaWindowBlocksAfterRetryDeadlinePasses covers a transient failure
+// overwriting NextRetryAfter while the longer quota window is still open.
+func TestOpenQuotaWindowBlocksAfterRetryDeadlinePasses(t *testing.T) {
+	now := time.Now().UTC()
+	recoverAt := now.Add(25 * time.Minute)
+	auth := modelStateAuth("auth-open-quota", "", "gpt-5", &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(-time.Minute),
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: recoverAt},
+	})
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blocked {
+		t.Fatal("expired retry deadline released a credential whose quota window is still open")
+	}
+	if reason != blockReasonCooldown {
+		t.Fatalf("reason = %v, want blockReasonCooldown", reason)
+	}
+	if !next.Equal(recoverAt) {
+		t.Fatalf("next = %v, want quota recovery time %v", next, recoverAt)
+	}
+}
+
+// TestBlockedNextUsesLatestRecoveryDeadline ensures the reported deadline never
+// under-reports, so Retry-After cannot invite a premature client retry.
+func TestBlockedNextUsesLatestRecoveryDeadline(t *testing.T) {
+	now := time.Now().UTC()
+	retryAt := now.Add(20 * time.Minute)
+	recoverAt := now.Add(5 * time.Minute)
+	auth := modelStateAuth("auth-latest-deadline", "", "gpt-5", &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: retryAt,
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: recoverAt},
+	})
+
+	blocked, _, next := isAuthBlockedForModel(auth, "gpt-5", now)
+	if !blocked {
+		t.Fatal("credential with future deadlines was reported dispatchable")
+	}
+	if !next.Equal(retryAt) {
+		t.Fatalf("next = %v, want the later deadline %v", next, retryAt)
+	}
+}
+
+// TestExpiredDeadlinesRestoreAvailability keeps recovery automatic: once every
+// deadline elapsed the credential returns without operator action.
+func TestExpiredDeadlinesRestoreAvailability(t *testing.T) {
+	now := time.Now().UTC()
+	auth := modelStateAuth("auth-expired", "", "gpt-5", &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(-time.Minute),
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: now.Add(-time.Second)},
+	})
+
+	blocked, reason, next := isAuthBlockedForModel(auth, "gpt-5", now)
+	if blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("blocked/reason/next = %v/%v/%v, want available after every deadline elapsed", blocked, reason, next)
+	}
+}
+
+// TestHighPriorityBadCredentialFallsBackToHealthy is the scheduling-level
+// regression test for the production 503: a priority=4 credential stuck in an
+// unbounded bad state must not starve a healthy priority=0 credential.
+func TestHighPriorityBadCredentialFallsBackToHealthy(t *testing.T) {
+	now := time.Now().UTC()
+	model := "gemini-3-flash-agent"
+	broken := modelStateAuth("auth-broken-high-priority", "4", model, &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		Quota:       QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+	})
+	healthy := modelStateAuth("auth-healthy-low-priority", "0", model, &ModelState{Status: StatusActive})
+
+	available, err := getAvailableAuths([]*Auth{broken, healthy}, "antigravity", model, now)
+	if err != nil {
+		t.Fatalf("getAvailableAuths() error = %v, want the healthy credential", err)
+	}
+	if len(available) != 1 || available[0].ID != healthy.ID {
+		ids := make([]string, 0, len(available))
+		for _, auth := range available {
+			ids = append(ids, auth.ID)
+		}
+		t.Fatalf("available = %v, want only %s", ids, healthy.ID)
+	}
+}
+
+// TestAllCredentialsInQuotaCooldownReportsRetryAfter keeps the 429 cooldown error
+// intact: a fleet-wide quota window still yields an actionable reset hint.
+func TestAllCredentialsInQuotaCooldownReportsRetryAfter(t *testing.T) {
+	now := time.Now().UTC()
+	model := "gpt-5"
+	earliest := now.Add(3 * time.Minute)
+	first := modelStateAuth("auth-cooldown-early", "", model, &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: earliest,
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: earliest},
+	})
+	later := now.Add(9 * time.Minute)
+	second := modelStateAuth("auth-cooldown-late", "", model, &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: later,
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: later},
+	})
+
+	_, err := getAvailableAuths([]*Auth{first, second}, "codex", model, now)
+	cooldownErr, ok := err.(*modelCooldownError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want *modelCooldownError", err, err)
+	}
+	if cooldownErr.resetIn > earliest.Sub(now) {
+		t.Fatalf("resetIn = %v, want at most the earliest recovery %v", cooldownErr.resetIn, earliest.Sub(now))
+	}
+}

--- a/internal/cliproxy/auth/selector_availability_test.go
+++ b/internal/cliproxy/auth/selector_availability_test.go
@@ -19,10 +19,11 @@ func modelStateAuth(id string, priority string, model string, state *ModelState)
 	return auth
 }
 
-// TestZeroDeadlineUnavailableModelBlocksDispatch locks the regression behind the
-// production 503: a model marked unavailable without any recovery deadline is an
-// unbounded bad state and must fail closed instead of being dispatched.
-func TestZeroDeadlineUnavailableModelBlocksDispatch(t *testing.T) {
+// TestZeroDeadlineUnavailableModelStaysDispatchable pins the fail-open rule: a state
+// with no recovery deadline is something nothing can expire, so it must read as
+// recovered rather than park the credential. Legacy rows and cluster merge artifacts
+// reach dispatch in exactly this shape.
+func TestZeroDeadlineUnavailableModelStaysDispatchable(t *testing.T) {
 	now := time.Now().UTC()
 	auth := modelStateAuth("auth-zero-deadline", "", "gemini-3-flash-agent", &ModelState{
 		Status:      StatusError,
@@ -31,35 +32,48 @@ func TestZeroDeadlineUnavailableModelBlocksDispatch(t *testing.T) {
 	})
 
 	blocked, reason, next := isAuthBlockedForModel(auth, "gemini-3-flash-agent", now)
-	if !blocked {
-		t.Fatal("unavailable model without a recovery deadline was reported dispatchable")
+	if blocked {
+		t.Fatal("a state with no recovery deadline parked the credential")
 	}
-	if reason != blockReasonOther {
-		t.Fatalf("reason = %v, want blockReasonOther for an unbounded bad state", reason)
-	}
-	if !next.IsZero() {
-		t.Fatalf("next = %v, want zero: there is no deadline to report", next)
+	if reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("reason/next = %v/%v, want an unblocked verdict", reason, next)
 	}
 }
 
-// TestQuotaExceededWithoutUnavailableBlocksDispatch covers state written by cluster
-// merges or the Management API where only the quota flag is set.
-func TestQuotaExceededWithoutUnavailableBlocksDispatch(t *testing.T) {
+// TestQuotaExceededWithOpenWindowBlocksDispatch covers state written by cluster merges
+// or the Management API where the quota flag carries the window and the unavailable
+// flag was never set.
+func TestQuotaExceededWithOpenWindowBlocksDispatch(t *testing.T) {
 	now := time.Now().UTC()
+	recoverAt := now.Add(10 * time.Minute)
 	auth := modelStateAuth("auth-quota-only", "", "gpt-5", &ModelState{
 		Status: StatusError,
-		Quota:  QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+		Quota:  QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: recoverAt},
 	})
 
 	blocked, reason, next := isAuthBlockedForModel(auth, "gpt-5", now)
 	if !blocked {
-		t.Fatal("quota-exceeded model was reported dispatchable")
+		t.Fatal("quota-exceeded model with an open window was reported dispatchable")
 	}
-	if reason != blockReasonOther {
-		t.Fatalf("reason = %v, want blockReasonOther without a recovery deadline", reason)
+	if reason != blockReasonCooldown {
+		t.Fatalf("reason = %v, want blockReasonCooldown", reason)
 	}
-	if !next.IsZero() {
-		t.Fatalf("next = %v, want zero", next)
+	if !next.Equal(recoverAt) {
+		t.Fatalf("next = %v, want %v", next, recoverAt)
+	}
+}
+
+// TestQuotaExceededWithoutDeadlineStaysDispatchable keeps a quota flag that lost its
+// window from becoming a state nothing can expire.
+func TestQuotaExceededWithoutDeadlineStaysDispatchable(t *testing.T) {
+	now := time.Now().UTC()
+	auth := modelStateAuth("auth-quota-no-window", "", "gpt-5", &ModelState{
+		Status: StatusError,
+		Quota:  QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+	})
+
+	if blocked, _, _ := isAuthBlockedForModel(auth, "gpt-5", now); blocked {
+		t.Fatal("quota flag without a recovery window parked the credential")
 	}
 }
 
@@ -109,6 +123,47 @@ func TestBlockedNextUsesLatestRecoveryDeadline(t *testing.T) {
 	}
 }
 
+// TestBlockAlwaysReportsDeadline pins the invariant the scheduler depends on: a block
+// verdict always carries a future deadline, so promoteExpiredLocked can always bring the
+// entry back on its own and no snapshot can strand a credential.
+func TestBlockAlwaysReportsDeadline(t *testing.T) {
+	now := time.Now().UTC()
+	future := now.Add(time.Minute)
+	past := now.Add(-time.Minute)
+
+	snapshots := []struct {
+		name          string
+		unavailable   bool
+		quotaExceeded bool
+		retryAfter    time.Time
+		recoverAt     time.Time
+	}{
+		{name: "no flags"},
+		{name: "unavailable without deadline", unavailable: true},
+		{name: "quota without deadline", quotaExceeded: true},
+		{name: "both without deadline", unavailable: true, quotaExceeded: true},
+		{name: "elapsed deadlines", unavailable: true, quotaExceeded: true, retryAfter: past, recoverAt: past},
+		{name: "open retry window", unavailable: true, retryAfter: future},
+		{name: "open quota window", quotaExceeded: true, recoverAt: future},
+		{name: "mixed windows", unavailable: true, quotaExceeded: true, retryAfter: past, recoverAt: future},
+	}
+
+	for _, tc := range snapshots {
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, _, next := availabilityBlock(tc.unavailable, tc.quotaExceeded, tc.retryAfter, tc.recoverAt, now)
+			if !blocked {
+				if !next.IsZero() {
+					t.Fatalf("next = %v, want zero for an unblocked verdict", next)
+				}
+				return
+			}
+			if next.IsZero() || !next.After(now) {
+				t.Fatalf("next = %v, want a future deadline for a blocked verdict", next)
+			}
+		})
+	}
+}
+
 // TestExpiredDeadlinesRestoreAvailability keeps recovery automatic: once every
 // deadline elapsed the credential returns without operator action.
 func TestExpiredDeadlinesRestoreAvailability(t *testing.T) {
@@ -126,20 +181,22 @@ func TestExpiredDeadlinesRestoreAvailability(t *testing.T) {
 	}
 }
 
-// TestHighPriorityBadCredentialFallsBackToHealthy is the scheduling-level
-// regression test for the production 503: a priority=4 credential stuck in an
-// unbounded bad state must not starve a healthy priority=0 credential.
-func TestHighPriorityBadCredentialFallsBackToHealthy(t *testing.T) {
+// TestHighPriorityCoolingCredentialFallsBackToHealthy is the scheduling-level
+// regression test for the production 503: a priority=4 credential inside its cooldown
+// must not starve a healthy priority=0 credential.
+func TestHighPriorityCoolingCredentialFallsBackToHealthy(t *testing.T) {
 	now := time.Now().UTC()
 	model := "gemini-3-flash-agent"
-	broken := modelStateAuth("auth-broken-high-priority", "4", model, &ModelState{
-		Status:      StatusError,
-		Unavailable: true,
-		Quota:       QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota"},
+	recoverAt := now.Add(5 * time.Minute)
+	cooling := modelStateAuth("auth-cooling-high-priority", "4", model, &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: recoverAt,
+		Quota:          QuotaState{Exceeded: true, Scope: quotaScopeModel, Reason: "quota", NextRecoverAt: recoverAt},
 	})
 	healthy := modelStateAuth("auth-healthy-low-priority", "0", model, &ModelState{Status: StatusActive})
 
-	available, err := getAvailableAuths([]*Auth{broken, healthy}, "antigravity", model, now)
+	available, err := getAvailableAuths([]*Auth{cooling, healthy}, "antigravity", model, now)
 	if err != nil {
 		t.Fatalf("getAvailableAuths() error = %v, want the healthy credential", err)
 	}
@@ -149,6 +206,37 @@ func TestHighPriorityBadCredentialFallsBackToHealthy(t *testing.T) {
 			ids = append(ids, auth.ID)
 		}
 		t.Fatalf("available = %v, want only %s", ids, healthy.ID)
+	}
+}
+
+// TestLegacyUnboundedStateKeepsCredentialSchedulable is the upgrade guard: a snapshot
+// written by an older Home version carries an unavailable flag with no deadline, and it
+// must never survive as a credential nothing can revive.
+func TestLegacyUnboundedStateKeepsCredentialSchedulable(t *testing.T) {
+	now := time.Now().UTC()
+	model := "gemini-3-flash-agent"
+	legacy := modelStateAuth("auth-legacy-unbounded", "4", model, &ModelState{
+		Status:      StatusError,
+		Unavailable: true,
+		LastError:   &Error{Message: "conflict", HTTPStatus: 409},
+	})
+
+	available, err := getAvailableAuths([]*Auth{legacy}, "antigravity", model, now)
+	if err != nil {
+		t.Fatalf("getAvailableAuths() error = %v, want the legacy credential to stay schedulable", err)
+	}
+	if len(available) != 1 || available[0].ID != legacy.ID {
+		t.Fatalf("available = %v, want the legacy credential", available)
+	}
+
+	// The next aggregate pass normalizes the stored snapshot so nothing keeps
+	// reporting a cooldown dispatch already ignores.
+	updateAggregatedAvailability(legacy, now)
+	if state := legacy.ModelStates[model]; state == nil || state.Unavailable {
+		t.Fatalf("state = %#v, want the unbounded flag cleared", state)
+	}
+	if legacy.Unavailable {
+		t.Fatal("credential aggregate still reports unavailable")
 	}
 }
 

--- a/internal/cliproxy/auth/selector_session_priority_test.go
+++ b/internal/cliproxy/auth/selector_session_priority_test.go
@@ -247,3 +247,85 @@ func TestAvailableAuthByIDIgnoresBlockedAndUnknownIDs(t *testing.T) {
 		t.Fatalf("empty lookup = %s, want nil", got.ID)
 	}
 }
+
+// wsSessionAuth builds a codex credential at the given priority with an explicit
+// websocket capability flag, for the shared session-affinity model.
+func wsSessionAuth(id, priority string, websockets bool) *Auth {
+	auth := modelStateAuth(id, priority, sessionPriorityModel, &ModelState{Status: StatusActive})
+	auth.Provider = "codex"
+	auth.Attributes["websockets"] = "false"
+	if websockets {
+		auth.Attributes["websockets"] = "true"
+	}
+	return auth
+}
+
+// TestWebsocketColdStartOutranksPriorityUnderSessionAffinity closes the gap that made
+// the scheduler's websocket preference unreachable in practice. A websocket session
+// binds on its first request and stays bound, so if that first pick ignores websocket
+// capability the whole session runs on a credential that cannot hold the transport.
+// Session affinity replaces the scheduler fast path entirely, so the preference has to
+// exist here too.
+func TestWebsocketColdStartOutranksPriorityUnderSessionAffinity(t *testing.T) {
+	httpOnly := wsSessionAuth("auth-http-high", "9", false)
+	websocketCapable := wsSessionAuth("auth-ws-low", "1", true)
+	selector := newSessionSelector()
+	auths := []*Auth{httpOnly, websocketCapable}
+
+	opts := sessionOptions("session-websocket")
+	opts.Metadata = map[string]any{DownstreamWebsocketMetadataKey: true}
+
+	picked, err := selector.Pick(context.Background(), "codex", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("cold start failed: %v", err)
+	}
+	if picked.ID != websocketCapable.ID {
+		t.Fatalf("cold start picked %s, want the websocket credential %s", picked.ID, websocketCapable.ID)
+	}
+
+	// The binding must then hold for the rest of the session.
+	again, err := selector.Pick(context.Background(), "codex", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("bound pick failed: %v", err)
+	}
+	if again.ID != websocketCapable.ID {
+		t.Fatalf("bound pick returned %s, want %s", again.ID, websocketCapable.ID)
+	}
+}
+
+// TestNonWebsocketColdStartStillFollowsPriority keeps the preference scoped: an
+// ordinary request must still bind to the highest priority credential.
+func TestNonWebsocketColdStartStillFollowsPriority(t *testing.T) {
+	httpOnly := wsSessionAuth("auth-http-high", "9", false)
+	websocketCapable := wsSessionAuth("auth-ws-low", "1", true)
+	selector := newSessionSelector()
+	auths := []*Auth{httpOnly, websocketCapable}
+
+	picked, err := selector.Pick(context.Background(), "codex", sessionPriorityModel, sessionOptions("session-plain"), auths)
+	if err != nil {
+		t.Fatalf("cold start failed: %v", err)
+	}
+	if picked.ID != httpOnly.ID {
+		t.Fatalf("cold start picked %s, want the highest priority credential %s", picked.ID, httpOnly.ID)
+	}
+}
+
+// TestWebsocketColdStartFallsBackWhenNoCapableCredential keeps a websocket request
+// dispatchable when nothing in the pool can hold a websocket upstream.
+func TestWebsocketColdStartFallsBackWhenNoCapableCredential(t *testing.T) {
+	high := wsSessionAuth("auth-http-high", "9", false)
+	low := wsSessionAuth("auth-http-low", "1", false)
+	selector := newSessionSelector()
+	auths := []*Auth{high, low}
+
+	opts := sessionOptions("session-websocket-nofit")
+	opts.Metadata = map[string]any{DownstreamWebsocketMetadataKey: true}
+
+	picked, err := selector.Pick(context.Background(), "codex", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("cold start failed: %v", err)
+	}
+	if picked.ID != high.ID {
+		t.Fatalf("cold start picked %s, want the highest priority credential %s", picked.ID, high.ID)
+	}
+}

--- a/internal/cliproxy/auth/selector_session_priority_test.go
+++ b/internal/cliproxy/auth/selector_session_priority_test.go
@@ -181,3 +181,69 @@ func TestAcrossPrioritiesReturnsEveryTier(t *testing.T) {
 		t.Fatalf("available = [%s %s], want ID-sorted [%s %s]", available[0].ID, available[1].ID, high.ID, low.ID)
 	}
 }
+
+// TestBoundSessionResolvesWithoutPoolWideEvaluation pins the cheap path: reusing an
+// established binding must depend only on the bound credential. The bound credential
+// here sits at the lowest priority while every other candidate is blocked, so a
+// pool-wide evaluation is neither needed nor allowed to change the answer.
+func TestBoundSessionResolvesWithoutPoolWideEvaluation(t *testing.T) {
+	now := time.Now().UTC()
+	bound := sessionPriorityAuth("auth-bound", "1")
+	high := sessionPriorityAuth("auth-high", "9")
+	other := sessionPriorityAuth("auth-other", "5")
+	selector := newSessionSelector()
+	opts := sessionOptions("session-cheap-path")
+	auths := []*Auth{high, other, bound}
+
+	// Cold start binds to the highest priority credential.
+	first, err := selector.Pick(context.Background(), "gemini", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("cold start failed: %v", err)
+	}
+	if first.ID != high.ID {
+		t.Fatalf("cold start picked %s, want %s", first.ID, high.ID)
+	}
+
+	// Rebind onto the lowest priority credential by blocking everything else.
+	blockModel(high, now)
+	blockModel(other, now)
+	second, err := selector.Pick(context.Background(), "gemini", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("rebinding failed: %v", err)
+	}
+	if second.ID != bound.ID {
+		t.Fatalf("rebinding picked %s, want %s", second.ID, bound.ID)
+	}
+
+	// The binding now resolves on its own even though the rest of the pool is blocked.
+	third, err := selector.Pick(context.Background(), "gemini", sessionPriorityModel, opts, auths)
+	if err != nil {
+		t.Fatalf("bound pick failed: %v", err)
+	}
+	if third.ID != bound.ID {
+		t.Fatalf("bound pick returned %s, want %s", third.ID, bound.ID)
+	}
+}
+
+// TestAvailableAuthByIDIgnoresBlockedAndUnknownIDs covers the single-credential lookup
+// behind the bound-session path.
+func TestAvailableAuthByIDIgnoresBlockedAndUnknownIDs(t *testing.T) {
+	now := time.Now().UTC()
+	healthy := sessionPriorityAuth("auth-healthy", "1")
+	blocked := sessionPriorityAuth("auth-blocked", "1")
+	blockModel(blocked, now)
+	auths := []*Auth{healthy, blocked}
+
+	if got := availableAuthByID(auths, healthy.ID, sessionPriorityModel, now); got == nil || got.ID != healthy.ID {
+		t.Fatalf("healthy lookup = %v, want %s", got, healthy.ID)
+	}
+	if got := availableAuthByID(auths, blocked.ID, sessionPriorityModel, now); got != nil {
+		t.Fatalf("blocked lookup = %s, want nil", got.ID)
+	}
+	if got := availableAuthByID(auths, "auth-missing", sessionPriorityModel, now); got != nil {
+		t.Fatalf("unknown lookup = %s, want nil", got.ID)
+	}
+	if got := availableAuthByID(auths, "", sessionPriorityModel, now); got != nil {
+		t.Fatalf("empty lookup = %s, want nil", got.ID)
+	}
+}

--- a/internal/cliproxy/auth/selector_session_priority_test.go
+++ b/internal/cliproxy/auth/selector_session_priority_test.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const sessionPriorityModel = "gemini-3-flash-agent"
+
+// sessionPriorityAuth builds a credential at the given priority for the shared model.
+func sessionPriorityAuth(id, priority string) *Auth {
+	return modelStateAuth(id, priority, sessionPriorityModel, &ModelState{Status: StatusActive})
+}
+
+// blockModel parks the credential's model behind a future cooldown.
+func blockModel(auth *Auth, now time.Time) {
+	auth.ModelStates[sessionPriorityModel] = &ModelState{
+		Status:         StatusError,
+		Unavailable:    true,
+		NextRetryAfter: now.Add(30 * time.Minute),
+	}
+}
+
+// unblockModel restores the credential's model to a healthy state.
+func unblockModel(auth *Auth) {
+	auth.ModelStates[sessionPriorityModel] = &ModelState{Status: StatusActive}
+}
+
+// sessionOptions builds dispatch options carrying an explicit session header.
+func sessionOptions(sessionID string) Options {
+	headers := http.Header{}
+	headers.Set("X-Session-ID", sessionID)
+	return Options{Headers: headers}
+}
+
+func newSessionSelector() *SessionAffinitySelector {
+	return NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &FillFirstSelector{},
+		TTL:      time.Hour,
+	})
+}
+
+// TestSessionColdBindingPrefersHighestPriority keeps credential priority in charge
+// of new bindings.
+func TestSessionColdBindingPrefersHighestPriority(t *testing.T) {
+	high := sessionPriorityAuth("auth-high", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+	selector := newSessionSelector()
+	defer selector.Stop()
+
+	picked, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, sessionOptions("sess-cold"), []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if picked.ID != high.ID {
+		t.Fatalf("picked = %s, want the highest priority credential %s", picked.ID, high.ID)
+	}
+}
+
+// TestSessionBindingSurvivesHigherPriorityRecovery is the regression test for
+// mid-conversation credential swaps: once a session is bound to a still-available
+// credential, a recovering higher-priority credential must not steal the session.
+func TestSessionBindingSurvivesHigherPriorityRecovery(t *testing.T) {
+	now := time.Now().UTC()
+	high := sessionPriorityAuth("auth-high", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+	blockModel(high, now)
+
+	selector := newSessionSelector()
+	defer selector.Stop()
+	opts := sessionOptions("sess-sticky")
+
+	bound, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if bound.ID != low.ID {
+		t.Fatalf("initial pick = %s, want %s while the high priority credential is cooling", bound.ID, low.ID)
+	}
+
+	unblockModel(high)
+
+	reused, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("second Pick() error = %v", err)
+	}
+	if reused.ID != low.ID {
+		t.Fatalf("second pick = %s, want the established binding %s to survive priority recovery", reused.ID, low.ID)
+	}
+}
+
+// TestSessionRebindsWhenBoundAuthBlocked keeps genuine failover working: a bound
+// credential that goes into cooldown must hand the session to the highest tier.
+func TestSessionRebindsWhenBoundAuthBlocked(t *testing.T) {
+	now := time.Now().UTC()
+	high := sessionPriorityAuth("auth-high", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+	blockModel(high, now)
+
+	selector := newSessionSelector()
+	defer selector.Stop()
+	opts := sessionOptions("sess-failover")
+
+	bound, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("initial Pick() error = %v", err)
+	}
+	if bound.ID != low.ID {
+		t.Fatalf("initial pick = %s, want %s", bound.ID, low.ID)
+	}
+
+	unblockModel(high)
+	blockModel(low, now)
+
+	failedOver, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, opts, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("failover Pick() error = %v", err)
+	}
+	if failedOver.ID != high.ID {
+		t.Fatalf("failover pick = %s, want %s once the bound credential is cooling", failedOver.ID, high.ID)
+	}
+}
+
+// TestSessionlessPickUsesHighestPriority keeps requests without a session signal on
+// the priority path.
+func TestSessionlessPickUsesHighestPriority(t *testing.T) {
+	high := sessionPriorityAuth("auth-high", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+	selector := newSessionSelector()
+	defer selector.Stop()
+
+	picked, err := selector.Pick(context.Background(), "antigravity", sessionPriorityModel, Options{}, []*Auth{low, high})
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	if picked.ID != high.ID {
+		t.Fatalf("picked = %s, want %s", picked.ID, high.ID)
+	}
+}
+
+// TestHighestPriorityAuthsNarrowsTiers pins the helper used to keep the fallback
+// selector on a single tier.
+func TestHighestPriorityAuthsNarrowsTiers(t *testing.T) {
+	high := sessionPriorityAuth("auth-high", "4")
+	alsoHigh := sessionPriorityAuth("auth-high-2", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+
+	narrowed := highestPriorityAuths([]*Auth{low, high, alsoHigh})
+	if len(narrowed) != 2 {
+		t.Fatalf("len(narrowed) = %d, want 2", len(narrowed))
+	}
+	for _, auth := range narrowed {
+		if authPriority(auth) != 4 {
+			t.Fatalf("narrowed contains %s at priority %d, want only priority 4", auth.ID, authPriority(auth))
+		}
+	}
+
+	singleTier := []*Auth{high, alsoHigh}
+	if got := highestPriorityAuths(singleTier); len(got) != len(singleTier) {
+		t.Fatalf("single tier was reallocated: len=%d, want %d", len(got), len(singleTier))
+	}
+}
+
+// TestAcrossPrioritiesReturnsEveryTier pins the membership view used to validate
+// established bindings.
+func TestAcrossPrioritiesReturnsEveryTier(t *testing.T) {
+	now := time.Now().UTC()
+	high := sessionPriorityAuth("auth-high", "4")
+	low := sessionPriorityAuth("auth-low", "0")
+
+	available, err := getAvailableAuthsAcrossPriorities([]*Auth{low, high}, "antigravity", sessionPriorityModel, now)
+	if err != nil {
+		t.Fatalf("getAvailableAuthsAcrossPriorities() error = %v", err)
+	}
+	if len(available) != 2 {
+		t.Fatalf("len(available) = %d, want both tiers", len(available))
+	}
+	if available[0].ID != high.ID || available[1].ID != low.ID {
+		t.Fatalf("available = [%s %s], want ID-sorted [%s %s]", available[0].ID, available[1].ID, high.ID, low.ID)
+	}
+}

--- a/internal/cliproxy/auth/session_cache.go
+++ b/internal/cliproxy/auth/session_cache.go
@@ -104,7 +104,9 @@ func (c *SessionCache) Invalidate(sessionID string) {
 }
 
 // InvalidateAuth removes all sessions bound to a specific auth ID.
-// Used when an auth becomes unavailable.
+// Used when an auth is removed from the manager. A merely unavailable auth is not
+// invalidated here: the binding is revalidated on every pick, so it recovers with the
+// credential instead of being dropped.
 func (c *SessionCache) InvalidateAuth(authID string) {
 	if authID == "" {
 		return

--- a/internal/cliproxy/auth/types.go
+++ b/internal/cliproxy/auth/types.go
@@ -132,6 +132,10 @@ type ModelState struct {
 	// QuotaResetAt marks an operator reset so peers can merge it without
 	// discarding unrelated local execution errors.
 	QuotaResetAt time.Time `json:"quota_reset_at,omitzero"`
+	// RetryBackoffLevel stores the progressive cooldown exponent for temporary
+	// restrictions that are not quota, such as a Cloudflare challenge. Quota keeps
+	// its own level in QuotaState so the two ladders cannot interfere.
+	RetryBackoffLevel int `json:"retry_backoff_level,omitempty"`
 }
 
 // recentRequestBucketID handles a recent request bucket id.

--- a/internal/home/runtime.go
+++ b/internal/home/runtime.go
@@ -797,15 +797,25 @@ type DispatchResult struct {
 
 // DispatchForAPIKey processes dispatch with API-key channel restrictions.
 func (r *Runtime) DispatchForAPIKey(ctx context.Context, reqModel string, headers http.Header, apiKey string) (*DispatchResult, error) {
-	return r.dispatchForAPIKey(ctx, reqModel, headers, apiKey, "", DispatchConcurrencyContext{})
+	return r.dispatchForAPIKey(ctx, reqModel, headers, apiKey, "", false, DispatchConcurrencyContext{})
 }
 
 // DispatchForAPIKeyWithConcurrency performs dispatch and atomic admission for a RESP request.
-func (r *Runtime) DispatchForAPIKeyWithConcurrency(ctx context.Context, reqModel string, headers http.Header, apiKey string, credentialPolicy string, concurrencyCtx DispatchConcurrencyContext) (*DispatchResult, error) {
-	return r.dispatchForAPIKey(ctx, reqModel, headers, apiKey, credentialPolicy, concurrencyCtx)
+func (r *Runtime) DispatchForAPIKeyWithConcurrency(ctx context.Context, reqModel string, headers http.Header, apiKey string, credentialPolicy string, downstreamWebsocket bool, concurrencyCtx DispatchConcurrencyContext) (*DispatchResult, error) {
+	return r.dispatchForAPIKey(ctx, reqModel, headers, apiKey, credentialPolicy, downstreamWebsocket, concurrencyCtx)
 }
 
-func (r *Runtime) dispatchForAPIKey(ctx context.Context, reqModel string, headers http.Header, apiKey string, credentialPolicy string, concurrencyCtx DispatchConcurrencyContext) (*DispatchResult, error) {
+// headersIndicateWebsocketUpgrade reports a downstream websocket from the forwarded
+// request headers. Nodes that predate the explicit dispatch field still forward the
+// upgrade header, so this keeps the preference working without a protocol bump.
+func headersIndicateWebsocketUpgrade(headers http.Header) bool {
+	if headers == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(headers.Get("Upgrade")), "websocket")
+}
+
+func (r *Runtime) dispatchForAPIKey(ctx context.Context, reqModel string, headers http.Header, apiKey string, credentialPolicy string, downstreamWebsocket bool, concurrencyCtx DispatchConcurrencyContext) (*DispatchResult, error) {
 	opts := coreauth.Options{}
 	if headers != nil {
 		opts.Headers = headers.Clone()
@@ -823,6 +833,9 @@ func (r *Runtime) dispatchForAPIKey(ctx context.Context, reqModel string, header
 	}
 	if credentialPolicy = strings.TrimSpace(credentialPolicy); credentialPolicy != "" {
 		metadata[coreauth.CredentialPolicyMetadataKey] = credentialPolicy
+	}
+	if downstreamWebsocket || headersIndicateWebsocketUpgrade(headers) {
+		metadata[coreauth.DownstreamWebsocketMetadataKey] = true
 	}
 	if len(metadata) > 0 {
 		opts.Metadata = metadata

--- a/internal/respserver/pop/dynamic/dispatch.go
+++ b/internal/respserver/pop/dynamic/dispatch.go
@@ -247,7 +247,8 @@ func dispatchRequest(ctx context.Context, env dispatch.Env, args []string) (*hom
 	}
 
 	concurrencyReq := dispatchConcurrencyRequest{Protocol: int(gjson.Get(jsonArg, "concurrency_protocol").Int())}
-	result, errDispatch := env.Runtime.DispatchForAPIKeyWithConcurrency(ctx, model, headers, userAPIKey, credentialPolicy, home.DispatchConcurrencyContext{
+	downstreamWebsocket := gjson.Get(jsonArg, "downstream_websocket").Bool()
+	result, errDispatch := env.Runtime.DispatchForAPIKeyWithConcurrency(ctx, model, headers, userAPIKey, credentialPolicy, downstreamWebsocket, home.DispatchConcurrencyContext{
 		Fingerprint:     env.ConnectionLifetime.Fingerprint,
 		ConnectedAt:     env.ConnectionLifetime.ConnectedAt,
 		Controlled:      env.ConnectionLifetime.Controlled,


### PR DESCRIPTION
## Problem

Home reported a credential as dispatchable when its model state was marked
unavailable or quota exceeded but carried no recovery deadline at all.

That state is unbounded: nothing can expire it. Home kept selecting the affected
credential, CPA nodes then refused to execute it, and requests failed with
`503 no execution models available` while healthy lower-priority credentials were
never considered. The failing selection also produced no cooldown, so the loop
repeated for every request.

The write side actively produced that state. Failure transitions always set the
model state unavailable, but several branches left no deadline behind:

- unmapped status codes (400, 409, 422, 451, 501, ...) always cleared the deadline
- 402/403, 404, 408/5xx cleared it whenever `disable_cooling` was in effect
- a 429 on a credential carrying `disable_cooling` produced `unavailable` **and**
  `quota.exceeded` with an empty recovery time

Two more scheduling defects were found in the same paths:

- an established session binding was validated against the highest available
  priority tier only, so a session bound to a lower-priority credential lost its
  binding the moment a higher-priority credential recovered
- execution results carrying a revoked grant or a Cloudflare interstitial had no
  dedicated branch and were retried once a minute forever

## Changes

Four independent commits, each buildable and green on its own.

**1. `fail closed on unbounded credential unavailability`**

Route the model-level availability decision through a shared `availabilityBlock`
helper mirroring CPA:

- unavailable or quota exceeded with no recovery time now blocks
- `quota.exceeded` alone blocks, instead of being ignored when `unavailable` is false
- an elapsed `next_retry_after` no longer releases a credential whose quota window
  is still open
- the reported deadline is the later of the retry and quota windows, so
  `Retry-After` can no longer under-report

Credential-wide aggregates stay advisory. Legacy Home versions recorded quota
state with a `credential` scope, and honouring it here would block every model
instead of the one that failed. `TestLegacyCredentialWideStateDoesNotBlockDispatch`
still passes unchanged.

**2. `clear unbounded availability flags when cooling is disabled`**

- unmapped status codes now use the existing transient path: cool the model for one
  minute so dispatch moves to another credential, then let it return on its own
- derive the unavailable flag from the deadline instead of asserting it unconditionally
- clear the unavailable and quota flags when disabled cooling leaves no deadline,
  since `disable_cooling` means keep retrying rather than park the credential

Failure detail is untouched: status, last error, and status message still record why
the attempt failed. Real cooldowns such as the 12h model-not-supported window keep
their deadline.

**3. `keep session bindings across credential priority tiers`**

Validate the bound credential against every priority tier while still handing the
fallback selector the highest tier only. Credential priority keeps deciding cold
bindings, sessionless requests, and genuine bound-credential failover; an
established binding now outranks priority for as long as it stays available.

**4. `cool down invalid_grant and cloudflare challenge failures`**

- `invalid_grant` on 400 or 401 suspends the model for 30 minutes
- a Cloudflare challenge reuses the quota backoff ladder with a ten second floor and
  records a `cloudflare challenge` quota reason so it is distinguishable from a real
  provider quota

Other statuses keep their existing handling, so a 5xx that merely mentions
`invalid_grant` stays transient.

## Scope

Two production files, +225/-38: `internal/cliproxy/auth/selector.go` and
`internal/cliproxy/auth/result.go`. All three dispatch paths (incremental scheduler
fast path, Manager dispatch, selector) already funnel through
`isAuthBlockedForModel`, so the availability fix covers every path.

Deliberately unchanged:

- provider `Retry-After` on 429 stays ignored in favour of the existing exponential
  backoff ladder
- the 401 cooldown keeps Home's shorter one minute window and does not suspend the
  model, because Home runs its own refresh loop
- credential-wide availability aggregates remain advisory
- `MarkResult` still ignores results without a model

## Testing

`gofmt` clean, `go build ./cmd/home` OK, `go test ./...` green. No existing test
was modified.

28 new tests across four files. Each stage was verified by temporarily reverting
only its implementation and confirming the new tests fail:

| stage | failing tests before the fix |
| --- | --- |
| availability | 5 of 7 (the other 2 are guards that must pass both before and after) |
| cooldown write path | 4 of 7 (3 guards: normal quota window, 408/5xx one minute, 12h model-not-supported) |
| session priority | 1 of 6 (`TestSessionBindingSurvivesHigherPriorityRecovery`) |

`internal/cliproxy/auth/selector_availability_test.go` includes
`TestHighPriorityBadCredentialFallsBackToHealthy`, the scheduling-level regression
test for the reported 503.

## Compatibility

No Management API route, request field, or response field changed, so
`docs/management/api.md` needs no update. The `status`, `unavailable`, and
`next_retry_after` fields keep their meaning; they simply stop being mutually
contradictory.
