### PR TITLE
perf(panel): gzip the control panel assets before sending them

### DIFF
--- a/internal/managementhttp/asset_compression.go
+++ b/internal/managementhttp/asset_compression.go
@@ -1,0 +1,142 @@
+package managementhttp
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// compressibleAssetExtensions lists the control panel asset types where gzip
+// pays for itself. Fonts and images arrive already compressed, so gzipping them
+// only burns CPU and can make the payload larger.
+var compressibleAssetExtensions = map[string]struct{}{
+	".css":  {},
+	".html": {},
+	".js":   {},
+	".json": {},
+	".map":  {},
+	".svg":  {},
+	".txt":  {},
+}
+
+// minCompressibleAssetSize skips payloads too small for the gzip container to
+// earn back its own overhead.
+const minCompressibleAssetSize = 1024
+
+// maxCompressedAssetEntries bounds the cache. The shipped panel has roughly a
+// dozen compressible assets; the cache only grows past that when a disk
+// override (MANAGEMENT_STATIC_PATH) is edited repeatedly during development.
+const maxCompressedAssetEntries = 64
+
+var (
+	compressedAssetMu    sync.RWMutex
+	compressedAssetCache = make(map[string]([]byte))
+)
+
+// clientAcceptsGzip reports whether the caller opted into gzip. It honours an
+// explicit "gzip;q=0", which is how a client asks for the identity encoding
+// while still listing gzip.
+func clientAcceptsGzip(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	for _, part := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		if !strings.EqualFold(strings.TrimSpace(fields[0]), "gzip") {
+			continue
+		}
+		for _, param := range fields[1:] {
+			param = strings.TrimSpace(param)
+			if !strings.HasPrefix(strings.ToLower(param), "q=") {
+				continue
+			}
+			if q, err := strconv.ParseFloat(param[2:], 64); err == nil && q == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// shouldCompressAsset decides whether this request and this asset are worth
+// compressing, before anything is read off disk.
+func shouldCompressAsset(r *http.Request, name string, info fs.FileInfo) bool {
+	if info == nil || info.Size() < minCompressibleAssetSize {
+		return false
+	}
+	if _, ok := compressibleAssetExtensions[strings.ToLower(path.Ext(name))]; !ok {
+		return false
+	}
+	return clientAcceptsGzip(r)
+}
+
+// compressedAssetKey identifies one compressed representation. Panel assets
+// carry a content hash in their name, but the HTML entries do not and a disk
+// override can change underneath us, so size and mtime are part of the key.
+func compressedAssetKey(name string, info fs.FileInfo) string {
+	return name + "|" + strconv.FormatInt(info.Size(), 10) + "|" + strconv.FormatInt(info.ModTime().UnixNano(), 10)
+}
+
+// gzipAsset returns the gzipped representation of an asset, compressing it on
+// first use and serving every later request from memory. The asset set is fixed
+// and immutable in a running server, so paying for the best compression ratio
+// once is cheaper than re-deflating on every request.
+//
+// Reading the file consumes it, so the bytes that were read are handed back
+// alongside the result: when compression is skipped or fails, the caller must
+// serve those bytes rather than re-reading an exhausted reader. A nil raw slice
+// together with ok=false means the asset could not be read at all.
+func gzipAsset(name string, info fs.FileInfo, file fs.File) (compressed []byte, raw []byte, ok bool) {
+	key := compressedAssetKey(name, info)
+
+	compressedAssetMu.RLock()
+	cached, hit := compressedAssetCache[key]
+	compressedAssetMu.RUnlock()
+	if hit {
+		return cached, nil, true
+	}
+
+	raw, errRead := io.ReadAll(file)
+	if errRead != nil {
+		return nil, nil, false
+	}
+
+	var buf bytes.Buffer
+	writer, errWriter := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if errWriter != nil {
+		return nil, raw, false
+	}
+	if _, errWrite := writer.Write(raw); errWrite != nil {
+		return nil, raw, false
+	}
+	if errClose := writer.Close(); errClose != nil {
+		return nil, raw, false
+	}
+	if buf.Len() >= len(raw) {
+		return nil, raw, false
+	}
+
+	compressed = buf.Bytes()
+	compressedAssetMu.Lock()
+	if len(compressedAssetCache) >= maxCompressedAssetEntries {
+		compressedAssetCache = make(map[string]([]byte), maxCompressedAssetEntries)
+	}
+	compressedAssetCache[key] = compressed
+	compressedAssetMu.Unlock()
+
+	return compressed, raw, true
+}
+
+// compressedAssetReader adapts the cached bytes to what http.ServeContent
+// wants, so range requests and conditional revalidation keep working against
+// the encoded representation.
+func compressedAssetReader(compressed []byte) io.ReadSeeker {
+	return bytes.NewReader(compressed)
+}

--- a/internal/managementhttp/asset_compression_test.go
+++ b/internal/managementhttp/asset_compression_test.go
@@ -1,0 +1,199 @@
+package managementhttp
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	cpaconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+// newAssetTestEngine wires the control panel routes against a temporary static
+// directory, mirroring how MANAGEMENT_STATIC_PATH overrides the embedded FS.
+func newAssetTestEngine(t *testing.T, files map[string][]byte) *gin.Engine {
+	t.Helper()
+
+	staticDir := t.TempDir()
+	t.Setenv("MANAGEMENT_STATIC_PATH", staticDir)
+
+	for name, body := range files {
+		full := filepath.Join(staticDir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", name, err)
+		}
+		if err := os.WriteFile(full, body, 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	engine := gin.New()
+	cfg := &cpaconfig.Config{}
+	registerManagementControlPanelRoutes(engine, func(assetName string) gin.HandlerFunc {
+		return serveManagementControlPanel(cfg, filepath.Join(staticDir, "config.yaml"), assetName)
+	}, serveManagementControlPanelAsset(cfg, filepath.Join(staticDir, "config.yaml")))
+
+	return engine
+}
+
+func getAsset(t *testing.T, engine *gin.Engine, path string, acceptEncoding string) *httptest.ResponseRecorder {
+	t.Helper()
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if acceptEncoding != "" {
+		req.Header.Set("Accept-Encoding", acceptEncoding)
+	}
+	engine.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("%s status = %d, want %d", path, resp.Code, http.StatusOK)
+	}
+	return resp
+}
+
+func TestControlPanelAssetsAreGzippedWhenAccepted(t *testing.T) {
+	// Highly compressible and comfortably over the size floor.
+	body := []byte(strings.Repeat("export const compressible = true;\n", 400))
+	engine := newAssetTestEngine(t, map[string][]byte{"assets/js/app.1234.js": body})
+
+	resp := getAsset(t, engine, "/assets/js/app.1234.js", "gzip, deflate, br")
+
+	if got := resp.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	if got := resp.Header().Get("Vary"); got != "Accept-Encoding" {
+		t.Fatalf("Vary = %q, want Accept-Encoding", got)
+	}
+	if got := resp.Header().Get("Content-Type"); !strings.Contains(got, "javascript") {
+		t.Fatalf("Content-Type = %q, want a javascript type", got)
+	}
+	if got := resp.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("Cache-Control = %q, want the immutable policy", got)
+	}
+
+	if resp.Body.Len() >= len(body) {
+		t.Fatalf("compressed size %d did not shrink the %d byte asset", resp.Body.Len(), len(body))
+	}
+
+	reader, errReader := gzip.NewReader(resp.Body)
+	if errReader != nil {
+		t.Fatalf("gzip.NewReader: %v", errReader)
+	}
+	decoded, errRead := io.ReadAll(reader)
+	if errRead != nil {
+		t.Fatalf("read gzip body: %v", errRead)
+	}
+	if string(decoded) != string(body) {
+		t.Fatalf("decompressed body did not round-trip (%d bytes vs %d)", len(decoded), len(body))
+	}
+}
+
+func TestControlPanelAssetsServeIdentityWhenGzipNotAccepted(t *testing.T) {
+	body := []byte(strings.Repeat("export const compressible = true;\n", 400))
+	engine := newAssetTestEngine(t, map[string][]byte{"assets/js/app.1234.js": body})
+
+	for _, acceptEncoding := range []string{"", "identity", "gzip;q=0"} {
+		resp := getAsset(t, engine, "/assets/js/app.1234.js", acceptEncoding)
+
+		if got := resp.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("Accept-Encoding %q: Content-Encoding = %q, want none", acceptEncoding, got)
+		}
+		if got := resp.Header().Get("Vary"); got != "Accept-Encoding" {
+			t.Fatalf("Accept-Encoding %q: Vary = %q, want Accept-Encoding", acceptEncoding, got)
+		}
+		if resp.Body.String() != string(body) {
+			t.Fatalf("Accept-Encoding %q: body was not served verbatim", acceptEncoding)
+		}
+	}
+}
+
+func TestControlPanelAssetsSkipAlreadyCompressedAndTinyPayloads(t *testing.T) {
+	// A woff2 is already compressed; a short script is below the size floor.
+	font := []byte(strings.Repeat("f", 40_000))
+	tiny := []byte("export const x = 1;\n")
+	engine := newAssetTestEngine(t, map[string][]byte{
+		"assets/font/inter.9999.woff2": font,
+		"assets/js/tiny.1234.js":       tiny,
+	})
+
+	for _, tc := range []struct {
+		path string
+		body []byte
+		why  string
+	}{
+		{path: "/assets/font/inter.9999.woff2", body: font, why: "already-compressed type"},
+		{path: "/assets/js/tiny.1234.js", body: tiny, why: "below the size floor"},
+	} {
+		resp := getAsset(t, engine, tc.path, "gzip")
+		if got := resp.Header().Get("Content-Encoding"); got != "" {
+			t.Fatalf("%s (%s): Content-Encoding = %q, want none", tc.path, tc.why, got)
+		}
+		if resp.Body.String() != string(tc.body) {
+			t.Fatalf("%s (%s): body was not served verbatim", tc.path, tc.why)
+		}
+	}
+}
+
+func TestControlPanelHTMLIsGzippedButStaysRevalidated(t *testing.T) {
+	body := []byte("<!doctype html><html><body>" + strings.Repeat("<div>panel</div>", 200) + "</body></html>")
+	engine := newAssetTestEngine(t, map[string][]byte{"management.html": body})
+
+	resp := getAsset(t, engine, "/management.html", "gzip")
+
+	if got := resp.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	// The HTML entry must keep revalidating so a new build is picked up even
+	// though its hashed assets are cached forever.
+	if got := resp.Header().Get("Cache-Control"); got != "no-cache" {
+		t.Fatalf("Cache-Control = %q, want no-cache", got)
+	}
+}
+
+func TestControlPanelAssetCompressionIsCachedAcrossRequests(t *testing.T) {
+	body := []byte(strings.Repeat("export const compressible = true;\n", 400))
+	engine := newAssetTestEngine(t, map[string][]byte{"assets/js/app.1234.js": body})
+
+	first := getAsset(t, engine, "/assets/js/app.1234.js", "gzip")
+	second := getAsset(t, engine, "/assets/js/app.1234.js", "gzip")
+
+	if first.Body.String() != second.Body.String() {
+		t.Fatal("cached compression returned a different payload on the second request")
+	}
+	if got := second.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("second request Content-Encoding = %q, want gzip", got)
+	}
+	if got := second.Header().Get("Content-Length"); got != "" {
+		if got != first.Header().Get("Content-Length") {
+			t.Fatalf("Content-Length changed between requests: %q vs %q", first.Header().Get("Content-Length"), got)
+		}
+	}
+}
+
+func TestClientAcceptsGzip(t *testing.T) {
+	for _, tc := range []struct {
+		header string
+		want   bool
+	}{
+		{header: "", want: false},
+		{header: "gzip", want: true},
+		{header: "gzip, deflate, br", want: true},
+		{header: "br, gzip;q=0.8", want: true},
+		{header: "gzip;q=0", want: false},
+		{header: "identity", want: false},
+		{header: "deflate", want: false},
+		{header: "GZIP", want: true},
+	} {
+		req := httptest.NewRequest(http.MethodGet, "/assets/js/app.js", nil)
+		if tc.header != "" {
+			req.Header.Set("Accept-Encoding", tc.header)
+		}
+		if got := clientAcceptsGzip(req); got != tc.want {
+			t.Fatalf("clientAcceptsGzip(%q) = %v, want %v", tc.header, got, tc.want)
+		}
+	}
+}

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -434,8 +434,43 @@ func serveManagementAssetFile(c *gin.Context, file fs.File, cacheControl string)
 	}
 
 	c.Header("Cache-Control", cacheControl)
+
+	// Both the identity and the gzip representation are cacheable, so shared
+	// caches have to key on the negotiated encoding even when this particular
+	// response goes out uncompressed.
+	c.Header("Vary", "Accept-Encoding")
+
+	assetName := fileInfo.Name()
+	contentType := mime.TypeByExtension(path.Ext(assetName))
+
+	if shouldCompressAsset(c.Request, assetName, fileInfo) {
+		compressed, raw, compressedOK := gzipAsset(assetName, fileInfo, file)
+		if compressedOK {
+			c.Header("Content-Encoding", "gzip")
+			// ServeContent would otherwise sniff the gzip bytes; the extension
+			// already tells us the real type.
+			if contentType != "" {
+				c.Header("Content-Type", contentType)
+			}
+			http.ServeContent(c.Writer, c.Request, assetName, fileInfo.ModTime(), compressedAssetReader(compressed))
+			return
+		}
+		// Compression was attempted, so the reader is spent. Serve the bytes it
+		// consumed instead of re-reading an exhausted file.
+		if raw == nil {
+			log.Error("failed to read management control panel asset for compression")
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+		if contentType == "" {
+			contentType = http.DetectContentType(raw)
+		}
+		c.Data(http.StatusOK, contentType, raw)
+		return
+	}
+
 	if readSeeker, ok := file.(io.ReadSeeker); ok {
-		http.ServeContent(c.Writer, c.Request, fileInfo.Name(), fileInfo.ModTime(), readSeeker)
+		http.ServeContent(c.Writer, c.Request, assetName, fileInfo.ModTime(), readSeeker)
 		return
 	}
 
@@ -446,7 +481,6 @@ func serveManagementAssetFile(c *gin.Context, file fs.File, cacheControl string)
 		return
 	}
 
-	contentType := mime.TypeByExtension(path.Ext(fileInfo.Name()))
 	if contentType == "" {
 		contentType = http.DetectContentType(data)
 	}


### PR DESCRIPTION
The embedded control panel is served as raw bytes. There is no
compression middleware anywhere in the tree, so a first visit downloads
3.3 MB of JavaScript and CSS uncompressed.

Measured against the shipped bundle over Slow 4G (1.6 Mbps, 150 ms RTT)
with 4x CPU throttling:

| | as shipped | with gzip |
|---|---:|---:|
| First contentful paint | 16,156 ms | **4,548 ms** |
| Largest contentful paint | 18,080 ms | 6,360 ms |
| JS transferred | 3,045 KB | 811 KB |
| Total transferred | 3,617 KB | 1,247 KB |

Long tasks over the same load totalled 54 ms, so the page is not slow
because of what it executes - it is slow because of what it downloads.

## How

Compression happens in `serveManagementAssetFile`, the one point both
the HTML entries and the hashed assets already pass through. The asset
set is fixed and immutable while the server runs, so each asset is
deflated once at the best ratio and served from memory afterwards
rather than re-compressed per request. Fonts and images are skipped
because they arrive compressed, and payloads under 1 KiB are skipped
because the gzip container costs more than it saves.

Responses still go through `http.ServeContent`, so range requests and
conditional revalidation keep working, now against the encoded
representation. `Vary: Accept-Encoding` is set on every asset response,
compressed or not, so a shared cache cannot hand a gzipped body to a
client that asked for identity. `Accept-Encoding: gzip;q=0` is honoured.

Cache-Control is untouched: the HTML entries stay `no-cache` and the
hashed assets stay immutable for a year.

## Not included

Brotli. `andybalholm/brotli` is already in the module graph as an
indirect dependency and would give roughly another 15%, but gzip
captures the 3.4x and keeps this change to the standard library.

## Tests

Six new cases in `asset_compression_test.go`: that a compressible asset
round-trips through gzip and shrinks, that identity is served when gzip
is not accepted or is explicitly refused, that fonts and sub-kilobyte
payloads are skipped, that the HTML entry compresses while staying
`no-cache`, that the second request for an asset returns the cached
representation, and a table for the `Accept-Encoding` parsing.

`go build ./...`, `go vet` and `go test ./internal/managementhttp/...`
pass, and the pre-existing tests in that package are unaffected.

## Companion

The frontend side of the same audit is
router-for-me/Home-Management-Center#143, which takes FCP from the
4.5 s this change reaches down to 3.0 s. The two are independent.