### PR TITLE
feat(api-keys): support editable display names without rotating keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ To export config and credentials back to local files, run:
 
 Export writes `./config.yaml` and credential files under `~/.cli-proxy-api/` by default. Use `-export-dir <path>` to write `<path>/config.yaml` and credential files under `<path>/auths/`. It refuses to overwrite an existing `config.yaml` or a non-empty credential directory at the selected target.
 
+`-export` / `-import` preserve the legacy exchange format. API keys are exported only as their actual key values, so Home database-only metadata such as API key display names, user ownership, and channel/model-group bindings is not a complete backup. Use `-db-export <snapshot.zip>` and `-db-import <snapshot.zip>` for full database backup and restore. Database snapshot format v4 includes API key display names and cannot be imported by older Home versions. Before upgrading, retain a database backup or an older-version-compatible snapshot for rollback.
+
 In cluster mode, the Management API operates directly on database data. The default listen port comes from `node.port` in `cluster.yaml`; the startup `-addr` flag can override the listen address. Set `node.external-port` when a reverse proxy changes the port that clients must use; when omitted, the advertised cluster node port follows the final listen port.
 
 RESP password authentication has been removed. Home RESP access only accepts mTLS-authenticated clients; CPA should connect with `-home-jwt` or configured TLS material. `allow-host` is only an IP allowlist and is not a password mechanism.

--- a/README_CN.md
+++ b/README_CN.md
@@ -41,6 +41,8 @@ Home 现在始终使用数据库驱动的运行时。没有 `cluster.yaml` 时�
 
 导出默认会写出当前目录的 `config.yaml`，并把凭证写到 `~/.cli-proxy-api/`。可以通过 `-export-dir <path>` 写出 `<path>/config.yaml`，并把凭证写到 `<path>/auths/`。如果目标 `config.yaml` 已存在，或者目标凭证目录已存在且非空，导出会拒绝覆盖。
 
+`-export` / `-import` 保留旧版交换格式。API key 只会导出实际 key 值，因此 Home 数据库专属的 API key 展示名称、用户归属、channel/model group 绑定等元数据不构成完整备份。完整数据库备份和恢复应使用 `-db-export <snapshot.zip>` 与 `-db-import <snapshot.zip>`。数据库快照 v4 包含 API key 展示名称，旧版 Home 无法导入；升级前应保留数据库备份或旧版本兼容快照，以便回滚。
+
 集群模式下，Management API 会直接操作数据库中的数据。默认监听端口来自 `cluster.yaml` 的 `node.port`；也可以通过启动参数 `-addr` 覆盖监听地址。如果前置反代改变了 client 实际需要连接的端口，可以设置 `node.external-port`；未设置时，对外发布的集群节点端口仍以最终监听端口为准。
 
 RESP 密码认证已经移除。Home RESP 只接受通过 mTLS 认证的客户端；CPA 应使用 `-home-jwt` 或配置好的 TLS 材料连接。`allow-host` 只是 IP 允许列表，不是密码机制。

--- a/docs/management/api.md
+++ b/docs/management/api.md
@@ -1345,6 +1345,8 @@ Common errors:
 
 ### GET `/api-keys`
 
+The response includes a strong `ETag` header for the complete visible API key collection. Clients that perform a read-modify-write replacement should send this value back in `If-Match` on `PUT /api-keys`.
+
 Returns client API keys accepted by Home.
 
 Input: none.
@@ -1360,6 +1362,7 @@ Example response:
       "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
+      "display_name": "Production key",
       "user-id": 1,
       "user_id": 1,
       "channels": [1],
@@ -1372,6 +1375,7 @@ Example response:
       "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
+      "display_name": "Production key",
       "user-id": 1,
       "user_id": 1,
       "channels": [1],
@@ -1392,6 +1396,7 @@ Fields:
 | `APIKeyEntry.api_key_id` | integer | Alias of `id`. |
 | `APIKeyEntry.api-key` | string | Client API key. |
 | `APIKeyEntry.api_key` | string | Alias of `api-key`. |
+| `APIKeyEntry.display_name` | string or null | Optional editable display name. It is metadata only and does not affect authentication or bindings. |
 | `APIKeyEntry.user-id` | integer or null | Bound `user.id`; `null` means unbound. |
 | `APIKeyEntry.user_id` | integer or null | Alias of `user-id`. |
 | `APIKeyEntry.channels` | array of integer | Bound channel group IDs. An empty array is non-restrictive. |
@@ -1404,13 +1409,14 @@ Atomically creates one client API key without replacing the existing list.
 ```json
 {
   "api_key": "client-key-1",
+  "display_name": "Production key",
   "user_id": 1,
   "channels": [1],
   "model_groups": [2]
 }
 ```
 
-The request also accepts `api-key`, `key`, or `value` as the key field. `user-id` and `model-groups` are accepted as aliases.
+The request also accepts `api-key`, `key`, or `value` as the key field. `user-id` and `model-groups` are accepted as aliases. `display_name` is optional; surrounding whitespace is trimmed, and an empty string or `null` stores no display name. A display name may contain at most 128 Unicode characters and must not contain control characters. Invalid names return `400 invalid_display_name`.
 
 A new key value receives a new stable identifier. Re-adding an identical soft-deleted key restores the previous record and reuses its identifier. Creating an active duplicate returns `409 api_key_exists`.
 
@@ -1423,6 +1429,7 @@ Successful response:
     "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
+    "display_name": "Production key",
     "user-id": 1,
     "user_id": 1,
     "channels": [1],
@@ -1454,6 +1461,7 @@ Structured entries are also accepted. Wrapper keys can be `items`, `api-keys`, `
   "api_key_entries": [
     {
       "api_key": "client-key-1",
+      "display_name": "Production key",
       "user_id": 1,
       "channels": [1],
       "model_groups": [2]
@@ -1467,13 +1475,16 @@ Entry fields:
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `api_key` | string | conditionally | Client API key. Aliases: `api-key`, `key`, `value`. |
-| `user_id` | integer | no | Bound `user.id`. Alias: `user-id`. |
-| `channels` | array of integer | no | Channel group IDs. |
-| `model_groups` | array of integer | no | Model group IDs. Alias: `model-groups`. |
+| `display_name` | string or null | no | Optional display name, up to 128 Unicode characters with no control characters. Omit it to preserve the name of an unchanged key; send an empty string or `null` to clear it. |
+| `user_id` | integer or null | no | Bound `user.id`. Alias: `user-id`. Omit it to preserve an unchanged key's owner; send `0` or `null` to clear the binding. |
+| `channels` | array of integer | no | Channel group IDs. Omit it to preserve an unchanged key's channel bindings. |
+| `model_groups` | array of integer | no | Model group IDs. Alias: `model-groups`. Omit it to preserve an unchanged key's model-group bindings. |
 
 If `user_id` references a missing user, the API returns `404 user_not_found`.
 
-`PUT` is an explicit complete-list replacement operation with last-write-wins semantics. `id` and `api_key_id` are response-only for this operation and are ignored in structured input. Unchanged key values preserve their identifiers, removed values are soft-deleted, and new values receive new identifiers unless they restore an identical soft-deleted value.
+`PUT` is an explicit complete-list replacement operation with last-write-wins semantics. When the same key appears more than once, the last entry is used. `id` and `api_key_id` are response-only for this operation and are ignored in structured input. Unchanged key values preserve their identifiers, removed values are soft-deleted, and new values receive new identifiers unless they restore an identical soft-deleted value. For an existing key value, including a soft-deleted record being restored, omitting `display_name`, `user_id`, `channels`, or `model_groups` preserves the corresponding stored value; this also keeps raw string entries backward compatible. A key value with no existing record uses empty defaults for omitted fields.
+
+`If-Match` is optional for backward compatibility. When supplied, Home verifies one or more strong ETags atomically against the current collection ETag; a stale, weak, wildcard, or malformed validator returns `412 api_keys_precondition_failed` without changing any key. Omitting `If-Match` retains the legacy unconditional replacement behavior. An explicit empty array (`[]`, or one supported wrapper containing `[]`) deletes all keys. `null`, null/blank/invalid entries, missing key values, conflicting key aliases, or multiple wrapper aliases return `400` without changing the collection. `POST`, `PUT`, and `PATCH` request bodies are limited to 1 MiB; oversized requests return `413 request_body_too_large`.
 
 Successful response:
 
@@ -1483,7 +1494,7 @@ Successful response:
 
 ### PATCH `/api-keys`
 
-Updates one client API key. Stable `id` / `api_key_id` selection is preferred. Legacy `index`, `old/new`, and raw-key selectors remain available for compatibility and are resolved to one database record before the update is applied. When `old/new` is used and the old value does not exist, `new` is created atomically. This route can also update `user_id`, `channels`, and `model_groups` for an existing API key.
+Updates one client API key. Stable `id` / `api_key_id` selection is preferred. Legacy `index`, `old/new`, and raw-key selectors remain available for compatibility and are resolved to one database record before the update is applied. When `old/new` is used and the old value does not exist, `new` is created atomically. This route can also update `display_name`, `user_id`, `channels`, and `model_groups` for an existing API key.
 
 ID update:
 
@@ -1492,6 +1503,7 @@ ID update:
   "id": 1,
   "value": {
     "api_key": "new-key",
+    "display_name": "Production key",
     "user_id": 1,
     "channels": [1],
     "model_groups": [2]
@@ -1503,6 +1515,18 @@ Binding-only updates can select the record by ID without resending the key value
 
 ```json
 { "api_key_id": 1, "channels": [1] }
+```
+
+Display-name-only updates do not rotate the key or change its ownership and group bindings:
+
+```json
+{ "api_key_id": 1, "display_name": "Primary production key" }
+```
+
+Send an empty string or `null` to clear the display name:
+
+```json
+{ "api_key_id": 1, "display_name": null }
 ```
 
 Index update:
@@ -1544,7 +1568,8 @@ Fields:
 | `old` | string | conditionally | Old key to find. |
 | `new` | string | conditionally | New key; appended when `old` is not found. |
 | `api_key` | string | conditionally | Legacy raw-key target. When supplied with `id`, it must match the selected record. Aliases: `api-key`, `key`. |
-| `user_id` | integer | no | Bound `user.id`. Alias: `user-id`; `0` clears the binding. |
+| `display_name` | string or null | no | Replacement display name, up to 128 Unicode characters with no control characters. Surrounding whitespace is trimmed; an empty string or `null` clears it. |
+| `user_id` | integer or null | no | Bound `user.id`. Alias: `user-id`; `0` or `null` clears the binding. |
 | `channels` | array of integer | no | Channel group IDs. |
 | `model_groups` | array of integer | no | Model group IDs. Alias: `model-groups`. |
 
@@ -1557,6 +1582,7 @@ Successful response:
     "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
+    "display_name": "Primary production key",
     "user-id": 1,
     "user_id": 1,
     "channels": [1],

--- a/docs/management/api_CN.md
+++ b/docs/management/api_CN.md
@@ -1345,6 +1345,8 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
 
 ### GET `/api-keys`
 
+响应会包含表示完整可见 API key 集合的强 `ETag` header。执行“读取-修改-写回”全量替换的客户端，应在 `PUT /api-keys` 时通过 `If-Match` 回传该值。
+
 返回 Home 接受的客户端 API keys。
 
 输入：无。
@@ -1360,6 +1362,7 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
       "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
+      "display_name": "生产环境 key",
       "user-id": 1,
       "user_id": 1,
       "channels": [1],
@@ -1372,6 +1375,7 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
       "api_key_id": 1,
       "api-key": "client-key-1",
       "api_key": "client-key-1",
+      "display_name": "生产环境 key",
       "user-id": 1,
       "user_id": 1,
       "channels": [1],
@@ -1392,6 +1396,7 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
 | `APIKeyEntry.api_key_id` | integer | `id` 的 alias。 |
 | `APIKeyEntry.api-key` | string | 客户端 API key。 |
 | `APIKeyEntry.api_key` | string | `api-key` 的 alias。 |
+| `APIKeyEntry.display_name` | string or null | 可选、可编辑的展示名称；仅作为元数据，不影响鉴权或绑定。 |
 | `APIKeyEntry.user-id` | integer or null | 绑定的 `user.id`；`null` 表示未绑定。 |
 | `APIKeyEntry.user_id` | integer or null | `user-id` 的 alias。 |
 | `APIKeyEntry.channels` | array of integer | 绑定的 channel group IDs；空数组表示不限制。 |
@@ -1404,13 +1409,14 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
 ```json
 {
   "api_key": "client-key-1",
+  "display_name": "生产环境 key",
   "user_id": 1,
   "channels": [1],
   "model_groups": [2]
 }
 ```
 
-密钥字段也接受 `api-key`、`key` 或 `value`；`user-id` 和 `model-groups` 作为别名。
+密钥字段也接受 `api-key`、`key` 或 `value`；`user-id` 和 `model-groups` 作为别名。`display_name` 可选；首尾空白会被去除，空字符串或 `null` 表示不设置展示名称。展示名称最多包含 128 个 Unicode 字符且不能包含控制字符；无效名称返回 `400 invalid_display_name`。
 
 新的密钥值会获得新的稳定标识。如果重新添加与历史软删除记录完全相同的密钥值，则恢复原记录并复用原标识。创建已存在的活跃密钥会返回 `409 api_key_exists`。
 
@@ -1423,6 +1429,7 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
     "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
+    "display_name": "生产环境 key",
     "user-id": 1,
     "user_id": 1,
     "channels": [1],
@@ -1454,6 +1461,7 @@ JSON 语法错误，或请求体无法解析到足以可靠定位具体字段时
   "api_key_entries": [
     {
       "api_key": "client-key-1",
+      "display_name": "生产环境 key",
       "user_id": 1,
       "channels": [1],
       "model_groups": [2]
@@ -1467,13 +1475,16 @@ Entry 字段：
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `api_key` | string | 条件必填 | 客户端 API key；也接受 `api-key`、`key`、`value`。 |
-| `user_id` | integer | 否 | 绑定的 `user.id`；也接受 `user-id`。 |
-| `channels` | array of integer | 否 | Channel group IDs。 |
-| `model_groups` | array of integer | 否 | Model group IDs；也接受 `model-groups`。 |
+| `display_name` | string or null | 否 | 可选展示名称，最多 128 个 Unicode 字符且不能包含控制字符。对未变化的 key 省略该字段会保留原名称；传空字符串或 `null` 会清空名称。 |
+| `user_id` | integer or null | 否 | 绑定的 `user.id`；也接受 `user-id`。对未变化的 key 省略时保留原归属；传 `0` 或 `null` 清空绑定。 |
+| `channels` | array of integer | 否 | Channel group IDs；对未变化的 key 省略时保留原 channel 绑定。 |
+| `model_groups` | array of integer | 否 | Model group IDs；也接受 `model-groups`；对未变化的 key 省略时保留原 model group 绑定。 |
 
 如果 `user_id` 引用不存在的用户，接口返回 `404 user_not_found`。
 
-`PUT` 是显式的完整列表替换操作，采用 last-write-wins 语义。对于此操作，`id` 和 `api_key_id` 仅用于响应，在结构化输入中会被忽略。未改变的密钥值保留原标识，被移除的值会软删除，新值会获得新标识；如果新值恢复了完全相同的软删除记录，则复用原标识。
+`PUT` 是显式的完整列表替换操作，采用 last-write-wins 语义；同一 key 重复出现时使用最后一条。对于此操作，`id` 和 `api_key_id` 仅用于响应，在结构化输入中会被忽略。未改变的密钥值保留原标识，被移除的值会软删除，新值会获得新标识；如果新值恢复了完全相同的软删除记录，则复用原标识。对于已有 key 值（包括正在恢复的软删除记录），省略 `display_name`、`user_id`、`channels` 或 `model_groups` 会分别保留数据库中的值，因此原始字符串 entry 也保持兼容；数据库中不存在的新 key 对省略字段使用空默认值。
+
+为兼容旧客户端，`If-Match` 为可选 header。提供该 header 时，Home 会在同一事务内将一个或多个强 ETag 与当前集合 ETag 原子核对；过期、弱、通配符或格式错误的 validator 返回 `412 api_keys_precondition_failed`，且不会修改任何 key。不提供 `If-Match` 时保留旧版无条件替换行为。显式空数组（`[]`，或任一支持的 wrapper 包含 `[]`）表示删除全部 key；`null`、null/空白/无效 entry、缺少 key 值、互相冲突的 key alias 或同时提供多个 wrapper alias 都会返回 `400`，且不修改集合。`POST`、`PUT`、`PATCH` 请求体上限为 1 MiB；超过限制返回 `413 request_body_too_large`。
 
 成功输出：
 
@@ -1483,7 +1494,7 @@ Entry 字段：
 
 ### PATCH `/api-keys`
 
-更新一个客户端 API key。优先使用稳定的 `id` / `api_key_id` 定位。旧的 `index`、`old/new` 和原始 key selector 继续作为兼容方式，后端会先将其解析到一条数据库记录，再执行定向更新。使用 `old/new` 时，如果旧值不存在，会原子创建 `new`。此接口还可以更新已有 API key 的 `user_id`、`channels` 和 `model_groups`。
+更新一个客户端 API key。优先使用稳定的 `id` / `api_key_id` 定位。旧的 `index`、`old/new` 和原始 key selector 继续作为兼容方式，后端会先将其解析到一条数据库记录，再执行定向更新。使用 `old/new` 时，如果旧值不存在，会原子创建 `new`。此接口还可以更新已有 API key 的 `display_name`、`user_id`、`channels` 和 `model_groups`。
 
 按 ID 更新：
 
@@ -1492,6 +1503,7 @@ Entry 字段：
   "id": 1,
   "value": {
     "api_key": "new-key",
+    "display_name": "生产环境 key",
     "user_id": 1,
     "channels": [1],
     "model_groups": [2]
@@ -1503,6 +1515,18 @@ Entry 字段：
 
 ```json
 { "api_key_id": 1, "channels": [1] }
+```
+
+仅更新展示名称不会轮换 key，也不会改变归属和分组绑定：
+
+```json
+{ "api_key_id": 1, "display_name": "主生产 key" }
+```
+
+传空字符串或 `null` 可以清空展示名称：
+
+```json
+{ "api_key_id": 1, "display_name": null }
 ```
 
 按下标更新：
@@ -1544,7 +1568,8 @@ Entry 字段：
 | `old` | string | 条件必填 | 要查找的旧 key。 |
 | `new` | string | 条件必填 | 新 key；旧值不存在时追加。 |
 | `api_key` | string | 条件必填 | 旧版原始 key selector；和 `id` 同时提交时必须匹配该记录；也接受 `api-key`、`key`。 |
-| `user_id` | integer | 否 | 绑定的 `user.id`；也接受 `user-id`；传 `0` 清空绑定。 |
+| `display_name` | string or null | 否 | 替换展示名称，最多 128 个 Unicode 字符且不能包含控制字符；首尾空白会被去除，空字符串或 `null` 会清空名称。 |
+| `user_id` | integer or null | 否 | 绑定的 `user.id`；也接受 `user-id`；传 `0` 或 `null` 清空绑定。 |
 | `channels` | array of integer | 否 | Channel group IDs。 |
 | `model_groups` | array of integer | 否 | Model group IDs；也接受 `model-groups`。 |
 
@@ -1557,6 +1582,7 @@ Entry 字段：
     "api_key_id": 1,
     "api-key": "client-key-1",
     "api_key": "client-key-1",
+    "display_name": "主生产 key",
     "user-id": 1,
     "user_id": 1,
     "channels": [1],

--- a/internal/cluster/api_keys.go
+++ b/internal/cluster/api_keys.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"gorm.io/gorm"
 )
@@ -22,17 +25,21 @@ var ErrAPIKeySelectorMismatch = errors.New("api key selector mismatch")
 type APIKeyEntry struct {
 	ID          uint
 	APIKey      string
+	DisplayName *string
 	UserID      *uint
 	Channels    []uint
 	ModelGroups []uint
 }
 
 type APIKeyEntryUpdate struct {
-	ID          uint
-	APIKey      string
-	UserID      *uint
-	Channels    *[]uint
-	ModelGroups *[]uint
+	ID             uint
+	APIKey         string
+	DisplayName    *string
+	DisplayNameSet bool
+	UserID         *uint
+	UserIDSet      bool
+	Channels       *[]uint
+	ModelGroups    *[]uint
 }
 
 type APIKeyUserUpdate struct {
@@ -48,11 +55,22 @@ type APIKeySelector struct {
 }
 
 type APIKeyAdminUpdate struct {
-	APIKey      *string
-	UserID      *uint
-	Channels    *[]uint
-	ModelGroups *[]uint
+	APIKey         *string
+	DisplayName    *string
+	DisplayNameSet bool
+	UserID         *uint
+	Channels       *[]uint
+	ModelGroups    *[]uint
 }
+
+const APIKeyDisplayNameMaxLength = 128
+
+var ErrInvalidAPIKeyDisplayName = errors.New("API key display_name is invalid")
+
+// ErrAPIKeyPreconditionFailed indicates that a conditional full-list replacement used a stale ETag.
+var ErrAPIKeyPreconditionFailed = errors.New("API key collection precondition failed")
+
+const apiKeyMutationAdvisoryLockKey int64 = 749327842680272318
 
 // IsAPIKeyConflictError reports whether an error is an API key uniqueness conflict.
 func IsAPIKeyConflictError(err error) bool {
@@ -73,25 +91,44 @@ func (r *Repository) ListAPIKeyEntries(ctx context.Context) ([]APIKeyEntry, erro
 	if errDB != nil {
 		return nil, errDB
 	}
+	return listAPIKeyEntriesTx(ctx, db)
+}
 
-	var records []APIKeyRecord
-	if errFind := db.WithContext(contextOrBackground(ctx)).Order("id").Find(&records).Error; errFind != nil {
-		return nil, errFind
+// ListAPIKeyEntriesWithETag returns one coherent collection representation and
+// a strong ETag that can guard a later full-list replacement.
+func (r *Repository) ListAPIKeyEntriesWithETag(ctx context.Context) ([]APIKeyEntry, string, error) {
+	db, errDB := r.database()
+	if errDB != nil {
+		return nil, "", errDB
 	}
 
-	out := make([]APIKeyEntry, 0, len(records))
-	for _, record := range records {
-		entry, errEntry := apiKeyEntryFromRecord(&record)
-		if errEntry != nil {
-			return nil, errEntry
+	ctx = contextOrBackground(ctx)
+	var entries []APIKeyEntry
+	var etag string
+	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyReadTransaction(tx); errLock != nil {
+			return errLock
 		}
-		out = append(out, entry)
-	}
-	return out, nil
+		var errEntries error
+		entries, errEntries = listAPIKeyEntriesTx(ctx, tx)
+		if errEntries != nil {
+			return errEntries
+		}
+		var errETag error
+		etag, errETag = apiKeyEntriesETag(entries)
+		return errETag
+	})
+	return entries, etag, errTransaction
 }
 
 // ReplaceAPIKeyEntries replaces active API key rows and updates explicit channel bindings.
 func (r *Repository) ReplaceAPIKeyEntries(ctx context.Context, entries []APIKeyEntryUpdate) (APIKeyUpsertStats, error) {
+	return r.ReplaceAPIKeyEntriesIfMatch(ctx, entries, nil)
+}
+
+// ReplaceAPIKeyEntriesIfMatch replaces active API key rows after optionally
+// verifying the collection ETag inside the mutation transaction.
+func (r *Repository) ReplaceAPIKeyEntriesIfMatch(ctx context.Context, entries []APIKeyEntryUpdate, ifMatch *string) (APIKeyUpsertStats, error) {
 	db, errDB := r.database()
 	if errDB != nil {
 		return APIKeyUpsertStats{}, errDB
@@ -100,6 +137,22 @@ func (r *Repository) ReplaceAPIKeyEntries(ctx context.Context, entries []APIKeyE
 	ctx = contextOrBackground(ctx)
 	var stats APIKeyUpsertStats
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
+		if ifMatch != nil {
+			currentEntries, errEntries := listAPIKeyEntriesTx(ctx, tx)
+			if errEntries != nil {
+				return errEntries
+			}
+			currentETag, errETag := apiKeyEntriesETag(currentEntries)
+			if errETag != nil {
+				return errETag
+			}
+			if !apiKeyETagMatches(*ifMatch, currentETag) {
+				return ErrAPIKeyPreconditionFailed
+			}
+		}
 		var errReplace error
 		stats, errReplace = replaceAPIKeyEntriesTxWithStats(ctx, tx, entries)
 		if errReplace != nil {
@@ -109,7 +162,10 @@ func (r *Repository) ReplaceAPIKeyEntries(ctx context.Context, entries []APIKeyE
 		if deleteResult.Error != nil {
 			return deleteResult.Error
 		}
-		if !stats.Changed() && deleteResult.RowsAffected == 0 {
+		if deleteResult.RowsAffected > 0 {
+			stats.RuntimeChanged = true
+		}
+		if !stats.RequiresRuntimeRefresh() && deleteResult.RowsAffected == 0 {
 			return nil
 		}
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
@@ -119,22 +175,37 @@ func (r *Repository) ReplaceAPIKeyEntries(ctx context.Context, entries []APIKeyE
 
 // CreateAPIKey creates or restores one API key without replacing the full key list.
 func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate) (*APIKeyRecord, error) {
+	record, _, errCreate := r.CreateAPIKeyWithRuntimeChange(ctx, update)
+	return record, errCreate
+}
+
+// CreateAPIKeyWithRuntimeChange creates or restores one API key and reports
+// whether the accepted runtime key set changed.
+func (r *Repository) CreateAPIKeyWithRuntimeChange(ctx context.Context, update APIKeyEntryUpdate) (*APIKeyRecord, bool, error) {
 	db, errDB := r.database()
 	if errDB != nil {
-		return nil, errDB
+		return nil, false, errDB
 	}
 	key := strings.TrimSpace(update.APIKey)
 	if key == "" {
-		return nil, fmt.Errorf("api key is required")
+		return nil, false, fmt.Errorf("api key is required")
 	}
 
 	userID := normalizeOptionalUserID(update.UserID)
+	var displayName *string
+	if update.DisplayNameSet {
+		var errDisplayName error
+		displayName, errDisplayName = normalizeAPIKeyDisplayName(update.DisplayName)
+		if errDisplayName != nil {
+			return nil, false, errDisplayName
+		}
+	}
 	channelsJSON := emptyAPIKeyChannelsJSON()
 	if update.Channels != nil {
 		var errChannels error
 		channelsJSON, errChannels = apiKeyChannelsJSON(*update.Channels)
 		if errChannels != nil {
-			return nil, errChannels
+			return nil, false, errChannels
 		}
 	}
 	modelGroupsJSON := emptyAPIKeyModelGroupsJSON()
@@ -142,13 +213,16 @@ func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate)
 		var errModelGroups error
 		modelGroupsJSON, errModelGroups = apiKeyModelGroupsJSON(*update.ModelGroups)
 		if errModelGroups != nil {
-			return nil, errModelGroups
+			return nil, false, errModelGroups
 		}
 	}
 
 	record := &APIKeyRecord{}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		if userID != nil {
 			if errUser := ensureUserExists(ctx, tx, *userID); errUser != nil {
 				return errUser
@@ -160,6 +234,7 @@ func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate)
 		switch {
 		case errors.Is(errFirst, gorm.ErrRecordNotFound):
 			record.APIKey = key
+			record.DisplayName = displayName
 			record.UserID = userID
 			record.Channels = channelsJSON
 			record.ModelGroups = modelGroupsJSON
@@ -172,15 +247,19 @@ func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate)
 		case errFirst != nil:
 			return errFirst
 		case existing.DeletedAt.Valid:
+			updates := map[string]any{
+				"user_id":      userID,
+				"channels":     channelsJSON,
+				"model_groups": modelGroupsJSON,
+				"deleted_at":   nil,
+			}
+			if update.DisplayNameSet {
+				updates["display_name"] = displayName
+			}
 			if errRestore := tx.WithContext(ctx).Unscoped().
 				Model(&APIKeyRecord{}).
 				Where("id = ?", existing.ID).
-				Updates(map[string]any{
-					"user_id":      userID,
-					"channels":     channelsJSON,
-					"model_groups": modelGroupsJSON,
-					"deleted_at":   nil,
-				}).Error; errRestore != nil {
+				Updates(updates).Error; errRestore != nil {
 				return errRestore
 			}
 			if errReload := tx.WithContext(ctx).Where("id = ?", existing.ID).First(record).Error; errReload != nil {
@@ -193,27 +272,39 @@ func (r *Repository) CreateAPIKey(ctx context.Context, update APIKeyEntryUpdate)
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
 	if errTransaction != nil {
-		return nil, errTransaction
+		return nil, false, errTransaction
 	}
-	return record, nil
+	return record, true, nil
 }
 
 // UpdateAPIKey updates one API key selected by stable ID or a legacy selector.
 func (r *Repository) UpdateAPIKey(ctx context.Context, selector APIKeySelector, update APIKeyAdminUpdate) (*APIKeyRecord, error) {
+	record, _, errUpdate := r.UpdateAPIKeyWithRuntimeChange(ctx, selector, update)
+	return record, errUpdate
+}
+
+// UpdateAPIKeyWithRuntimeChange updates one API key and reports whether the
+// accepted runtime key set or dispatch-affecting bindings changed.
+func (r *Repository) UpdateAPIKeyWithRuntimeChange(ctx context.Context, selector APIKeySelector, update APIKeyAdminUpdate) (*APIKeyRecord, bool, error) {
 	db, errDB := r.database()
 	if errDB != nil {
-		return nil, errDB
+		return nil, false, errDB
 	}
 	if errSelector := validateAPIKeySelector(selector); errSelector != nil {
-		return nil, errSelector
+		return nil, false, errSelector
 	}
 
 	record := &APIKeyRecord{}
+	runtimeChanged := false
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		if errFind := findAPIKeyRecord(ctx, tx, selector, record); errFind != nil {
 			return errFind
 		}
+		updates := make(map[string]any)
 		if update.APIKey != nil {
 			nextKey := strings.TrimSpace(*update.APIKey)
 			if nextKey == "" {
@@ -224,7 +315,19 @@ func (r *Repository) UpdateAPIKey(ctx context.Context, selector APIKeySelector, 
 					return errAvailable
 				}
 			}
-			record.APIKey = nextKey
+			if nextKey != strings.TrimSpace(record.APIKey) {
+				updates["api_key"] = nextKey
+				runtimeChanged = true
+			}
+		}
+		if update.DisplayNameSet {
+			nextDisplayName, errDisplayName := normalizeAPIKeyDisplayName(update.DisplayName)
+			if errDisplayName != nil {
+				return errDisplayName
+			}
+			if !sameOptionalString(record.DisplayName, nextDisplayName) {
+				updates["display_name"] = nextDisplayName
+			}
 		}
 		if update.UserID != nil {
 			nextUserID := normalizeOptionalUserID(update.UserID)
@@ -233,34 +336,60 @@ func (r *Repository) UpdateAPIKey(ctx context.Context, selector APIKeySelector, 
 					return errUser
 				}
 			}
-			record.UserID = nextUserID
+			if !sameOptionalUint(record.UserID, nextUserID) {
+				updates["user_id"] = nextUserID
+				runtimeChanged = true
+			}
 		}
 		if update.Channels != nil {
 			channelsJSON, errChannels := apiKeyChannelsJSON(*update.Channels)
 			if errChannels != nil {
 				return errChannels
 			}
-			record.Channels = channelsJSON
+			currentChannels, errCurrent := apiKeyChannelsFromJSON(record.Channels)
+			if errCurrent != nil {
+				return errCurrent
+			}
+			if !reflect.DeepEqual(currentChannels, normalizeChannelGroupIDs(*update.Channels)) {
+				updates["channels"] = channelsJSON
+				runtimeChanged = true
+			}
 		}
 		if update.ModelGroups != nil {
 			modelGroupsJSON, errModelGroups := apiKeyModelGroupsJSON(*update.ModelGroups)
 			if errModelGroups != nil {
 				return errModelGroups
 			}
-			record.ModelGroups = modelGroupsJSON
+			currentModelGroups, errCurrent := apiKeyModelGroupsFromJSON(record.ModelGroups)
+			if errCurrent != nil {
+				return errCurrent
+			}
+			if !reflect.DeepEqual(currentModelGroups, normalizeModelGroupIDs(*update.ModelGroups)) {
+				updates["model_groups"] = modelGroupsJSON
+				runtimeChanged = true
+			}
 		}
-		if errSave := tx.WithContext(ctx).Save(record).Error; errSave != nil {
-			if IsAPIKeyConflictError(errSave) {
+		if len(updates) == 0 {
+			return nil
+		}
+		if errUpdate := tx.WithContext(ctx).Model(&APIKeyRecord{}).Where("id = ?", record.ID).Updates(updates).Error; errUpdate != nil {
+			if IsAPIKeyConflictError(errUpdate) {
 				return ErrAPIKeyExists
 			}
-			return errSave
+			return errUpdate
+		}
+		if errReload := tx.WithContext(ctx).Where("id = ?", record.ID).First(record).Error; errReload != nil {
+			return errReload
+		}
+		if !runtimeChanged {
+			return nil
 		}
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
 	if errTransaction != nil {
-		return nil, errTransaction
+		return nil, false, errTransaction
 	}
-	return record, nil
+	return record, runtimeChanged, nil
 }
 
 // DeleteAPIKey deletes one API key selected by stable ID or a legacy selector.
@@ -275,6 +404,9 @@ func (r *Repository) DeleteAPIKey(ctx context.Context, selector APIKeySelector) 
 
 	ctx = contextOrBackground(ctx)
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		record := &APIKeyRecord{}
 		if errFind := findAPIKeyRecord(ctx, tx, selector, record); errFind != nil {
 			return errFind
@@ -339,9 +471,13 @@ func (r *Repository) UpdateAPIKeyBindings(ctx context.Context, apiKey string, us
 	record := &APIKeyRecord{}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		if errFirst := tx.Where("api_key = ?", apiKey).First(record).Error; errFirst != nil {
 			return errFirst
 		}
+		updates := make(map[string]any)
 		if userID != nil {
 			nextUserID := normalizeOptionalUserID(userID)
 			if nextUserID != nil {
@@ -349,24 +485,29 @@ func (r *Repository) UpdateAPIKeyBindings(ctx context.Context, apiKey string, us
 					return errUser
 				}
 			}
-			record.UserID = nextUserID
+			updates["user_id"] = nextUserID
 		}
 		if channels != nil {
 			channelsJSON, errChannels := apiKeyChannelsJSON(*channels)
 			if errChannels != nil {
 				return errChannels
 			}
-			record.Channels = channelsJSON
+			updates["channels"] = channelsJSON
 		}
 		if modelGroups != nil {
 			modelGroupsJSON, errModelGroups := apiKeyModelGroupsJSON(*modelGroups)
 			if errModelGroups != nil {
 				return errModelGroups
 			}
-			record.ModelGroups = modelGroupsJSON
+			updates["model_groups"] = modelGroupsJSON
 		}
-		if errSave := tx.Save(record).Error; errSave != nil {
-			return errSave
+		if len(updates) > 0 {
+			if errUpdate := tx.WithContext(ctx).Model(&APIKeyRecord{}).Where("id = ?", record.ID).Updates(updates).Error; errUpdate != nil {
+				return errUpdate
+			}
+			if errReload := tx.WithContext(ctx).Where("id = ?", record.ID).First(record).Error; errReload != nil {
+				return errReload
+			}
 		}
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
@@ -414,6 +555,9 @@ func (r *Repository) CreateAPIKeyForUser(ctx context.Context, userID uint, updat
 	record := &APIKeyRecord{}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		if errUser := ensureUserExists(ctx, tx, userID); errUser != nil {
 			return errUser
 		}
@@ -466,12 +610,15 @@ func (r *Repository) CreateAPIKeyForUser(ctx context.Context, userID uint, updat
 			if !sameOptionalUint(existing.UserID, &userID) {
 				return ErrAPIKeyExists
 			}
-			existing.Channels = channelsJSON
-			existing.ModelGroups = modelGroupsJSON
-			if errSave := tx.WithContext(ctx).Save(existing).Error; errSave != nil {
-				return errSave
+			if errUpdate := tx.WithContext(ctx).Model(&APIKeyRecord{}).Where("id = ?", existing.ID).Updates(map[string]any{
+				"channels":     channelsJSON,
+				"model_groups": modelGroupsJSON,
+			}).Error; errUpdate != nil {
+				return errUpdate
 			}
-			record = existing
+			if errReload := tx.WithContext(ctx).Where("id = ?", existing.ID).First(record).Error; errReload != nil {
+				return errReload
+			}
 		}
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
@@ -498,6 +645,9 @@ func (r *Repository) UpdateAPIKeyForUser(ctx context.Context, userID uint, id ui
 	record := &APIKeyRecord{}
 	ctx = contextOrBackground(ctx)
 	errTransaction := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		query := tx.WithContext(ctx).Where("user_id = ?", userID)
 		if id > 0 {
 			query = query.Where("id = ?", id)
@@ -507,6 +657,7 @@ func (r *Repository) UpdateAPIKeyForUser(ctx context.Context, userID uint, id ui
 		if errFirst := query.First(record).Error; errFirst != nil {
 			return errFirst
 		}
+		updates := make(map[string]any)
 		if update.APIKey != nil {
 			nextKey := strings.TrimSpace(*update.APIKey)
 			if nextKey == "" {
@@ -517,24 +668,34 @@ func (r *Repository) UpdateAPIKeyForUser(ctx context.Context, userID uint, id ui
 					return errAvailable
 				}
 			}
-			record.APIKey = nextKey
+			if nextKey != strings.TrimSpace(record.APIKey) {
+				updates["api_key"] = nextKey
+			}
 		}
 		if update.Channels != nil {
 			channelsJSON, errChannels := apiKeyChannelsJSON(*update.Channels)
 			if errChannels != nil {
 				return errChannels
 			}
-			record.Channels = channelsJSON
+			updates["channels"] = channelsJSON
 		}
 		if update.ModelGroups != nil {
 			modelGroupsJSON, errModelGroups := apiKeyModelGroupsJSON(*update.ModelGroups)
 			if errModelGroups != nil {
 				return errModelGroups
 			}
-			record.ModelGroups = modelGroupsJSON
+			updates["model_groups"] = modelGroupsJSON
 		}
-		if errSave := tx.Save(record).Error; errSave != nil {
-			return errSave
+		if len(updates) > 0 {
+			if errUpdate := tx.WithContext(ctx).Model(&APIKeyRecord{}).Where("id = ?", record.ID).Updates(updates).Error; errUpdate != nil {
+				if IsAPIKeyConflictError(errUpdate) {
+					return ErrAPIKeyExists
+				}
+				return errUpdate
+			}
+			if errReload := tx.WithContext(ctx).Where("id = ?", record.ID).First(record).Error; errReload != nil {
+				return errReload
+			}
 		}
 		return appendEvent(tx, "config", "upsert", configAPIKeysRootKey, time.Now().UTC().UnixNano())
 	})
@@ -586,6 +747,9 @@ func (r *Repository) DeleteAPIKeyForUser(ctx context.Context, userID uint, id ui
 
 	ctx = contextOrBackground(ctx)
 	return db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		query := tx.WithContext(ctx).Where("user_id = ?", userID)
 		if id > 0 {
 			query = query.Where("id = ?", id)
@@ -1043,7 +1207,16 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 			continue
 		}
 		userID := normalizeOptionalUserID(entry.UserID)
-		if userID != nil {
+		userIDSet := entry.UserIDSet || entry.UserID != nil
+		var displayName *string
+		if entry.DisplayNameSet {
+			var errDisplayName error
+			displayName, errDisplayName = normalizeAPIKeyDisplayName(entry.DisplayName)
+			if errDisplayName != nil {
+				return APIKeyUpsertStats{}, errDisplayName
+			}
+		}
+		if userIDSet && userID != nil {
 			if errUser := ensureUserExists(ctx, tx, *userID); errUser != nil {
 				return APIKeyUpsertStats{}, errUser
 			}
@@ -1079,16 +1252,23 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 			if record.DeletedAt.Valid {
 				updates["deleted_at"] = nil
 				stats.Restored++
+				stats.RuntimeChanged = true
 			} else {
 				stats.Unchanged++
 			}
 			if strings.TrimSpace(record.APIKey) != key {
 				updates["api_key"] = key
 				updatedEntry = true
+				stats.RuntimeChanged = true
 			}
-			if !sameOptionalUint(record.UserID, userID) {
+			if entry.DisplayNameSet && !sameOptionalString(record.DisplayName, displayName) {
+				updates["display_name"] = displayName
+				updatedEntry = true
+			}
+			if userIDSet && !sameOptionalUint(record.UserID, userID) {
 				updates["user_id"] = userID
 				updatedEntry = true
+				stats.RuntimeChanged = true
 			}
 			if entry.Channels != nil {
 				currentChannels, errCurrent := apiKeyChannelsFromJSON(record.Channels)
@@ -1098,6 +1278,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 				if !reflect.DeepEqual(currentChannels, normalizeChannelGroupIDs(*entry.Channels)) {
 					updates["channels"] = channelsJSON
 					updatedEntry = true
+					stats.RuntimeChanged = true
 				}
 			}
 			if entry.ModelGroups != nil {
@@ -1108,6 +1289,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 				if !reflect.DeepEqual(currentModelGroups, normalizeModelGroupIDs(*entry.ModelGroups)) {
 					updates["model_groups"] = modelGroupsJSON
 					updatedEntry = true
+					stats.RuntimeChanged = true
 				}
 			}
 			if updatedEntry && !record.DeletedAt.Valid {
@@ -1127,6 +1309,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 
 		created := APIKeyRecord{
 			APIKey:      key,
+			DisplayName: displayName,
 			UserID:      userID,
 			Channels:    channelsJSON,
 			ModelGroups: modelGroupsJSON,
@@ -1136,6 +1319,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 		}
 		keepIDs[created.ID] = struct{}{}
 		stats.Created++
+		stats.RuntimeChanged = true
 	}
 
 	for _, record := range existing {
@@ -1149,6 +1333,7 @@ func replaceAPIKeyEntriesTxWithStats(ctx context.Context, tx *gorm.DB, entries [
 			return APIKeyUpsertStats{}, errDelete
 		}
 		stats.Removed++
+		stats.RuntimeChanged = true
 	}
 	return stats, nil
 }
@@ -1159,7 +1344,8 @@ func normalizeAPIKeyEntryUpdates(entries []APIKeyEntryUpdate) []APIKeyEntryUpdat
 	}
 	normalized := make([]APIKeyEntryUpdate, 0, len(entries))
 	seen := make(map[string]struct{}, len(entries))
-	for _, entry := range entries {
+	for index := len(entries) - 1; index >= 0; index-- {
+		entry := entries[index]
 		key := strings.TrimSpace(entry.APIKey)
 		if key == "" {
 			continue
@@ -1168,7 +1354,10 @@ func normalizeAPIKeyEntryUpdates(entries []APIKeyEntryUpdate) []APIKeyEntryUpdat
 			continue
 		}
 		seen[key] = struct{}{}
-		next := APIKeyEntryUpdate{ID: entry.ID, APIKey: key}
+		next := APIKeyEntryUpdate{ID: entry.ID, APIKey: key, DisplayNameSet: entry.DisplayNameSet, UserIDSet: entry.UserIDSet || entry.UserID != nil}
+		if entry.DisplayNameSet {
+			next.DisplayName = entry.DisplayName
+		}
 		next.UserID = normalizeOptionalUserID(entry.UserID)
 		if entry.Channels != nil {
 			channels := normalizeChannelGroupIDs(*entry.Channels)
@@ -1180,7 +1369,96 @@ func normalizeAPIKeyEntryUpdates(entries []APIKeyEntryUpdate) []APIKeyEntryUpdat
 		}
 		normalized = append(normalized, next)
 	}
+	for left, right := 0, len(normalized)-1; left < right; left, right = left+1, right-1 {
+		normalized[left], normalized[right] = normalized[right], normalized[left]
+	}
 	return normalized
+}
+
+func lockAPIKeyMutationTransaction(tx *gorm.DB) error {
+	if tx == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	if tx.Dialector == nil || tx.Dialector.Name() != "postgres" {
+		return nil
+	}
+	return tx.Exec("SELECT pg_advisory_xact_lock(?)", apiKeyMutationAdvisoryLockKey).Error
+}
+
+func lockAPIKeyReadTransaction(tx *gorm.DB) error {
+	if tx == nil {
+		return fmt.Errorf("database connection is nil")
+	}
+	if tx.Dialector == nil || tx.Dialector.Name() != "postgres" {
+		return nil
+	}
+	return tx.Exec("SELECT pg_advisory_xact_lock_shared(?)", apiKeyMutationAdvisoryLockKey).Error
+}
+
+func listAPIKeyEntriesTx(ctx context.Context, db *gorm.DB) ([]APIKeyEntry, error) {
+	if db == nil {
+		return nil, fmt.Errorf("database connection is nil")
+	}
+	var records []APIKeyRecord
+	if errFind := db.WithContext(contextOrBackground(ctx)).Order("id").Find(&records).Error; errFind != nil {
+		return nil, errFind
+	}
+	entries := make([]APIKeyEntry, 0, len(records))
+	for i := range records {
+		entry, errEntry := apiKeyEntryFromRecord(&records[i])
+		if errEntry != nil {
+			return nil, errEntry
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func apiKeyEntriesETag(entries []APIKeyEntry) (string, error) {
+	hasher := sha256.New()
+	encoder := json.NewEncoder(hasher)
+	encoder.SetEscapeHTML(false)
+	for i := range entries {
+		entry := entries[i]
+		fingerprint := struct {
+			ID          uint    `json:"id"`
+			APIKey      string  `json:"api_key"`
+			DisplayName *string `json:"display_name"`
+			UserID      *uint   `json:"user_id"`
+			Channels    []uint  `json:"channels"`
+			ModelGroups []uint  `json:"model_groups"`
+		}{
+			ID:          entry.ID,
+			APIKey:      entry.APIKey,
+			DisplayName: entry.DisplayName,
+			UserID:      entry.UserID,
+			Channels:    entry.Channels,
+			ModelGroups: entry.ModelGroups,
+		}
+		if errEncode := encoder.Encode(fingerprint); errEncode != nil {
+			return "", errEncode
+		}
+	}
+	return fmt.Sprintf(`"%x"`, hasher.Sum(nil)), nil
+}
+
+func apiKeyETagMatches(ifMatch string, current string) bool {
+	current = strings.TrimSpace(current)
+	matched := false
+	for _, candidate := range strings.Split(ifMatch, ",") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == "*" || strings.HasPrefix(candidate, "W/") || !isQuotedAPIKeyETag(candidate) {
+			return false
+		}
+		if candidate == current {
+			matched = true
+		}
+	}
+	return matched
+}
+
+func isQuotedAPIKeyETag(value string) bool {
+	return len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"'
 }
 
 func apiKeyEntryFromRecord(record *APIKeyRecord) (APIKeyEntry, error) {
@@ -1198,6 +1476,7 @@ func apiKeyEntryFromRecord(record *APIKeyRecord) (APIKeyEntry, error) {
 	return APIKeyEntry{
 		ID:          record.ID,
 		APIKey:      strings.TrimSpace(record.APIKey),
+		DisplayName: normalizedAPIKeyDisplayName(record.DisplayName),
 		UserID:      normalizeOptionalUserID(record.UserID),
 		Channels:    channels,
 		ModelGroups: modelGroups,
@@ -1238,6 +1517,49 @@ func emptyAPIKeyModelGroupsJSON() JSONB {
 func sameOptionalUint(left *uint, right *uint) bool {
 	left = normalizeOptionalUserID(left)
 	right = normalizeOptionalUserID(right)
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func normalizeAPIKeyDisplayName(displayName *string) (*string, error) {
+	if displayName == nil {
+		return nil, nil
+	}
+	value := *displayName
+	if !utf8.ValidString(value) {
+		return nil, fmt.Errorf("%w: invalid UTF-8", ErrInvalidAPIKeyDisplayName)
+	}
+	for _, character := range value {
+		if unicode.IsControl(character) {
+			return nil, fmt.Errorf("%w: control characters are not allowed", ErrInvalidAPIKeyDisplayName)
+		}
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	if utf8.RuneCountInString(value) > APIKeyDisplayNameMaxLength {
+		return nil, fmt.Errorf("%w: length exceeds %d characters", ErrInvalidAPIKeyDisplayName, APIKeyDisplayNameMaxLength)
+	}
+	return &value, nil
+}
+
+func normalizedAPIKeyDisplayName(displayName *string) *string {
+	if displayName == nil {
+		return nil
+	}
+	value := strings.TrimSpace(*displayName)
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func sameOptionalString(left *string, right *string) bool {
+	left = normalizedAPIKeyDisplayName(left)
+	right = normalizedAPIKeyDisplayName(right)
 	if left == nil || right == nil {
 		return left == nil && right == nil
 	}

--- a/internal/cluster/api_keys_test.go
+++ b/internal/cluster/api_keys_test.go
@@ -1,11 +1,302 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
 	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
+
+func TestAutoMigrateAddsNullableAPIKeyDisplayName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}()
+
+	if errCreateLegacy := db.Exec(`CREATE TABLE api_key (
+		id integer PRIMARY KEY AUTOINCREMENT,
+		api_key text NOT NULL UNIQUE,
+		user_id integer,
+		channels text,
+		model_groups text,
+		created_at datetime,
+		updated_at datetime,
+		deleted_at datetime
+	)`).Error; errCreateLegacy != nil {
+		t.Fatalf("create legacy api_key table: %v", errCreateLegacy)
+	}
+	if errSeed := db.Exec(`INSERT INTO api_key (api_key, channels, model_groups) VALUES (?, ?, ?)`, "legacy-key", "[]", "[]").Error; errSeed != nil {
+		t.Fatalf("seed legacy api_key row: %v", errSeed)
+	}
+
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	if !db.Migrator().HasColumn(&APIKeyRecord{}, "display_name") {
+		t.Fatal("AutoMigrate() did not add api_key.display_name")
+	}
+	var record APIKeyRecord
+	if errFirst := db.First(&record, "api_key = ?", "legacy-key").Error; errFirst != nil {
+		t.Fatalf("load migrated API key: %v", errFirst)
+	}
+	if record.DisplayName != nil || record.APIKey != "legacy-key" {
+		t.Fatalf("migrated record = %#v, want unchanged key and null display name", record)
+	}
+}
+
+func TestAPIKeyMutationLocksUsePostgresAdvisoryLock(t *testing.T) {
+	var logs bytes.Buffer
+	db, errOpen := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=127.0.0.1 user=cliproxy dbname=cliproxy_home sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		DisableAutomaticPing: true,
+		DryRun:               true,
+		Logger: logger.New(log.New(&logs, "", 0), logger.Config{
+			LogLevel: logger.Info,
+		}),
+	})
+	if errOpen != nil {
+		t.Fatalf("open postgres dry-run db: %v", errOpen)
+	}
+
+	if errLock := lockAPIKeyMutationTransaction(db); errLock != nil {
+		t.Fatalf("lockAPIKeyMutationTransaction() error = %v", errLock)
+	}
+	if errLock := lockAPIKeyReadTransaction(db); errLock != nil {
+		t.Fatalf("lockAPIKeyReadTransaction() error = %v", errLock)
+	}
+	output := logs.String()
+	if !strings.Contains(output, "pg_advisory_xact_lock") ||
+		!strings.Contains(output, "pg_advisory_xact_lock_shared") ||
+		!strings.Contains(output, strconv.FormatInt(apiKeyMutationAdvisoryLockKey, 10)) {
+		t.Fatalf("postgres API key advisory lock SQL = %q", output)
+	}
+}
+
+func TestAPIKeyETagMatchesRequiresStrongValidators(t *testing.T) {
+	current := `"current"`
+	if !apiKeyETagMatches(current, current) || !apiKeyETagMatches(`"stale", "current"`, current) {
+		t.Fatal("strong matching ETag was rejected")
+	}
+	for _, candidate := range []string{"*", `W/"current"`, "current", `"current", W/"stale"`, ""} {
+		if apiKeyETagMatches(candidate, current) {
+			t.Fatalf("invalid or weak If-Match %q was accepted", candidate)
+		}
+	}
+}
+
+func TestCreateAPIKeyIgnoresDisplayNameWithoutPresenceFlag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, errOpenSQLite := OpenSQLite(ctx, filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("get sqlite db: %v", errDB)
+	}
+	t.Cleanup(func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	})
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+
+	displayName := "should be ignored"
+	record, errCreate := NewRepository(db).CreateAPIKey(ctx, APIKeyEntryUpdate{
+		APIKey:      "presence-flag-key",
+		DisplayName: &displayName,
+	})
+	if errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+	if record.DisplayName != nil {
+		t.Fatalf("created display name = %q, want null without DisplayNameSet", *record.DisplayName)
+	}
+}
+
+func TestAPIKeyDisplayNameValidationAndRuntimeChangeEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, repo := openAPIKeyTestRepository(t)
+	displayName := "Initial name"
+	record, runtimeChanged, errCreate := repo.CreateAPIKeyWithRuntimeChange(ctx, APIKeyEntryUpdate{
+		APIKey:         "runtime-change-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+	})
+	if errCreate != nil || !runtimeChanged {
+		t.Fatalf("CreateAPIKeyWithRuntimeChange() = %#v, %t, %v", record, runtimeChanged, errCreate)
+	}
+	eventsAfterCreate := apiKeyEventCount(t, db)
+
+	renamed := "Renamed metadata"
+	updated, runtimeChanged, errRename := repo.UpdateAPIKeyWithRuntimeChange(ctx, APIKeySelector{ID: record.ID}, APIKeyAdminUpdate{
+		DisplayName:    &renamed,
+		DisplayNameSet: true,
+	})
+	if errRename != nil || runtimeChanged {
+		t.Fatalf("name-only UpdateAPIKeyWithRuntimeChange() = %#v, %t, %v", updated, runtimeChanged, errRename)
+	}
+	if updated.DisplayName == nil || *updated.DisplayName != renamed {
+		t.Fatalf("updated display name = %v, want %q", updated.DisplayName, renamed)
+	}
+	if got := apiKeyEventCount(t, db); got != eventsAfterCreate {
+		t.Fatalf("events after name-only update = %d, want %d", got, eventsAfterCreate)
+	}
+
+	rotatedKey := "runtime-change-key-rotated"
+	_, runtimeChanged, errRotate := repo.UpdateAPIKeyWithRuntimeChange(ctx, APIKeySelector{ID: record.ID}, APIKeyAdminUpdate{APIKey: &rotatedKey})
+	if errRotate != nil || !runtimeChanged {
+		t.Fatalf("key rotation UpdateAPIKeyWithRuntimeChange() runtimeChanged=%t error=%v", runtimeChanged, errRotate)
+	}
+	if got := apiKeyEventCount(t, db); got != eventsAfterCreate+1 {
+		t.Fatalf("events after key rotation = %d, want %d", got, eventsAfterCreate+1)
+	}
+
+	for _, testCase := range []struct {
+		name  string
+		value string
+	}{
+		{name: "too long", value: strings.Repeat("名", APIKeyDisplayNameMaxLength+1)},
+		{name: "control character", value: "invalid\nname"},
+		{name: "leading control character", value: "\tinvalid"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			before := apiKeyEventCount(t, db)
+			_, _, errUpdate := repo.UpdateAPIKeyWithRuntimeChange(ctx, APIKeySelector{ID: record.ID}, APIKeyAdminUpdate{
+				DisplayName:    &testCase.value,
+				DisplayNameSet: true,
+			})
+			if !errors.Is(errUpdate, ErrInvalidAPIKeyDisplayName) {
+				t.Fatalf("UpdateAPIKeyWithRuntimeChange() error = %v, want ErrInvalidAPIKeyDisplayName", errUpdate)
+			}
+			if got := apiKeyEventCount(t, db); got != before {
+				t.Fatalf("events after rejected name = %d, want %d", got, before)
+			}
+			entry, errEntry := repo.ListAPIKeyEntries(ctx)
+			if errEntry != nil || len(entry) != 1 || entry[0].DisplayName == nil || *entry[0].DisplayName != renamed {
+				t.Fatalf("entry after rejected name = %#v, %v", entry, errEntry)
+			}
+		})
+	}
+}
+
+func TestAPIKeySparseWritePathsPreserveDisplayName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	_, repo := openAPIKeyTestRepository(t)
+	username := "sparse-write-user"
+	user, errUser := repo.CreateUser(ctx, UserUpdate{Username: &username})
+	if errUser != nil {
+		t.Fatalf("CreateUser() error = %v", errUser)
+	}
+	displayName := "Must survive sparse writes"
+	channels := []uint{11}
+	modelGroups := []uint{21}
+	record, errCreate := repo.CreateAPIKey(ctx, APIKeyEntryUpdate{
+		APIKey:         "sparse-write-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+		UserID:         &user.ID,
+		UserIDSet:      true,
+		Channels:       &channels,
+		ModelGroups:    &modelGroups,
+	})
+	if errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	nextChannels := []uint{12}
+	if _, errBindings := repo.UpdateAPIKeyBindings(ctx, record.APIKey, nil, &nextChannels, nil); errBindings != nil {
+		t.Fatalf("UpdateAPIKeyBindings() error = %v", errBindings)
+	}
+	assertAPIKeyRecordDisplayName(t, repo, record.ID, displayName)
+
+	nextModelGroups := []uint{22}
+	if _, errExistingCreate := repo.CreateAPIKeyForUser(ctx, user.ID, APIKeyUserUpdate{
+		APIKey:      &record.APIKey,
+		Channels:    &nextChannels,
+		ModelGroups: &nextModelGroups,
+	}); errExistingCreate != nil {
+		t.Fatalf("CreateAPIKeyForUser(existing) error = %v", errExistingCreate)
+	}
+	assertAPIKeyRecordDisplayName(t, repo, record.ID, displayName)
+
+	rotatedKey := "sparse-write-key-rotated"
+	if _, errUpdate := repo.UpdateAPIKeyForUser(ctx, user.ID, record.ID, "", APIKeyUserUpdate{APIKey: &rotatedKey}); errUpdate != nil {
+		t.Fatalf("UpdateAPIKeyForUser() error = %v", errUpdate)
+	}
+	assertAPIKeyRecordDisplayName(t, repo, record.ID, displayName)
+
+	entries, errEntries := repo.ListAPIKeyEntries(ctx)
+	if errEntries != nil || len(entries) != 1 || entries[0].APIKey != rotatedKey || !reflect.DeepEqual(entries[0].Channels, nextChannels) || !reflect.DeepEqual(entries[0].ModelGroups, nextModelGroups) {
+		t.Fatalf("sparse write result = %#v, %v", entries, errEntries)
+	}
+}
+
+func TestReplaceAPIKeyEntriesUsesLastDuplicateAndPresenceSemantics(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	_, repo := openAPIKeyTestRepository(t)
+	firstName := "First duplicate"
+	lastName := "Last duplicate"
+	stats, errReplace := repo.ReplaceAPIKeyEntries(ctx, []APIKeyEntryUpdate{
+		{APIKey: "duplicate-key", DisplayName: &firstName, DisplayNameSet: true},
+		{APIKey: "duplicate-key", DisplayName: &lastName, DisplayNameSet: true},
+	})
+	if errReplace != nil {
+		t.Fatalf("ReplaceAPIKeyEntries() error = %v", errReplace)
+	}
+	if !stats.RequiresRuntimeRefresh() {
+		t.Fatal("new API key did not require runtime refresh")
+	}
+	entries, errEntries := repo.ListAPIKeyEntries(ctx)
+	if errEntries != nil || len(entries) != 1 || entries[0].DisplayName == nil || *entries[0].DisplayName != lastName {
+		t.Fatalf("last-write-wins entries = %#v, %v", entries, errEntries)
+	}
+
+	stats, errReplace = repo.ReplaceAPIKeyEntries(ctx, []APIKeyEntryUpdate{{APIKey: "duplicate-key"}})
+	if errReplace != nil {
+		t.Fatalf("ReplaceAPIKeyEntries(omitted fields) error = %v", errReplace)
+	}
+	if stats.RequiresRuntimeRefresh() {
+		t.Fatal("omitted metadata and bindings unexpectedly required runtime refresh")
+	}
+	entries, errEntries = repo.ListAPIKeyEntries(ctx)
+	if errEntries != nil || len(entries) != 1 || entries[0].DisplayName == nil || *entries[0].DisplayName != lastName {
+		t.Fatalf("omitted display name entries = %#v, %v", entries, errEntries)
+	}
+}
 
 func TestUpdateAPIKeyForUserRejectsDuplicateRename(t *testing.T) {
 	t.Parallel()
@@ -68,5 +359,46 @@ func TestUpdateAPIKeyForUserRejectsDuplicateRename(t *testing.T) {
 	}
 	if len(records) != 1 || records[0].APIKey != firstKey {
 		t.Fatalf("first user API keys = %#v, want only %q", records, firstKey)
+	}
+}
+
+func openAPIKeyTestRepository(t *testing.T) (*gorm.DB, *Repository) {
+	t.Helper()
+	db, errOpenSQLite := OpenSQLite(t.Context(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpenSQLite != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpenSQLite)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	t.Cleanup(func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	})
+	if errMigrate := AutoMigrate(db); errMigrate != nil {
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	return db, NewRepository(db)
+}
+
+func apiKeyEventCount(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var count int64
+	if errCount := db.Model(&ClusterEventRecord{}).Count(&count).Error; errCount != nil {
+		t.Fatalf("count cluster events: %v", errCount)
+	}
+	return count
+}
+
+func assertAPIKeyRecordDisplayName(t *testing.T, repo *Repository, id uint, want string) {
+	t.Helper()
+	entries, errEntries := repo.ListAPIKeyEntries(t.Context())
+	if errEntries != nil {
+		t.Fatalf("ListAPIKeyEntries() error = %v", errEntries)
+	}
+	if len(entries) != 1 || entries[0].ID != id || entries[0].DisplayName == nil || *entries[0].DisplayName != want {
+		t.Fatalf("API key entry = %#v, want id %d and display name %q", entries, id, want)
 	}
 }

--- a/internal/cluster/cpa_node_metadata_snapshot_test.go
+++ b/internal/cluster/cpa_node_metadata_snapshot_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestDatabaseSnapshotV3IncludesCPANodeMetadata(t *testing.T) {
 	t.Parallel()
-	models, okModels := databaseSnapshotModels(databaseSnapshotFormatVersion)
+	models, okModels := databaseSnapshotModels(3)
 	if !okModels {
-		t.Fatal("current database snapshot registry is unsupported")
+		t.Fatal("database snapshot v3 registry is unsupported")
 	}
 	if len(models) != len(databaseSnapshotV2Models)+1 {
 		t.Fatalf("v3 model count = %d, want v2 count plus metadata", len(models))

--- a/internal/cluster/database_models.go
+++ b/internal/cluster/database_models.go
@@ -1,6 +1,10 @@
 package cluster
 
-import "time"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // databaseModel describes one managed Home database table.
 type databaseModel struct {
@@ -40,6 +44,23 @@ func (databaseSnapshotV1CPANodeRecord) TableName() string {
 	return "cpa_node"
 }
 
+// databaseSnapshotV3APIKeyRecord freezes the API key shape used by snapshot
+// formats v1 through v3, before display names were added.
+type databaseSnapshotV3APIKeyRecord struct {
+	ID          uint           `gorm:"column:id;primaryKey;autoIncrement;index:idx_api_key_active_order,priority:2"`
+	APIKey      string         `gorm:"column:api_key;not null;uniqueIndex"`
+	UserID      *uint          `gorm:"column:user_id;index;index:idx_api_key_user_active,priority:1"`
+	Channels    JSONB          `gorm:"column:channels"`
+	ModelGroups JSONB          `gorm:"column:model_groups"`
+	CreatedAt   time.Time      `gorm:"column:created_at"`
+	UpdatedAt   time.Time      `gorm:"column:updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"column:deleted_at;index;index:idx_api_key_active_order,priority:1;index:idx_api_key_user_active,priority:2"`
+}
+
+func (databaseSnapshotV3APIKeyRecord) TableName() string {
+	return "api_key"
+}
+
 var databaseSnapshotV1Models = []databaseModel{
 	newDatabaseModel[AuthRecord]("auth", []string{"uuid"}, false, true),
 	newDatabaseModel[ConfigRecord]("config", []string{"key"}, false, true),
@@ -54,7 +75,7 @@ var databaseSnapshotV1Models = []databaseModel{
 	newDatabaseModel[UserSecurityThrottleRecord]("user_security_throttle", []string{"key"}, false, false),
 	newDatabaseModel[ChannelGroupRecord]("channel_group", []string{"id"}, true, true),
 	newDatabaseModel[ModelGroupRecord]("model_group", []string{"id"}, true, true),
-	newDatabaseModel[APIKeyRecord]("api_key", []string{"id"}, true, true),
+	newDatabaseModel[databaseSnapshotV3APIKeyRecord]("api_key", []string{"id"}, true, true),
 	newDatabaseModel[ChannelGroupDetailRecord]("channel_group_detail", []string{"id"}, true, true),
 	newDatabaseModel[ModelGroupDetailRecord]("model_group_detail", []string{"id"}, true, true),
 	newDatabaseModel[ClusterNodeRecord]("cluster", []string{"ip", "port"}, false, false),
@@ -75,12 +96,15 @@ var databaseSnapshotV1Models = []databaseModel{
 }
 
 // databaseSnapshotV2Models is the frozen database snapshot format v2 registry.
-var databaseSnapshotV2Models = currentDatabaseModels()
+var databaseSnapshotV2Models = databaseSnapshotV2ModelRegistry()
 
-// homeDatabaseModels is the current database snapshot registry.
-var homeDatabaseModels = append(append([]databaseModel(nil), databaseSnapshotV2Models...),
+// databaseSnapshotV3Models is the frozen database snapshot format v3 registry.
+var databaseSnapshotV3Models = append(append([]databaseModel(nil), databaseSnapshotV2Models...),
 	newDatabaseModel[CPANodeMetadataRecord]("cpa_node_metadata", []string{"node_id"}, false, true),
 )
+
+// homeDatabaseModels is the current database snapshot registry.
+var homeDatabaseModels = currentDatabaseModels()
 
 var databaseMigrationOnlyModels = []databaseModel{
 	newDatabaseModel[ClusterMasterGateRecord]("cluster_master_gate", []string{"id"}, false, false),
@@ -91,7 +115,7 @@ var databaseMigrationOnlyModels = []databaseModel{
 	newDatabaseModel[ManagementInFlightSnapshotCursorStateModelRecord]("management_in_flight_snapshot_cursor_state_models", []string{"cursor", "credential_id", "model"}, false, false),
 }
 
-func currentDatabaseModels() []databaseModel {
+func databaseSnapshotV2ModelRegistry() []databaseModel {
 	models := append([]databaseModel(nil), databaseSnapshotV1Models...)
 	for index := range models {
 		if models[index].name == "cpa_node" {
@@ -116,12 +140,25 @@ func currentDatabaseModels() []databaseModel {
 	)
 }
 
+func currentDatabaseModels() []databaseModel {
+	models := append([]databaseModel(nil), databaseSnapshotV3Models...)
+	for index := range models {
+		if models[index].name == "api_key" {
+			models[index] = newDatabaseModel[APIKeyRecord]("api_key", []string{"id"}, true, true)
+			break
+		}
+	}
+	return models
+}
+
 func databaseSnapshotModels(formatVersion int) ([]databaseModel, bool) {
 	switch formatVersion {
 	case 1:
 		return databaseSnapshotV1Models, true
 	case 2:
 		return databaseSnapshotV2Models, true
+	case 3:
+		return databaseSnapshotV3Models, true
 	case databaseSnapshotFormatVersion:
 		return homeDatabaseModels, true
 	default:

--- a/internal/cluster/database_snapshot.go
+++ b/internal/cluster/database_snapshot.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	databaseSnapshotFormat        = "cliproxyapihome-database-snapshot"
-	databaseSnapshotFormatVersion = 3
+	databaseSnapshotFormatVersion = 4
 	databaseSnapshotManifestName  = "manifest.json"
 	databaseSnapshotBatchSize     = 500
 	databaseSnapshotManifestLimit = 4 << 20
@@ -635,6 +635,14 @@ func validateDatabaseSnapshotRecord(ctx context.Context, model databaseModel, mo
 		}
 	}
 	switch typed := record.(type) {
+	case *APIKeyRecord:
+		normalizedDisplayName, errDisplayName := normalizeAPIKeyDisplayName(typed.DisplayName)
+		if errDisplayName != nil {
+			return databaseSnapshotFieldError(model.name, primaryLabel, "display_name", errDisplayName.Error())
+		}
+		if !sameExactOptionalString(typed.DisplayName, normalizedDisplayName) {
+			return databaseSnapshotFieldError(model.name, primaryLabel, "display_name", "must be normalized")
+		}
 	case *ChannelGroupDetailRecord:
 		if strings.TrimSpace(typed.AuthID) == "" {
 			return databaseSnapshotFieldError(model.name, primaryLabel, "auth_id", "must not be blank")
@@ -653,6 +661,13 @@ func validateDatabaseSnapshotRecord(ctx context.Context, model databaseModel, mo
 		}
 	}
 	return nil
+}
+
+func sameExactOptionalString(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func (s *ValidatedDatabaseSnapshot) validatePostgresFields(ctx context.Context) error {
@@ -748,6 +763,15 @@ func validateDatabaseSnapshotExportRecordEncoding(ctx context.Context, model dat
 		fieldValue, _ := field.ValueOf(ctx, value)
 		if errEncoding := validateSnapshotValueEncoding(reflect.ValueOf(fieldValue)); errEncoding != nil {
 			return databaseSnapshotFieldError(model.name, primaryLabel, field.DBName, errEncoding.Error())
+		}
+	}
+	if apiKey, ok := record.(*APIKeyRecord); ok {
+		normalizedDisplayName, errDisplayName := normalizeAPIKeyDisplayName(apiKey.DisplayName)
+		if errDisplayName != nil {
+			return databaseSnapshotFieldError(model.name, primaryLabel, "display_name", errDisplayName.Error())
+		}
+		if !sameExactOptionalString(apiKey.DisplayName, normalizedDisplayName) {
+			return databaseSnapshotFieldError(model.name, primaryLabel, "display_name", "must be normalized")
 		}
 	}
 	return nil

--- a/internal/cluster/database_snapshot_test.go
+++ b/internal/cluster/database_snapshot_test.go
@@ -120,6 +120,39 @@ func TestDatabaseSnapshotV2RegistryExcludesMigrationOnlyModels(t *testing.T) {
 	}
 }
 
+func TestDatabaseSnapshotV4FreezesLegacyAPIKeyShape(t *testing.T) {
+	t.Parallel()
+
+	legacyModels, okLegacy := databaseSnapshotModels(3)
+	if !okLegacy {
+		t.Fatal("database snapshot v3 registry is unsupported")
+	}
+	currentModels, okCurrent := databaseSnapshotModels(databaseSnapshotFormatVersion)
+	if !okCurrent {
+		t.Fatal("current database snapshot registry is unsupported")
+	}
+
+	legacyType := databaseSnapshotModelType(t, legacyModels, "api_key")
+	if legacyType != reflect.TypeOf(&databaseSnapshotV3APIKeyRecord{}) {
+		t.Fatalf("v3 API key snapshot type = %v, want frozen legacy type", legacyType)
+	}
+	currentType := databaseSnapshotModelType(t, currentModels, "api_key")
+	if currentType != reflect.TypeOf(&APIKeyRecord{}) {
+		t.Fatalf("v4 API key snapshot type = %v, want current APIKeyRecord", currentType)
+	}
+}
+
+func databaseSnapshotModelType(t *testing.T, models []databaseModel, name string) reflect.Type {
+	t.Helper()
+	for _, model := range models {
+		if model.name == name {
+			return reflect.TypeOf(model.newRecord())
+		}
+	}
+	t.Fatalf("database snapshot model %q is missing", name)
+	return nil
+}
+
 func TestDatabaseSnapshotV1RegistryRemainsCompatible(t *testing.T) {
 	t.Parallel()
 
@@ -146,6 +179,122 @@ func TestDatabaseSnapshotV1RegistryRemainsCompatible(t *testing.T) {
 		if gotOrder := strings.Join(databaseSnapshotV2Models[index].orderBy, ","); gotOrder != "home_ip,home_port,home_started_at,node_key" {
 			t.Fatalf("current cpa_node order = %q", gotOrder)
 		}
+	}
+}
+
+func TestDatabaseSnapshotV3APIKeyRecordRemainsImportable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	source := openDatabaseSnapshotSQLiteTestDB(t, filepath.Join(t.TempDir(), "source.db"))
+	if errCreate := source.Create(&APIKeyRecord{
+		APIKey:      "legacy-snapshot-key",
+		Channels:    JSONB(`[]`),
+		ModelGroups: JSONB(`[]`),
+	}).Error; errCreate != nil {
+		t.Fatalf("create source API key: %v", errCreate)
+	}
+
+	snapshotPath := filepath.Join(t.TempDir(), "legacy-v3.snapshot.zip")
+	if _, errExport := exportDatabaseSnapshotVersion(ctx, source, snapshotPath, 3); errExport != nil {
+		t.Fatalf("exportDatabaseSnapshotVersion(v3) error = %v", errExport)
+	}
+	snapshot, errOpen := OpenDatabaseSnapshot(ctx, snapshotPath)
+	if errOpen != nil {
+		t.Fatalf("OpenDatabaseSnapshot(v3) error = %v", errOpen)
+	}
+	t.Cleanup(func() {
+		if errClose := snapshot.Close(); errClose != nil {
+			t.Errorf("close v3 snapshot: %v", errClose)
+		}
+	})
+
+	target := openDatabaseSnapshotSQLiteRawTestDB(t, filepath.Join(t.TempDir(), "target.db"))
+	if _, errImport := ImportDatabaseSnapshot(ctx, target, snapshot, nil); errImport != nil {
+		t.Fatalf("ImportDatabaseSnapshot(v3) error = %v", errImport)
+	}
+	var imported APIKeyRecord
+	if errFirst := target.First(&imported, "api_key = ?", "legacy-snapshot-key").Error; errFirst != nil {
+		t.Fatalf("load imported v3 API key: %v", errFirst)
+	}
+	if imported.DisplayName != nil {
+		t.Fatalf("imported v3 display name = %q, want null", *imported.DisplayName)
+	}
+}
+
+func TestValidateDatabaseSnapshotRecordRejectsInvalidAPIKeyDisplayName(t *testing.T) {
+	model := currentDatabaseModels()[0]
+	for _, candidate := range currentDatabaseModels() {
+		if candidate.name == "api_key" {
+			model = candidate
+			break
+		}
+	}
+	db, errOpen := OpenSQLite(t.Context(), filepath.Join(t.TempDir(), "snapshot-display-name.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite database: %v", errClose)
+		}
+	}()
+	statement := &gorm.Statement{DB: db}
+	if errParse := statement.Parse(&APIKeyRecord{}); errParse != nil {
+		t.Fatalf("parse APIKeyRecord schema: %v", errParse)
+	}
+
+	for _, displayName := range []string{
+		strings.Repeat("a", APIKeyDisplayNameMaxLength+1),
+		"invalid\nname",
+		"  padded  ",
+	} {
+		record := &APIKeyRecord{ID: 1, APIKey: "snapshot-key", DisplayName: &displayName}
+		raw, errMarshal := json.Marshal(record)
+		if errMarshal != nil {
+			t.Fatalf("marshal API key record: %v", errMarshal)
+		}
+		errValidate := validateDatabaseSnapshotRecord(t.Context(), model, statement.Schema, raw, record)
+		if errValidate == nil || !strings.Contains(errValidate.Error(), "display_name") {
+			t.Fatalf("validate display name %q error = %v, want display_name failure", displayName, errValidate)
+		}
+	}
+}
+
+func TestValidateDatabaseSnapshotExportRejectsUnnormalizedAPIKeyDisplayName(t *testing.T) {
+	model := currentDatabaseModels()[0]
+	for _, candidate := range currentDatabaseModels() {
+		if candidate.name == "api_key" {
+			model = candidate
+			break
+		}
+	}
+	db, errOpen := OpenSQLite(t.Context(), filepath.Join(t.TempDir(), "snapshot-export-display-name.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	defer func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite database: %v", errClose)
+		}
+	}()
+	statement := &gorm.Statement{DB: db}
+	if errParse := statement.Parse(&APIKeyRecord{}); errParse != nil {
+		t.Fatalf("parse APIKeyRecord schema: %v", errParse)
+	}
+	displayName := "  padded  "
+	record := &APIKeyRecord{ID: 1, APIKey: "snapshot-key", DisplayName: &displayName}
+	errValidate := validateDatabaseSnapshotExportRecordEncoding(t.Context(), model, statement.Schema, record)
+	if errValidate == nil || !strings.Contains(errValidate.Error(), "display_name") {
+		t.Fatalf("export validation error = %v, want display_name failure", errValidate)
 	}
 }
 
@@ -221,6 +370,13 @@ func TestDatabaseSnapshotSQLiteRoundTrip(t *testing.T) {
 	if activationGate.ActivePolicyCount != 1 {
 		t.Fatalf("imported active policy count = %d, want 1", activationGate.ActivePolicyCount)
 	}
+	var apiKey APIKeyRecord
+	if errFirst := target.First(&apiKey, "api_key = ?", "snapshot-api-key").Error; errFirst != nil {
+		t.Fatalf("load imported API key: %v", errFirst)
+	}
+	if apiKey.DisplayName == nil || *apiKey.DisplayName != "Snapshot API key" {
+		t.Fatalf("imported API key display name = %v, want %q", apiKey.DisplayName, "Snapshot API key")
+	}
 	var pluginAuth PluginStoreAuthRecord
 	if errFirst := target.First(&pluginAuth, want.pluginAuthID).Error; errFirst != nil {
 		t.Fatalf("load imported plugin auth: %v", errFirst)
@@ -276,6 +432,63 @@ func TestDatabaseSnapshotSQLiteRoundTrip(t *testing.T) {
 	if createdLog.ID <= want.maximumLogID {
 		t.Fatalf("log id after import = %d, want greater than %d", createdLog.ID, want.maximumLogID)
 	}
+}
+
+func exportDatabaseSnapshotVersion(ctx context.Context, db *gorm.DB, path string, formatVersion int) (DatabaseSnapshotManifest, error) {
+	models, okModels := databaseSnapshotModels(formatVersion)
+	if !okModels {
+		return DatabaseSnapshotManifest{}, fmt.Errorf("unsupported test snapshot version %d", formatVersion)
+	}
+	file, errCreate := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if errCreate != nil {
+		return DatabaseSnapshotManifest{}, errCreate
+	}
+	zipWriter := zip.NewWriter(file)
+	manifest := DatabaseSnapshotManifest{
+		Format:        databaseSnapshotFormat,
+		FormatVersion: formatVersion,
+		CreatedAt:     time.Now().UTC(),
+		SourceBackend: DatabaseBackendSQLite,
+		Tables:        make([]DatabaseSnapshotManifestTable, 0, len(models)),
+	}
+	errExport := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		for _, model := range models {
+			entry, errEntry := zipWriter.CreateHeader(&zip.FileHeader{Name: databaseSnapshotTableEntryName(model.name), Method: zip.Deflate})
+			if errEntry != nil {
+				return errEntry
+			}
+			hasher := sha256.New()
+			rows, errRows := exportDatabaseSnapshotTable(ctx, tx, model, io.MultiWriter(entry, hasher))
+			if errRows != nil {
+				return errRows
+			}
+			manifest.Tables = append(manifest.Tables, DatabaseSnapshotManifestTable{
+				Name:    model.name,
+				Rows:    rows,
+				SHA256:  hex.EncodeToString(hasher.Sum(nil)),
+				Restore: model.restore,
+			})
+		}
+		return nil
+	})
+	if errExport == nil {
+		var manifestWriter io.Writer
+		manifestWriter, errExport = zipWriter.CreateHeader(&zip.FileHeader{Name: databaseSnapshotManifestName, Method: zip.Deflate})
+		if errExport == nil {
+			var raw []byte
+			raw, errExport = json.Marshal(manifest)
+			if errExport == nil {
+				_, errExport = manifestWriter.Write(append(raw, '\n'))
+			}
+		}
+	}
+	if errCloseZIP := zipWriter.Close(); errExport == nil && errCloseZIP != nil {
+		errExport = errCloseZIP
+	}
+	if errClose := file.Close(); errExport == nil && errClose != nil {
+		errExport = errClose
+	}
+	return manifest, errExport
 }
 
 func TestDatabaseSnapshotExportRejectsExistingFile(t *testing.T) {
@@ -1186,6 +1399,7 @@ func seedDatabaseSnapshotTestData(t *testing.T, db *gorm.DB) databaseSnapshotTes
 	channelGroupID := uint(201)
 	modelGroupID := uint(301)
 	apiKeyID := uint(401)
+	apiKeyDisplayName := "Snapshot API key"
 	usageID := uint(501)
 	pluginAuthID := uint(601)
 	authUUID := "auth-snapshot-uuid"
@@ -1208,7 +1422,7 @@ func seedDatabaseSnapshotTestData(t *testing.T, db *gorm.DB) databaseSnapshotTes
 		&UserSecurityThrottleRecord{Key: "snapshot-throttle", Count: 1, ExpiresAt: expiresAt, UpdatedAt: now},
 		&ChannelGroupRecord{ID: channelGroupID, ChannelName: "snapshot-channel", CreatedAt: now, UpdatedAt: now},
 		&ModelGroupRecord{ID: modelGroupID, GroupName: "snapshot-models", CreatedAt: now, UpdatedAt: now},
-		&APIKeyRecord{ID: apiKeyID, APIKey: "snapshot-api-key", UserID: &userID, Channels: JSONB(`[201]`), ModelGroups: JSONB(`[301]`), CreatedAt: now, UpdatedAt: now},
+		&APIKeyRecord{ID: apiKeyID, APIKey: "snapshot-api-key", DisplayName: &apiKeyDisplayName, UserID: &userID, Channels: JSONB(`[201]`), ModelGroups: JSONB(`[301]`), CreatedAt: now, UpdatedAt: now},
 		&ChannelGroupDetailRecord{ID: 211, ChannelGroupID: channelGroupID, AuthID: "auth-logical-id", CreatedAt: now, UpdatedAt: now},
 		&ModelGroupDetailRecord{ID: 311, ModelGroupID: modelGroupID, ModelID: "gpt-test", CreatedAt: now, UpdatedAt: now},
 		&UsageRecord{ID: usageID, Timestamp: now, Source: "snapshot", AuthIndex: "auth-index", InputTokens: 1, OutputTokens: 2, TotalTokens: 3, Provider: "codex", Model: "gpt-test", TokensJSON: JSONB(`{"input":1}`), FailJSON: JSONB(`null`), PayloadJSON: JSONB(`{"model":"gpt-test"}`), CreatedAt: now},

--- a/internal/cluster/import_export.go
+++ b/internal/cluster/import_export.go
@@ -135,7 +135,21 @@ func ImportLocalState(ctx context.Context, opts ImportOptions) (ImportStats, err
 		return stats, errDB
 	}
 	mutationStats := ImportStats{}
+	importsAPIKeys := false
+	for key := range root {
+		if strings.TrimSpace(key) == configAPIKeysRootKey {
+			importsAPIKeys = true
+			break
+		}
+	}
 	errTransaction := withConcurrencyTransaction(ctx, db, func(tx *gorm.DB) error {
+		// Import may emit lifecycle or auth events before reaching api-keys.
+		// Lock the key collection first whenever this import includes it.
+		if importsAPIKeys {
+			if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+				return errLock
+			}
+		}
 		gate, errGate := lockConcurrencyActivationGate(tx)
 		if errGate != nil {
 			return errGate

--- a/internal/cluster/import_export_test.go
+++ b/internal/cluster/import_export_test.go
@@ -69,6 +69,37 @@ xai-api-key:
 	assertActiveAuthCount(t, db, 3)
 }
 
+func TestImportLocalStatePreservesAPIKeyDisplayName(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, configPath, "api-keys:\n  - named-key\n")
+
+	db := openImportTestSQLite(t)
+	repo := NewRepository(db)
+	displayName := "Production key"
+	if _, errCreate := repo.CreateAPIKey(context.Background(), APIKeyEntryUpdate{
+		APIKey:         "named-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+	}); errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	if _, errImport := ImportLocalState(context.Background(), ImportOptions{
+		ConfigPath: configPath,
+		Repository: repo,
+	}); errImport != nil {
+		t.Fatalf("ImportLocalState() error = %v", errImport)
+	}
+	entries, errList := repo.ListAPIKeyEntries(context.Background())
+	if errList != nil {
+		t.Fatalf("ListAPIKeyEntries() error = %v", errList)
+	}
+	if len(entries) != 1 || entries[0].DisplayName == nil || *entries[0].DisplayName != displayName {
+		t.Fatalf("imported API key entries = %#v, want preserved display name %q", entries, displayName)
+	}
+}
+
 func TestImportLocalStateEmitsOneConfigEventForHotOnlyCredentialConcurrencyChange(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -447,6 +478,38 @@ func TestExportLocalState_CustomOutputDirWritesAuthsUnderOutputDir(t *testing.T)
 	}
 	assertFileContains(t, filepath.Join(outputDir, "config.yaml"), "auth-dir: auths")
 	assertFileExists(t, filepath.Join(outputDir, "auths", "codex.json"))
+}
+
+func TestExportLocalStateKeepsNamedAPIKeysInLegacyStringShape(t *testing.T) {
+	outputDir := t.TempDir()
+	db := openImportTestSQLite(t)
+	repo := NewRepository(db)
+	displayName := "Production key"
+	if _, errCreate := repo.CreateAPIKey(context.Background(), APIKeyEntryUpdate{
+		APIKey:         "named-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+	}); errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	if _, errExport := ExportLocalState(context.Background(), ExportOptions{
+		OutputDir:   outputDir,
+		Repository:  repo,
+		AuthDirName: "auths",
+	}); errExport != nil {
+		t.Fatalf("ExportLocalState() error = %v", errExport)
+	}
+	raw, errRead := os.ReadFile(filepath.Join(outputDir, "config.yaml"))
+	if errRead != nil {
+		t.Fatalf("read exported config: %v", errRead)
+	}
+	if !strings.Contains(string(raw), "api-keys:\n    - named-key") {
+		t.Fatalf("exported config does not keep api-keys as strings:\n%s", string(raw))
+	}
+	if strings.Contains(string(raw), "display_name") {
+		t.Fatalf("exported config unexpectedly contains Home-only display_name metadata:\n%s", string(raw))
+	}
 }
 
 func openImportTestSQLite(t *testing.T) *gorm.DB {

--- a/internal/cluster/management/api_keys.go
+++ b/internal/cluster/management/api_keys.go
@@ -1,28 +1,79 @@
 package management
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
 	"gorm.io/gorm"
 )
 
+const apiKeyMaxRequestBodySize int64 = 1 << 20
+
+type apiKeyRequestError struct {
+	code string
+	err  error
+}
+
+func bytesTrimSpace(data []byte) []byte {
+	return bytes.TrimSpace(data)
+}
+
+func decodeStrictAPIKeyJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if errDecode := decoder.Decode(target); errDecode != nil {
+		return errDecode
+	}
+	var trailing any
+	if errTrailing := decoder.Decode(&trailing); !errors.Is(errTrailing, io.EOF) {
+		if errTrailing == nil {
+			return fmt.Errorf("multiple JSON values are not allowed")
+		}
+		return errTrailing
+	}
+	return nil
+}
+
+func (e *apiKeyRequestError) Error() string {
+	if e == nil || e.err == nil {
+		return "invalid API key request"
+	}
+	return e.err.Error()
+}
+
+func (e *apiKeyRequestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func newAPIKeyRequestError(code string, format string, args ...any) error {
+	return &apiKeyRequestError{code: code, err: fmt.Errorf(format, args...)}
+}
+
 type apiKeyEntryBody struct {
-	APIKey          *string `json:"api_key"`
-	APIKeyDash      *string `json:"api-key"`
-	Key             *string `json:"key"`
-	Value           *string `json:"value"`
-	UserID          *uint   `json:"user_id"`
-	UserIDDash      *uint   `json:"user-id"`
-	Channels        *[]uint `json:"channels"`
-	ModelGroups     *[]uint `json:"model_groups"`
-	ModelGroupsDash *[]uint `json:"model-groups"`
+	APIKey          *string         `json:"api_key"`
+	APIKeyDash      *string         `json:"api-key"`
+	Key             *string         `json:"key"`
+	Value           *string         `json:"value"`
+	DisplayName     json.RawMessage `json:"display_name"`
+	UserID          json.RawMessage `json:"user_id"`
+	UserIDDash      json.RawMessage `json:"user-id"`
+	Channels        *[]uint         `json:"channels"`
+	ModelGroups     *[]uint         `json:"model_groups"`
+	ModelGroupsDash *[]uint         `json:"model-groups"`
 }
 
 type apiKeyPatchBody struct {
@@ -36,11 +87,49 @@ type apiKeyPatchBody struct {
 	APIKey          *string         `json:"api_key"`
 	APIKeyDash      *string         `json:"api-key"`
 	Key             *string         `json:"key"`
-	UserID          *uint           `json:"user_id"`
-	UserIDDash      *uint           `json:"user-id"`
+	DisplayName     json.RawMessage `json:"display_name"`
+	UserID          json.RawMessage `json:"user_id"`
+	UserIDDash      json.RawMessage `json:"user-id"`
 	Channels        *[]uint         `json:"channels"`
 	ModelGroups     *[]uint         `json:"model_groups"`
 	ModelGroupsDash *[]uint         `json:"model-groups"`
+}
+
+func (b apiKeyPatchBody) selectorAPIKey() (string, error) {
+	values := make([]string, 0, 3)
+	for _, value := range []*string{b.APIKey, b.APIKeyDash, b.Key} {
+		if value == nil {
+			continue
+		}
+		key := strings.TrimSpace(*value)
+		if key == "" {
+			return "", newAPIKeyRequestError("invalid_body", "API key selector aliases must not be blank")
+		}
+		values = append(values, key)
+	}
+	if len(values) == 0 {
+		return "", nil
+	}
+	for _, value := range values[1:] {
+		if value != values[0] {
+			return "", newAPIKeyRequestError("invalid_body", "conflicting API key selector aliases")
+		}
+	}
+	return values[0], nil
+}
+
+func (b apiKeyPatchBody) selectorID() (*uint, error) {
+	var selected *uint
+	for _, value := range []*uint{b.ID, b.APIKeyID, b.APIKeyIDDash} {
+		if value == nil {
+			continue
+		}
+		if selected != nil && *selected != *value {
+			return nil, newAPIKeyRequestError("invalid_body", "conflicting API key ID aliases")
+		}
+		selected = value
+	}
+	return selected, nil
 }
 
 func apiKeyEntriesResponse(entries []cluster.APIKeyEntry) gin.H {
@@ -65,6 +154,7 @@ func apiKeyEntriesResponse(entries []cluster.APIKeyEntry) gin.H {
 			"api_key_id":   entry.ID,
 			"api-key":      key,
 			"api_key":      key,
+			"display_name": optionalAPIKeyDisplayNameValue(entry.DisplayName),
 			"user-id":      optionalUserIDValue(entry.UserID),
 			"user_id":      optionalUserIDValue(entry.UserID),
 			"channels":     channels,
@@ -79,40 +169,63 @@ func apiKeyEntriesResponse(entries []cluster.APIKeyEntry) gin.H {
 }
 
 func decodeAPIKeyEntryUpdates(data []byte) ([]cluster.APIKeyEntryUpdate, error) {
-	if len(data) == 0 {
-		return nil, fmt.Errorf("empty body")
+	data = []byte(strings.TrimSpace(string(data)))
+	if len(data) == 0 || string(data) == "null" {
+		return nil, newAPIKeyRequestError("invalid_body", "API key replacement body must be an array or object wrapper")
 	}
-	if entries, errEntries := decodeAPIKeyEntryArray(data); errEntries == nil {
+	if data[0] == '[' {
+		entries, errEntries := decodeAPIKeyEntryArray(data)
+		if errEntries != nil {
+			return nil, errEntries
+		}
 		return entries, nil
+	}
+	if data[0] != '{' {
+		return nil, newAPIKeyRequestError("invalid_body", "API key replacement body must be an array or object wrapper")
 	}
 
 	var wrapper map[string]json.RawMessage
-	if errUnmarshal := json.Unmarshal(data, &wrapper); errUnmarshal != nil {
-		return nil, errUnmarshal
+	if errUnmarshal := decodeStrictAPIKeyJSON(data, &wrapper); errUnmarshal != nil {
+		return nil, newAPIKeyRequestError("invalid_body", "invalid API key replacement body: %v", errUnmarshal)
 	}
+	var selected json.RawMessage
+	selectedKey := ""
 	for _, key := range []string{"items", "api-keys", "api_keys", "api_key_entries"} {
-		raw := wrapper[key]
-		if len(raw) == 0 {
+		raw, present := wrapper[key]
+		if !present {
 			continue
 		}
-		return decodeAPIKeyEntryArray(raw)
+		if selectedKey != "" {
+			return nil, newAPIKeyRequestError("invalid_body", "API key replacement body must contain exactly one wrapper field")
+		}
+		selectedKey = key
+		selected = raw
 	}
-	return nil, fmt.Errorf("missing api key items")
+	if selectedKey == "" {
+		return nil, newAPIKeyRequestError("invalid_body", "missing API key replacement items")
+	}
+	if string(bytesTrimSpace(selected)) == "null" {
+		return nil, newAPIKeyRequestError("invalid_body", "%s must be an array", selectedKey)
+	}
+	return decodeAPIKeyEntryArray(selected)
 }
 
 func decodeAPIKeyEntryArray(data []byte) ([]cluster.APIKeyEntryUpdate, error) {
 	var rawItems []json.RawMessage
-	if errUnmarshal := json.Unmarshal(data, &rawItems); errUnmarshal != nil {
-		return nil, errUnmarshal
+	if errUnmarshal := decodeStrictAPIKeyJSON(data, &rawItems); errUnmarshal != nil {
+		return nil, newAPIKeyRequestError("invalid_body", "API key replacement items must be an array: %v", errUnmarshal)
+	}
+	if rawItems == nil {
+		return nil, newAPIKeyRequestError("invalid_body", "API key replacement items must be an array")
 	}
 	entries := make([]cluster.APIKeyEntryUpdate, 0, len(rawItems))
-	for _, raw := range rawItems {
+	for index, raw := range rawItems {
 		entry, errEntry := decodeAPIKeyEntry(raw)
 		if errEntry != nil {
-			return nil, errEntry
+			return nil, fmt.Errorf("API key replacement item %d: %w", index, errEntry)
 		}
 		if strings.TrimSpace(entry.APIKey) == "" {
-			continue
+			return nil, newAPIKeyRequestError("invalid_body", "API key replacement item %d is missing a non-empty key", index)
 		}
 		entries = append(entries, entry)
 	}
@@ -120,71 +233,198 @@ func decodeAPIKeyEntryArray(data []byte) ([]cluster.APIKeyEntryUpdate, error) {
 }
 
 func decodeAPIKeyEntry(data []byte) (cluster.APIKeyEntryUpdate, error) {
+	data = bytesTrimSpace(data)
+	if len(data) == 0 || string(data) == "null" {
+		return cluster.APIKeyEntryUpdate{}, newAPIKeyRequestError("invalid_body", "API key entry must be a non-empty string or object")
+	}
 	var key string
-	if errString := json.Unmarshal(data, &key); errString == nil {
-		return cluster.APIKeyEntryUpdate{APIKey: strings.TrimSpace(key)}, nil
+	if data[0] == '"' {
+		if errString := json.Unmarshal(data, &key); errString != nil {
+			return cluster.APIKeyEntryUpdate{}, newAPIKeyRequestError("invalid_body", "invalid API key string: %v", errString)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return cluster.APIKeyEntryUpdate{}, newAPIKeyRequestError("invalid_body", "API key entry must not be blank")
+		}
+		return cluster.APIKeyEntryUpdate{APIKey: key}, nil
+	}
+	if data[0] != '{' {
+		return cluster.APIKeyEntryUpdate{}, newAPIKeyRequestError("invalid_body", "API key entry must be a non-empty string or object")
 	}
 
 	var body apiKeyEntryBody
-	if errUnmarshal := json.Unmarshal(data, &body); errUnmarshal != nil {
-		return cluster.APIKeyEntryUpdate{}, errUnmarshal
+	if errUnmarshal := decodeStrictAPIKeyJSON(data, &body); errUnmarshal != nil {
+		return cluster.APIKeyEntryUpdate{}, newAPIKeyRequestError("invalid_body", "invalid API key entry: %v", errUnmarshal)
+	}
+	apiKey, errAPIKey := body.apiKey()
+	if errAPIKey != nil {
+		return cluster.APIKeyEntryUpdate{}, errAPIKey
+	}
+	displayName, displayNameSet, errDisplayName := decodeOptionalAPIKeyDisplayName(body.DisplayName)
+	if errDisplayName != nil {
+		return cluster.APIKeyEntryUpdate{}, errDisplayName
+	}
+	userID, userIDSet, errUserID := decodeOptionalAPIKeyUserIDAliases(body.UserID, body.UserIDDash)
+	if errUserID != nil {
+		return cluster.APIKeyEntryUpdate{}, errUserID
+	}
+	modelGroups, errModelGroups := body.modelGroups()
+	if errModelGroups != nil {
+		return cluster.APIKeyEntryUpdate{}, errModelGroups
 	}
 	return cluster.APIKeyEntryUpdate{
-		APIKey:      body.apiKey(),
-		UserID:      body.userID(),
-		Channels:    body.Channels,
-		ModelGroups: body.modelGroups(),
+		APIKey:         apiKey,
+		DisplayName:    displayName,
+		DisplayNameSet: displayNameSet,
+		UserID:         userID,
+		UserIDSet:      userIDSet,
+		Channels:       body.Channels,
+		ModelGroups:    modelGroups,
 	}, nil
 }
 
-func (b apiKeyEntryBody) apiKey() string {
+func decodeOptionalAPIKeyDisplayName(raw json.RawMessage) (*string, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	if !utf8.Valid(raw) {
+		return nil, false, newAPIKeyRequestError("invalid_display_name", "display_name must contain valid UTF-8")
+	}
+	if strings.TrimSpace(string(raw)) == "null" {
+		return nil, true, nil
+	}
+	var value string
+	if errUnmarshal := json.Unmarshal(raw, &value); errUnmarshal != nil {
+		return nil, false, newAPIKeyRequestError("invalid_display_name", "display_name must be a string or null")
+	}
+	normalized, errDisplayName := validateAPIKeyDisplayName(&value)
+	if errDisplayName != nil {
+		return nil, false, errDisplayName
+	}
+	return normalized, true, nil
+}
+
+func validateAPIKeyDisplayName(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if !utf8.ValidString(*value) {
+		return nil, newAPIKeyRequestError("invalid_display_name", "display_name must contain valid UTF-8")
+	}
+	for _, character := range *value {
+		if unicode.IsControl(character) {
+			return nil, newAPIKeyRequestError("invalid_display_name", "display_name must not contain control characters")
+		}
+	}
+	trimmed := strings.TrimSpace(*value)
+	if utf8.RuneCountInString(trimmed) > cluster.APIKeyDisplayNameMaxLength {
+		return nil, newAPIKeyRequestError("invalid_display_name", "display_name must not exceed %d characters", cluster.APIKeyDisplayNameMaxLength)
+	}
+	return &trimmed, nil
+}
+
+func decodeOptionalAPIKeyUserID(raw json.RawMessage) (*uint, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	if strings.TrimSpace(string(raw)) == "null" {
+		return nil, true, nil
+	}
+	var value uint
+	if errUnmarshal := json.Unmarshal(raw, &value); errUnmarshal != nil {
+		return nil, false, fmt.Errorf("user_id must be a non-negative integer or null")
+	}
+	return &value, true, nil
+}
+
+func decodeOptionalAPIKeyUserIDAliases(values ...json.RawMessage) (*uint, bool, error) {
+	var selected *uint
+	selectedSet := false
+	for _, raw := range values {
+		if len(raw) == 0 {
+			continue
+		}
+		value, valueSet, errValue := decodeOptionalAPIKeyUserID(raw)
+		if errValue != nil {
+			return nil, false, errValue
+		}
+		if !selectedSet {
+			selected = value
+			selectedSet = valueSet
+			continue
+		}
+		if !sameAPIKeyRequestUserID(selected, value) {
+			return nil, false, newAPIKeyRequestError("invalid_body", "conflicting user ID aliases")
+		}
+	}
+	return selected, selectedSet, nil
+}
+
+func sameAPIKeyRequestUserID(left *uint, right *uint) bool {
+	if left == nil || *left == 0 {
+		return right == nil || *right == 0
+	}
+	return right != nil && *right == *left
+}
+
+func (b apiKeyEntryBody) apiKey() (string, error) {
+	values := make([]string, 0, 4)
 	for _, value := range []*string{b.APIKey, b.APIKeyDash, b.Key, b.Value} {
 		if value == nil {
 			continue
 		}
-		if key := strings.TrimSpace(*value); key != "" {
-			return key
+		key := strings.TrimSpace(*value)
+		if key == "" {
+			return "", newAPIKeyRequestError("invalid_body", "API key aliases must not be blank")
+		}
+		values = append(values, key)
+	}
+	if len(values) == 0 {
+		return "", newAPIKeyRequestError("invalid_body", "API key entry is missing a non-empty key")
+	}
+	for _, value := range values[1:] {
+		if value != values[0] {
+			return "", newAPIKeyRequestError("invalid_body", "conflicting API key aliases")
 		}
 	}
-	return ""
+	return values[0], nil
 }
 
-func (b apiKeyEntryBody) modelGroups() *[]uint {
+func (b apiKeyEntryBody) modelGroups() (*[]uint, error) {
+	if b.ModelGroups != nil && b.ModelGroupsDash != nil && !sameAPIKeyRequestIDs(*b.ModelGroups, *b.ModelGroupsDash) {
+		return nil, newAPIKeyRequestError("invalid_body", "conflicting model group aliases")
+	}
 	if b.ModelGroups != nil {
-		return b.ModelGroups
+		return b.ModelGroups, nil
 	}
-	return b.ModelGroupsDash
-}
-
-func (b apiKeyEntryBody) userID() *uint {
-	if b.UserID != nil {
-		return b.UserID
-	}
-	return b.UserIDDash
+	return b.ModelGroupsDash, nil
 }
 
 func (h *Handler) createAPIKeyEntry(c *gin.Context) {
+	limitAPIKeyRequestBody(c)
 	data, errData := c.GetRawData()
 	if errData != nil {
-		respondError(c, http.StatusBadRequest, "invalid_body", errData)
+		respondAPIKeyRequestError(c, errData)
 		return
 	}
 	entry, errEntry := decodeAPIKeyEntry(data)
-	if errEntry != nil || strings.TrimSpace(entry.APIKey) == "" {
-		respondError(c, http.StatusBadRequest, "invalid_body", errEntry)
+	if errEntry != nil {
+		respondAPIKeyRequestError(c, errEntry)
 		return
 	}
 
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
-	record, errCreate := h.repo.CreateAPIKey(ctx, entry)
+	record, runtimeChanged, errCreate := h.repo.CreateAPIKeyWithRuntimeChange(ctx, entry)
 	if errCreate != nil {
 		respondAPIKeyMutationError(c, errCreate)
 		return
 	}
-	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
-		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
-		return
+	if runtimeChanged {
+		if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+			respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+			return
+		}
 	}
 	responseEntry, errResponseEntry := clusterAPIKeyEntryFromRecord(record)
 	if errResponseEntry != nil {
@@ -195,12 +435,27 @@ func (h *Handler) createAPIKeyEntry(c *gin.Context) {
 }
 
 func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
+	limitAPIKeyRequestBody(c)
 	var body apiKeyPatchBody
 	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
-		return fmt.Errorf("invalid body")
+		var maxBytesError *http.MaxBytesError
+		if errors.As(errBindJSON, &maxBytesError) {
+			return errBindJSON
+		}
+		return newAPIKeyRequestError("invalid_body", "invalid API key patch body: %v", errBindJSON)
 	}
-	if body.id() != nil && (body.Index != nil || body.Old != nil) {
+	selectorID, errSelectorID := body.selectorID()
+	if errSelectorID != nil {
+		return errSelectorID
+	}
+	if selectorID != nil && (body.Index != nil || body.Old != nil) {
 		return fmt.Errorf("invalid api key selector")
+	}
+	if body.Index != nil && (body.Old != nil || body.New != nil) {
+		return fmt.Errorf("invalid api key selector")
+	}
+	if body.Old != nil && body.New == nil {
+		return fmt.Errorf("old requires new")
 	}
 
 	ctx, cancel := h.requestContext(c)
@@ -217,7 +472,7 @@ func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 		selector.Index = body.Index
 		next, errEntry := decodeAPIKeyEntry(body.Value)
 		if errEntry != nil {
-			return fmt.Errorf("invalid value")
+			return errEntry
 		}
 		if strings.TrimSpace(next.APIKey) == "" {
 			return fmt.Errorf("invalid value")
@@ -233,19 +488,23 @@ func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 		update.APIKey = &newKey
 		appendIfMissing = true
 	} else {
-		if id := body.id(); id != nil {
+		selectorKey, errSelectorKey := body.selectorAPIKey()
+		if errSelectorKey != nil {
+			return errSelectorKey
+		}
+		if id := selectorID; id != nil {
 			if *id == 0 {
 				return fmt.Errorf("invalid id")
 			}
 			selector.ID = *id
-			selector.APIKey = body.apiKey()
+			selector.APIKey = selectorKey
 		} else {
-			selector.APIKey = body.apiKey()
+			selector.APIKey = selectorKey
 		}
 		if len(body.Value) > 0 {
 			next, errEntry := decodeAPIKeyEntry(body.Value)
 			if errEntry != nil {
-				return fmt.Errorf("invalid value")
+				return errEntry
 			}
 			applyAPIKeyEntryUpdate(&update, next)
 		}
@@ -256,35 +515,61 @@ func (h *Handler) patchAPIKeyEntries(c *gin.Context) error {
 			}
 			update.APIKey = &newKey
 		}
-		if userID := body.userID(); userID != nil {
+		userID, userIDSet, errUserID := decodeOptionalAPIKeyUserIDAliases(body.UserID, body.UserIDDash)
+		if errUserID != nil {
+			return errUserID
+		}
+		if userIDSet {
+			if userID == nil {
+				zero := uint(0)
+				userID = &zero
+			}
 			update.UserID = userID
 		}
 		if body.Channels != nil {
 			update.Channels = body.Channels
 		}
-		if modelGroups := body.modelGroups(); modelGroups != nil {
+		modelGroups, errModelGroups := body.modelGroups()
+		if errModelGroups != nil {
+			return errModelGroups
+		}
+		if modelGroups != nil {
 			update.ModelGroups = modelGroups
 		}
 	}
+	displayName, displayNameSet, errDisplayName := decodeOptionalAPIKeyDisplayName(body.DisplayName)
+	if errDisplayName != nil {
+		return errDisplayName
+	}
+	if displayNameSet {
+		update.DisplayName = displayName
+		update.DisplayNameSet = true
+	}
 
-	if update.APIKey == nil && update.UserID == nil && update.Channels == nil && update.ModelGroups == nil {
+	if update.APIKey == nil && !update.DisplayNameSet && update.UserID == nil && update.Channels == nil && update.ModelGroups == nil {
 		return fmt.Errorf("missing fields")
 	}
 	if selector.ID == 0 && selector.Index == nil && strings.TrimSpace(selector.APIKey) == "" {
 		return fmt.Errorf("missing api key selector")
 	}
 
-	record, errUpdate := h.repo.UpdateAPIKey(ctx, selector, update)
+	record, runtimeChanged, errUpdate := h.repo.UpdateAPIKeyWithRuntimeChange(ctx, selector, update)
 	if errUpdate != nil && appendIfMissing && errors.Is(errUpdate, gorm.ErrRecordNotFound) {
-		record, errUpdate = h.repo.CreateAPIKey(ctx, cluster.APIKeyEntryUpdate{APIKey: *update.APIKey})
+		record, runtimeChanged, errUpdate = h.repo.CreateAPIKeyWithRuntimeChange(ctx, cluster.APIKeyEntryUpdate{
+			APIKey:         *update.APIKey,
+			DisplayName:    update.DisplayName,
+			DisplayNameSet: update.DisplayNameSet,
+		})
 	}
 	if errUpdate != nil {
 		respondAPIKeyMutationError(c, errUpdate)
 		return nil
 	}
-	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
-		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
-		return nil
+	if runtimeChanged {
+		if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+			respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+			return nil
+		}
 	}
 	responseEntry, errResponseEntry := clusterAPIKeyEntryFromRecord(record)
 	if errResponseEntry != nil {
@@ -340,8 +625,17 @@ func applyAPIKeyEntryUpdate(update *cluster.APIKeyAdminUpdate, entry cluster.API
 	if key := strings.TrimSpace(entry.APIKey); key != "" {
 		update.APIKey = &key
 	}
-	if entry.UserID != nil {
-		update.UserID = entry.UserID
+	if entry.DisplayNameSet {
+		update.DisplayName = entry.DisplayName
+		update.DisplayNameSet = true
+	}
+	if entry.UserIDSet || entry.UserID != nil {
+		if entry.UserID == nil {
+			zero := uint(0)
+			update.UserID = &zero
+		} else {
+			update.UserID = entry.UserID
+		}
 	}
 	if entry.Channels != nil {
 		update.Channels = entry.Channels
@@ -361,21 +655,32 @@ func respondAPIKeyMutationError(c *gin.Context, err error) {
 		respondError(c, http.StatusNotFound, "api_key_not_found", err)
 	case errors.Is(err, cluster.ErrAPIKeySelectorMismatch):
 		respondError(c, http.StatusBadRequest, "invalid_api_key_selector", err)
+	case errors.Is(err, cluster.ErrInvalidAPIKeyDisplayName):
+		respondError(c, http.StatusBadRequest, "invalid_display_name", err)
 	default:
 		respondError(c, http.StatusInternalServerError, "write_failed", err)
 	}
 }
 
-func (b apiKeyPatchBody) apiKey() string {
-	for _, value := range []*string{b.APIKey, b.APIKeyDash, b.Key} {
-		if value == nil {
-			continue
-		}
-		if key := strings.TrimSpace(*value); key != "" {
-			return key
-		}
+func limitAPIKeyRequestBody(c *gin.Context) {
+	if c == nil || c.Request == nil || c.Request.Body == nil {
+		return
 	}
-	return ""
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, apiKeyMaxRequestBodySize)
+}
+
+func respondAPIKeyRequestError(c *gin.Context, err error) {
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		respondError(c, http.StatusRequestEntityTooLarge, "request_body_too_large", fmt.Errorf("API key request body exceeds %d bytes", apiKeyMaxRequestBodySize))
+		return
+	}
+	requestError := &apiKeyRequestError{}
+	if errors.As(err, &requestError) {
+		respondError(c, http.StatusBadRequest, requestError.code, requestError.err)
+		return
+	}
+	respondError(c, http.StatusBadRequest, "invalid_body", err)
 }
 
 func clusterAPIKeyEntryFromRecord(record *cluster.APIKeyRecord) (cluster.APIKeyEntry, error) {
@@ -396,6 +701,7 @@ func apiKeyEntryToMap(entry cluster.APIKeyEntry) gin.H {
 		"api_key_id":   entry.ID,
 		"api-key":      strings.TrimSpace(entry.APIKey),
 		"api_key":      strings.TrimSpace(entry.APIKey),
+		"display_name": optionalAPIKeyDisplayNameValue(entry.DisplayName),
 		"user-id":      optionalUserIDValue(entry.UserID),
 		"user_id":      optionalUserIDValue(entry.UserID),
 		"channels":     channels,
@@ -403,27 +709,45 @@ func apiKeyEntryToMap(entry cluster.APIKeyEntry) gin.H {
 	}
 }
 
-func (b apiKeyPatchBody) modelGroups() *[]uint {
+func optionalAPIKeyDisplayNameValue(displayName *string) any {
+	if displayName == nil {
+		return nil
+	}
+	value := strings.TrimSpace(*displayName)
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func (b apiKeyPatchBody) modelGroups() (*[]uint, error) {
+	if b.ModelGroups != nil && b.ModelGroupsDash != nil && !sameAPIKeyRequestIDs(*b.ModelGroups, *b.ModelGroupsDash) {
+		return nil, newAPIKeyRequestError("invalid_body", "conflicting model group aliases")
+	}
 	if b.ModelGroups != nil {
-		return b.ModelGroups
+		return b.ModelGroups, nil
 	}
-	return b.ModelGroupsDash
+	return b.ModelGroupsDash, nil
 }
 
-func (b apiKeyPatchBody) userID() *uint {
-	if b.UserID != nil {
-		return b.UserID
-	}
-	return b.UserIDDash
-}
-
-func (b apiKeyPatchBody) id() *uint {
-	for _, value := range []*uint{b.ID, b.APIKeyID, b.APIKeyIDDash} {
-		if value != nil {
-			return value
+func sameAPIKeyRequestIDs(left []uint, right []uint) bool {
+	normalize := func(values []uint) []uint {
+		seen := make(map[uint]struct{}, len(values))
+		out := make([]uint, 0, len(values))
+		for _, value := range values {
+			if value == 0 {
+				continue
+			}
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			out = append(out, value)
 		}
+		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+		return out
 	}
-	return nil
+	return reflect.DeepEqual(normalize(left), normalize(right))
 }
 
 func normalizeAPIKeyEntryUserID(userID *uint) *uint {

--- a/internal/cluster/management/api_keys_test.go
+++ b/internal/cluster/management/api_keys_test.go
@@ -1,0 +1,719 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/cluster"
+	appconfig "github.com/router-for-me/CLIProxyAPIHome/internal/config"
+	"github.com/router-for-me/CLIProxyAPIHome/internal/home"
+)
+
+type apiKeyManagementEntryResponse struct {
+	ID          uint    `json:"id"`
+	APIKey      string  `json:"api_key"`
+	DisplayName *string `json:"display_name"`
+	UserID      *uint   `json:"user_id"`
+	Channels    []uint  `json:"channels"`
+	ModelGroups []uint  `json:"model_groups"`
+}
+
+func TestAPIKeyDisplayNameManagementCRUDPreservesKeyIdentityAndBindings(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	ctx := t.Context()
+	username := "display-name-user"
+	user, errUser := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username})
+	if errUser != nil {
+		t.Fatalf("CreateUser() error = %v", errUser)
+	}
+	channel, errChannel := handler.repo.CreateChannelGroup(ctx, "display-name-channel", false)
+	if errChannel != nil {
+		t.Fatalf("CreateChannelGroup() error = %v", errChannel)
+	}
+	modelGroup, errModelGroup := handler.repo.CreateModelGroup(ctx, "display-name-models", false)
+	if errModelGroup != nil {
+		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
+	}
+
+	createResponse := performAPIKeyManagementRequest(t, engine, http.MethodPost, "/api-keys", map[string]any{
+		"api_key":      "client-key-1",
+		"display_name": "  Production key  ",
+		"user_id":      user.ID,
+		"channels":     []uint{channel.ID},
+		"model_groups": []uint{modelGroup.ID},
+	})
+	if createResponse.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", createResponse.Code, createResponse.Body.String())
+	}
+	created := decodeAPIKeyMutationResponse(t, createResponse)
+	assertAPIKeyManagementEntry(t, created, "client-key-1", "Production key", user.ID, []uint{channel.ID}, []uint{modelGroup.ID})
+
+	patchResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":           created.ID,
+		"display_name": "  Primary production key  ",
+	})
+	if patchResponse.Code != http.StatusOK {
+		t.Fatalf("patch status = %d body=%s", patchResponse.Code, patchResponse.Body.String())
+	}
+	patched := decodeAPIKeyMutationResponse(t, patchResponse)
+	if patched.ID != created.ID {
+		t.Fatalf("patched id = %d, want %d", patched.ID, created.ID)
+	}
+	assertAPIKeyManagementEntry(t, patched, "client-key-1", "Primary production key", user.ID, []uint{channel.ID}, []uint{modelGroup.ID})
+
+	valid, errValidate := handler.repo.ValidateAPIKey(ctx, "client-key-1")
+	if errValidate != nil {
+		t.Fatalf("ValidateAPIKey() error = %v", errValidate)
+	}
+	if !valid {
+		t.Fatal("original API key no longer authenticates after display-name-only update")
+	}
+
+	listResponse := performAPIKeyManagementRequest(t, engine, http.MethodGet, "/api-keys", nil)
+	if listResponse.Code != http.StatusOK {
+		t.Fatalf("list status = %d body=%s", listResponse.Code, listResponse.Body.String())
+	}
+	var listPayload struct {
+		Keys    []string                        `json:"api-keys"`
+		Items   []apiKeyManagementEntryResponse `json:"items"`
+		Entries []apiKeyManagementEntryResponse `json:"api_key_entries"`
+	}
+	decodeAPIKeyManagementResponse(t, listResponse, &listPayload)
+	if !reflect.DeepEqual(listPayload.Keys, []string{"client-key-1"}) {
+		t.Fatalf("compatibility keys = %#v, want raw key unchanged", listPayload.Keys)
+	}
+	if len(listPayload.Items) != 1 || len(listPayload.Entries) != 1 {
+		t.Fatalf("list items/entries = %d/%d, want 1/1", len(listPayload.Items), len(listPayload.Entries))
+	}
+	assertAPIKeyManagementEntry(t, listPayload.Items[0], "client-key-1", "Primary production key", user.ID, []uint{channel.ID}, []uint{modelGroup.ID})
+
+	clearResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":           created.ID,
+		"display_name": "   ",
+	})
+	if clearResponse.Code != http.StatusOK {
+		t.Fatalf("clear status = %d body=%s", clearResponse.Code, clearResponse.Body.String())
+	}
+	cleared := decodeAPIKeyMutationResponse(t, clearResponse)
+	if cleared.DisplayName != nil {
+		t.Fatalf("cleared display_name = %q, want null", *cleared.DisplayName)
+	}
+	assertAPIKeyManagementEntryBindings(t, cleared, "client-key-1", user.ID, []uint{channel.ID}, []uint{modelGroup.ID})
+
+	restoreResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":           created.ID,
+		"display_name": "Temporary name",
+	})
+	if restoreResponse.Code != http.StatusOK {
+		t.Fatalf("restore-name status = %d body=%s", restoreResponse.Code, restoreResponse.Body.String())
+	}
+	nullResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":           created.ID,
+		"display_name": nil,
+	})
+	if nullResponse.Code != http.StatusOK {
+		t.Fatalf("null-name status = %d body=%s", nullResponse.Code, nullResponse.Body.String())
+	}
+	nullCleared := decodeAPIKeyMutationResponse(t, nullResponse)
+	if nullCleared.DisplayName != nil {
+		t.Fatalf("null-cleared display_name = %q, want null", *nullCleared.DisplayName)
+	}
+	assertAPIKeyManagementEntryBindings(t, nullCleared, "client-key-1", user.ID, []uint{channel.ID}, []uint{modelGroup.ID})
+}
+
+func TestPutAPIKeysPreservesOmittedDisplayNameAndClearsExplicitNull(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	displayName := "Compatibility key"
+	record, errCreate := handler.repo.CreateAPIKey(t.Context(), cluster.APIKeyEntryUpdate{
+		APIKey:         "compat-client-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+	})
+	if errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	omittedResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+		"api_key_entries": []map[string]any{{"api_key": "compat-client-key"}},
+	})
+	if omittedResponse.Code != http.StatusOK {
+		t.Fatalf("omitted-name PUT status = %d body=%s", omittedResponse.Code, omittedResponse.Body.String())
+	}
+	omitted := loadSingleAPIKeyEntry(t, handler.repo)
+	if omitted.ID != record.ID || omitted.DisplayName == nil || *omitted.DisplayName != displayName {
+		t.Fatalf("omitted-name PUT entry = %#v, want id %d and display name %q", omitted, record.ID, displayName)
+	}
+	legacyResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", []string{"compat-client-key"})
+	if legacyResponse.Code != http.StatusOK {
+		t.Fatalf("legacy string PUT status = %d body=%s", legacyResponse.Code, legacyResponse.Body.String())
+	}
+	legacy := loadSingleAPIKeyEntry(t, handler.repo)
+	if legacy.ID != record.ID || legacy.DisplayName == nil || *legacy.DisplayName != displayName {
+		t.Fatalf("legacy string PUT entry = %#v, want id %d and display name %q", legacy, record.ID, displayName)
+	}
+
+	renamedDisplayName := "Renamed by PUT"
+	renameResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+		"api_key_entries": []map[string]any{{"api_key": "compat-client-key", "display_name": renamedDisplayName}},
+	})
+	if renameResponse.Code != http.StatusOK {
+		t.Fatalf("renamed-name PUT status = %d body=%s", renameResponse.Code, renameResponse.Body.String())
+	}
+	renamed := loadSingleAPIKeyEntry(t, handler.repo)
+	if renamed.ID != record.ID || renamed.DisplayName == nil || *renamed.DisplayName != renamedDisplayName {
+		t.Fatalf("renamed-name PUT entry = %#v, want same id and display name %q", renamed, renamedDisplayName)
+	}
+
+	nullResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+		"api_key_entries": []map[string]any{{"api_key": "compat-client-key", "display_name": nil}},
+	})
+	if nullResponse.Code != http.StatusOK {
+		t.Fatalf("null-name PUT status = %d body=%s", nullResponse.Code, nullResponse.Body.String())
+	}
+	cleared := loadSingleAPIKeyEntry(t, handler.repo)
+	if cleared.ID != record.ID || cleared.DisplayName != nil {
+		t.Fatalf("null-name PUT entry = %#v, want same id and cleared display name", cleared)
+	}
+
+	invalidResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":           record.ID,
+		"display_name": 42,
+	})
+	if invalidResponse.Code != http.StatusBadRequest {
+		t.Fatalf("invalid display_name status = %d body=%s, want 400", invalidResponse.Code, invalidResponse.Body.String())
+	}
+
+	for _, invalidName := range []string{strings.Repeat("名", cluster.APIKeyDisplayNameMaxLength+1), "invalid\nname", "\tinvalid"} {
+		postResponse := performAPIKeyManagementRequest(t, engine, http.MethodPost, "/api-keys", map[string]any{
+			"api_key": "invalid-name-key", "display_name": invalidName,
+		})
+		if postResponse.Code != http.StatusBadRequest {
+			t.Fatalf("invalid POST display_name status = %d body=%s, want 400", postResponse.Code, postResponse.Body.String())
+		}
+		patchResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+			"id": record.ID, "display_name": invalidName,
+		})
+		if patchResponse.Code != http.StatusBadRequest {
+			t.Fatalf("invalid PATCH display_name status = %d body=%s, want 400", patchResponse.Code, patchResponse.Body.String())
+		}
+		putResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+			"api_key_entries": []map[string]any{{"api_key": "compat-client-key", "display_name": invalidName}},
+		})
+		if putResponse.Code != http.StatusBadRequest {
+			t.Fatalf("invalid PUT display_name status = %d body=%s, want 400", putResponse.Code, putResponse.Body.String())
+		}
+		entry := loadSingleAPIKeyEntry(t, handler.repo)
+		if entry.ID != record.ID || entry.APIKey != record.APIKey || entry.DisplayName != nil {
+			t.Fatalf("rejected display_name mutated API key entry: %#v", entry)
+		}
+	}
+}
+
+func TestPutAPIKeysPreservesOmittedRuntimeBindingsAndClearsExplicitUserID(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	ctx := t.Context()
+	username := "put-presence-user"
+	user, errUser := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username})
+	if errUser != nil {
+		t.Fatalf("CreateUser() error = %v", errUser)
+	}
+	channel, errChannel := handler.repo.CreateChannelGroup(ctx, "put-presence-channel", false)
+	if errChannel != nil {
+		t.Fatalf("CreateChannelGroup() error = %v", errChannel)
+	}
+	modelGroup, errModelGroup := handler.repo.CreateModelGroup(ctx, "put-presence-models", false)
+	if errModelGroup != nil {
+		t.Fatalf("CreateModelGroup() error = %v", errModelGroup)
+	}
+	displayName := "Before PUT"
+	channels := []uint{channel.ID}
+	modelGroups := []uint{modelGroup.ID}
+	record, errCreate := handler.repo.CreateAPIKey(ctx, cluster.APIKeyEntryUpdate{
+		APIKey:         "put-presence-key",
+		DisplayName:    &displayName,
+		DisplayNameSet: true,
+		UserID:         &user.ID,
+		UserIDSet:      true,
+		Channels:       &channels,
+		ModelGroups:    &modelGroups,
+	})
+	if errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	renameResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+		"api_key_entries": []map[string]any{{"api_key": record.APIKey, "display_name": "After PUT"}},
+	})
+	if renameResponse.Code != http.StatusOK {
+		t.Fatalf("name-only PUT status = %d body=%s", renameResponse.Code, renameResponse.Body.String())
+	}
+	renamed := loadSingleAPIKeyEntry(t, handler.repo)
+	if renamed.ID != record.ID || renamed.DisplayName == nil || *renamed.DisplayName != "After PUT" {
+		t.Fatalf("name-only PUT entry = %#v, want stable ID and renamed display name", renamed)
+	}
+	if renamed.UserID == nil || *renamed.UserID != user.ID || !reflect.DeepEqual(renamed.Channels, channels) || !reflect.DeepEqual(renamed.ModelGroups, modelGroups) {
+		t.Fatalf("name-only PUT changed runtime bindings: %#v", renamed)
+	}
+	valid, errValidate := handler.repo.ValidateAPIKey(ctx, record.APIKey)
+	if errValidate != nil || !valid {
+		t.Fatalf("ValidateAPIKey() = %t, %v; want original key accepted", valid, errValidate)
+	}
+
+	for _, explicitUserID := range []any{nil, float64(0)} {
+		if _, errRebind := handler.repo.UpdateAPIKeyBindings(ctx, record.APIKey, &user.ID, nil, nil); errRebind != nil {
+			t.Fatalf("rebind user before clearing with %v: %v", explicitUserID, errRebind)
+		}
+		clearResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+			"api_key_entries": []map[string]any{{"api_key": record.APIKey, "user_id": explicitUserID}},
+		})
+		if clearResponse.Code != http.StatusOK {
+			t.Fatalf("clear user_id %v PUT status = %d body=%s", explicitUserID, clearResponse.Code, clearResponse.Body.String())
+		}
+		cleared := loadSingleAPIKeyEntry(t, handler.repo)
+		if cleared.UserID != nil {
+			t.Fatalf("cleared user_id = %v, want nil for %v", cleared.UserID, explicitUserID)
+		}
+		if !reflect.DeepEqual(cleared.Channels, channels) || !reflect.DeepEqual(cleared.ModelGroups, modelGroups) {
+			t.Fatalf("clearing user_id changed group bindings: %#v", cleared)
+		}
+	}
+}
+
+func TestPatchAPIKeysNestedNullClearsUserID(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	ctx := t.Context()
+	username := "nested-null-user"
+	user, errUser := handler.repo.CreateUser(ctx, cluster.UserUpdate{Username: &username})
+	if errUser != nil {
+		t.Fatalf("CreateUser() error = %v", errUser)
+	}
+	record, errCreate := handler.repo.CreateAPIKey(ctx, cluster.APIKeyEntryUpdate{APIKey: "nested-null-key", UserID: &user.ID, UserIDSet: true})
+	if errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+
+	response := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id":    record.ID,
+		"value": map[string]any{"api_key": record.APIKey, "user_id": nil},
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("nested null PATCH status = %d body=%s", response.Code, response.Body.String())
+	}
+	updated := decodeAPIKeyMutationResponse(t, response)
+	if updated.UserID != nil || updated.ID != record.ID || updated.APIKey != record.APIKey {
+		t.Fatalf("nested null PATCH entry = %#v, want same key with no user", updated)
+	}
+}
+
+func TestAPIKeyRuntimeRefreshOnlyForRuntimeChanges(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementRuntimeTestServer(t)
+	defer closeRepo()
+	initialRuntimeConfig := handler.runtime.Config()
+
+	createResponse := performAPIKeyManagementRequest(t, engine, http.MethodPost, "/api-keys", map[string]any{"api_key": "runtime-refresh-key"})
+	if createResponse.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", createResponse.Code, createResponse.Body.String())
+	}
+	created := decodeAPIKeyMutationResponse(t, createResponse)
+	runtimeConfigAfterCreate := handler.runtime.Config()
+	if runtimeConfigAfterCreate == initialRuntimeConfig {
+		t.Fatal("runtime config was not refreshed after API key creation")
+	}
+	eventsAfterCreate := apiKeyManagementEventCount(t, handler.repo)
+
+	nameResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id": created.ID, "display_name": "Runtime metadata only",
+	})
+	if nameResponse.Code != http.StatusOK {
+		t.Fatalf("name-only PATCH status = %d body=%s", nameResponse.Code, nameResponse.Body.String())
+	}
+	if got := apiKeyManagementEventCount(t, handler.repo); got != eventsAfterCreate {
+		t.Fatalf("config events after name-only PATCH = %d, want %d", got, eventsAfterCreate)
+	}
+	if got := handler.runtime.Config(); got != runtimeConfigAfterCreate {
+		t.Fatal("runtime config was refreshed after display-name-only PATCH")
+	}
+	putNameResponse := performAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", map[string]any{
+		"api_key_entries": []map[string]any{{"api_key": created.APIKey, "display_name": "PUT metadata only"}},
+	})
+	if putNameResponse.Code != http.StatusOK {
+		t.Fatalf("name-only PUT status = %d body=%s", putNameResponse.Code, putNameResponse.Body.String())
+	}
+	if got := apiKeyManagementEventCount(t, handler.repo); got != eventsAfterCreate {
+		t.Fatalf("config events after name-only PUT = %d, want %d", got, eventsAfterCreate)
+	}
+	if got := handler.runtime.Config(); got != runtimeConfigAfterCreate {
+		t.Fatal("runtime config was refreshed after display-name-only PUT")
+	}
+
+	rotateResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id": created.ID, "new": "runtime-refresh-key-rotated",
+	})
+	if rotateResponse.Code != http.StatusOK {
+		t.Fatalf("key rotation PATCH status = %d body=%s", rotateResponse.Code, rotateResponse.Body.String())
+	}
+	if got := apiKeyManagementEventCount(t, handler.repo); got != eventsAfterCreate+1 {
+		t.Fatalf("config events after key rotation = %d, want %d", got, eventsAfterCreate+1)
+	}
+	runtimeConfigAfterRotation := handler.runtime.Config()
+	if runtimeConfigAfterRotation == runtimeConfigAfterCreate {
+		t.Fatal("runtime config was not refreshed after API key rotation")
+	}
+	validOld, errValidateOld := handler.repo.ValidateAPIKey(t.Context(), "runtime-refresh-key")
+	validNew, errValidateNew := handler.repo.ValidateAPIKey(t.Context(), "runtime-refresh-key-rotated")
+	if errValidateOld != nil || errValidateNew != nil || validOld || !validNew {
+		t.Fatalf("rotated key validation old=%t/%v new=%t/%v", validOld, errValidateOld, validNew, errValidateNew)
+	}
+
+	bindingResponse := performAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", map[string]any{
+		"id": created.ID, "channels": []uint{101},
+	})
+	if bindingResponse.Code != http.StatusOK {
+		t.Fatalf("binding PATCH status = %d body=%s", bindingResponse.Code, bindingResponse.Body.String())
+	}
+	if got := apiKeyManagementEventCount(t, handler.repo); got != eventsAfterCreate+2 {
+		t.Fatalf("config events after binding update = %d, want %d", got, eventsAfterCreate+2)
+	}
+	if got := handler.runtime.Config(); got == runtimeConfigAfterRotation {
+		t.Fatal("runtime config was not refreshed after API key binding update")
+	}
+}
+
+func TestPutAPIKeysRejectsMalformedReplacementWithoutDeletingExistingKeys(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	if _, errCreate := handler.repo.CreateAPIKey(t.Context(), cluster.APIKeyEntryUpdate{APIKey: "preserved-key"}); errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+	malformedBodies := []string{
+		`null`,
+		`[null]`,
+		`[{}]`,
+		`[{"display_name":"name only"}]`,
+		`[""]`,
+		`{"items":null}`,
+		`[42]`,
+		`[true]`,
+		`{"items":[],"api_key_entries":[]}`,
+		`[{"api_key":"one","key":"two"}]`,
+		`[{"api_key":""}]`,
+		`[{"api_key":"","key":"fallback-key"}]`,
+		`[{"api_key":"preserved-key","user_id":1,"user-id":2}]`,
+		`[{"api_key":"preserved-key","model_groups":[1],"model-groups":[2]}]`,
+	}
+	for _, body := range malformedBodies {
+		response := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", body, nil)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("malformed PUT %s status = %d body=%s, want 400", body, response.Code, response.Body.String())
+		}
+		entry := loadSingleAPIKeyEntry(t, handler.repo)
+		if entry.APIKey != "preserved-key" {
+			t.Fatalf("malformed PUT %s changed entry to %#v", body, entry)
+		}
+	}
+	compatibilityResponse := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `[{"api_key":"preserved-key","future_metadata":"ignored"}]`, nil)
+	if compatibilityResponse.Code != http.StatusOK {
+		t.Fatalf("unknown metadata compatibility PUT status = %d body=%s", compatibilityResponse.Code, compatibilityResponse.Body.String())
+	}
+
+	for _, body := range []string{`[]`, `{"items":[]}`} {
+		response := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", body, nil)
+		if response.Code != http.StatusOK {
+			t.Fatalf("explicit empty PUT %s status = %d body=%s, want 200", body, response.Code, response.Body.String())
+		}
+		entries, errEntries := handler.repo.ListAPIKeyEntries(t.Context())
+		if errEntries != nil || len(entries) != 0 {
+			t.Fatalf("entries after explicit empty PUT = %#v, %v; want empty", entries, errEntries)
+		}
+		if _, errRestore := handler.repo.CreateAPIKey(t.Context(), cluster.APIKeyEntryUpdate{APIKey: "preserved-key"}); errRestore != nil {
+			t.Fatalf("restore API key after explicit empty PUT: %v", errRestore)
+		}
+	}
+}
+
+func TestAPIKeyDisplayNameErrorsUseStableEnvelope(t *testing.T) {
+	_, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	requests := []struct {
+		method string
+		body   string
+	}{
+		{method: http.MethodPost, body: `{"api_key":"post-key","display_name":42}`},
+		{method: http.MethodPut, body: `[{"api_key":"put-key","display_name":42}]`},
+		{method: http.MethodPatch, body: `{"api_key":"missing-key","display_name":42}`},
+		{method: http.MethodPatch, body: `{"api_key":"missing-key","value":{"api_key":"missing-key","display_name":42}}`},
+	}
+	for _, request := range requests {
+		response := performRawAPIKeyManagementRequest(t, engine, request.method, "/api-keys", request.body, nil)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("%s display_name type error status = %d body=%s", request.method, response.Code, response.Body.String())
+		}
+		var envelope struct {
+			Error   string `json:"error"`
+			Message string `json:"message"`
+		}
+		decodeAPIKeyManagementResponse(t, response, &envelope)
+		if envelope.Error != "invalid_display_name" || envelope.Message == "" {
+			t.Fatalf("%s display_name error = %#v", request.method, envelope)
+		}
+	}
+}
+
+func TestPatchAPIKeysRejectsConflictingSelectorAliases(t *testing.T) {
+	_, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	for _, body := range []string{
+		`{"api_key":"one","key":"two","display_name":"name"}`,
+		`{"id":1,"api_key_id":2,"display_name":"name"}`,
+		`{"api_key":"one","user_id":1,"user-id":2}`,
+		`{"api_key":"one","model_groups":[1],"model-groups":[2]}`,
+	} {
+		response := performRawAPIKeyManagementRequest(t, engine, http.MethodPatch, "/api-keys", body, nil)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("conflicting PATCH %s status = %d body=%s, want 400", body, response.Code, response.Body.String())
+		}
+	}
+}
+
+func TestAPIKeyRequestBodyLimit(t *testing.T) {
+	_, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	tooLargeName := strings.Repeat("a", int(apiKeyMaxRequestBodySize))
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {
+		body := fmt.Sprintf(`{"api_key":"limited-key","display_name":%q}`, tooLargeName)
+		if method == http.MethodPut {
+			body = "[" + body + "]"
+		}
+		response := performRawAPIKeyManagementRequest(t, engine, method, "/api-keys", body, nil)
+		if response.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("%s oversized body status = %d body=%s, want 413", method, response.Code, response.Body.String())
+		}
+	}
+}
+
+func TestAPIKeyCollectionETagGuardsFullReplacement(t *testing.T) {
+	handler, engine, closeRepo := newAPIKeyManagementTestServer(t)
+	defer closeRepo()
+
+	if _, errCreate := handler.repo.CreateAPIKey(t.Context(), cluster.APIKeyEntryUpdate{APIKey: "first-key"}); errCreate != nil {
+		t.Fatalf("CreateAPIKey() error = %v", errCreate)
+	}
+	getResponse := performRawAPIKeyManagementRequest(t, engine, http.MethodGet, "/api-keys", "", nil)
+	etag := getResponse.Header().Get("ETag")
+	if getResponse.Code != http.StatusOK || etag == "" {
+		t.Fatalf("GET status = %d ETag=%q body=%s", getResponse.Code, etag, getResponse.Body.String())
+	}
+	if cacheControl := getResponse.Header().Get("Cache-Control"); cacheControl != "no-store" {
+		t.Fatalf("GET Cache-Control = %q, want no-store", cacheControl)
+	}
+
+	success := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `["first-key"]`, map[string]string{"If-Match": etag})
+	if success.Code != http.StatusOK {
+		t.Fatalf("matching If-Match PUT status = %d body=%s", success.Code, success.Body.String())
+	}
+	for _, invalidIfMatch := range []string{"*", "W/" + etag, strings.Trim(etag, `"`)} {
+		response := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `["first-key"]`, map[string]string{"If-Match": invalidIfMatch})
+		if response.Code != http.StatusPreconditionFailed {
+			t.Fatalf("invalid If-Match %q status = %d body=%s, want 412", invalidIfMatch, response.Code, response.Body.String())
+		}
+	}
+	emptyIfMatch := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `["first-key"]`, map[string]string{"If-Match": ""})
+	if emptyIfMatch.Code != http.StatusPreconditionFailed {
+		t.Fatalf("empty If-Match status = %d body=%s, want 412", emptyIfMatch.Code, emptyIfMatch.Body.String())
+	}
+	multipleIfMatchRequest := httptest.NewRequest(http.MethodPut, "/api-keys", strings.NewReader(`["first-key"]`))
+	multipleIfMatchRequest.Header.Set("Content-Type", "application/json")
+	multipleIfMatchRequest.Header.Add("If-Match", `"stale"`)
+	multipleIfMatchRequest.Header.Add("If-Match", etag)
+	multipleIfMatch := httptest.NewRecorder()
+	engine.ServeHTTP(multipleIfMatch, multipleIfMatchRequest)
+	if multipleIfMatch.Code != http.StatusOK {
+		t.Fatalf("multi-line matching If-Match status = %d body=%s, want 200", multipleIfMatch.Code, multipleIfMatch.Body.String())
+	}
+	concurrentResponse := performRawAPIKeyManagementRequest(t, engine, http.MethodPost, "/api-keys", `{"api_key":"concurrent-key"}`, nil)
+	if concurrentResponse.Code != http.StatusCreated {
+		t.Fatalf("concurrent POST status = %d body=%s", concurrentResponse.Code, concurrentResponse.Body.String())
+	}
+
+	stale := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `["first-key"]`, map[string]string{"If-Match": etag})
+	if stale.Code != http.StatusPreconditionFailed {
+		t.Fatalf("stale If-Match PUT status = %d body=%s, want 412", stale.Code, stale.Body.String())
+	}
+	entries, errEntries := handler.repo.ListAPIKeyEntries(t.Context())
+	if errEntries != nil || len(entries) != 2 {
+		t.Fatalf("entries after stale PUT = %#v, %v; want both keys", entries, errEntries)
+	}
+
+	legacy := performRawAPIKeyManagementRequest(t, engine, http.MethodPut, "/api-keys", `["first-key"]`, nil)
+	if legacy.Code != http.StatusOK {
+		t.Fatalf("unconditional legacy PUT status = %d body=%s", legacy.Code, legacy.Body.String())
+	}
+	entry := loadSingleAPIKeyEntry(t, handler.repo)
+	if entry.APIKey != "first-key" {
+		t.Fatalf("legacy PUT entry = %#v", entry)
+	}
+}
+
+func newAPIKeyManagementTestServer(t *testing.T) (*Handler, *gin.Engine, func()) {
+	return newAPIKeyManagementTestServerWithRuntime(t, nil)
+}
+
+func newAPIKeyManagementRuntimeTestServer(t *testing.T) (*Handler, *gin.Engine, func()) {
+	t.Helper()
+	runtime, errRuntime := home.NewRuntime(&appconfig.Config{AuthDir: t.TempDir()})
+	if errRuntime != nil {
+		t.Fatalf("home.NewRuntime() error = %v", errRuntime)
+	}
+	return newAPIKeyManagementTestServerWithRuntime(t, runtime)
+}
+
+func newAPIKeyManagementTestServerWithRuntime(t *testing.T, runtime *home.Runtime) (*Handler, *gin.Engine, func()) {
+	t.Helper()
+	db, errOpen := cluster.OpenSQLite(context.Background(), filepath.Join(t.TempDir(), "home.db"))
+	if errOpen != nil {
+		t.Fatalf("OpenSQLite() error = %v", errOpen)
+	}
+	sqlDB, errDB := db.DB()
+	if errDB != nil {
+		t.Fatalf("db.DB() error = %v", errDB)
+	}
+	closeRepo := func() {
+		if errClose := sqlDB.Close(); errClose != nil {
+			t.Errorf("close sqlite db: %v", errClose)
+		}
+	}
+	if errMigrate := cluster.AutoMigrate(db); errMigrate != nil {
+		closeRepo()
+		t.Fatalf("AutoMigrate() error = %v", errMigrate)
+	}
+	repo := cluster.NewRepository(db)
+	if runtime != nil {
+		if _, errEnsure := repo.EnsureLifecycleConfig(t.Context(), cluster.DefaultHeartbeatTimeout()); errEnsure != nil {
+			closeRepo()
+			t.Fatalf("EnsureLifecycleConfig() error = %v", errEnsure)
+		}
+	}
+	handler := NewHandler(repo, runtime, "127.0.0.1", 0)
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/api-keys", handler.GetAPIKeys)
+	engine.POST("/api-keys", handler.PostAPIKeys)
+	engine.PUT("/api-keys", handler.PutAPIKeys)
+	engine.PATCH("/api-keys", handler.PatchAPIKeys)
+	engine.DELETE("/api-keys", handler.DeleteAPIKeys)
+	return handler, engine, closeRepo
+}
+
+func performRawAPIKeyManagementRequest(t *testing.T, engine *gin.Engine, method string, path string, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if body != "" {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	for key, value := range headers {
+		request.Header.Set(key, value)
+	}
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	return response
+}
+
+func apiKeyManagementEventCount(t *testing.T, repo *cluster.Repository) int64 {
+	t.Helper()
+	maxID, errMaxID := repo.MaxEventID(t.Context())
+	if errMaxID != nil {
+		t.Fatalf("MaxEventID() error = %v", errMaxID)
+	}
+	return maxID
+}
+
+func performAPIKeyManagementRequest(t *testing.T, engine *gin.Engine, method string, path string, payload any) *httptest.ResponseRecorder {
+	t.Helper()
+	body := strings.NewReader("")
+	if payload != nil {
+		raw, errMarshal := json.Marshal(payload)
+		if errMarshal != nil {
+			t.Fatalf("marshal request body: %v", errMarshal)
+		}
+		body = strings.NewReader(string(raw))
+	}
+	request := httptest.NewRequest(method, path, body)
+	if payload != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	return response
+}
+
+func decodeAPIKeyMutationResponse(t *testing.T, response *httptest.ResponseRecorder) apiKeyManagementEntryResponse {
+	t.Helper()
+	var payload struct {
+		APIKey apiKeyManagementEntryResponse `json:"api_key"`
+	}
+	decodeAPIKeyManagementResponse(t, response, &payload)
+	return payload.APIKey
+}
+
+func decodeAPIKeyManagementResponse(t *testing.T, response *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if errDecode := json.Unmarshal(response.Body.Bytes(), target); errDecode != nil {
+		t.Fatalf("decode response %q: %v", response.Body.String(), errDecode)
+	}
+}
+
+func loadSingleAPIKeyEntry(t *testing.T, repo *cluster.Repository) cluster.APIKeyEntry {
+	t.Helper()
+	entries, errList := repo.ListAPIKeyEntries(t.Context())
+	if errList != nil {
+		t.Fatalf("ListAPIKeyEntries() error = %v", errList)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("API key entries = %d, want 1", len(entries))
+	}
+	return entries[0]
+}
+
+func assertAPIKeyManagementEntry(t *testing.T, entry apiKeyManagementEntryResponse, apiKey string, displayName string, userID uint, channels []uint, modelGroups []uint) {
+	t.Helper()
+	if entry.DisplayName == nil || *entry.DisplayName != displayName {
+		t.Fatalf("display_name = %v, want %q", entry.DisplayName, displayName)
+	}
+	assertAPIKeyManagementEntryBindings(t, entry, apiKey, userID, channels, modelGroups)
+}
+
+func assertAPIKeyManagementEntryBindings(t *testing.T, entry apiKeyManagementEntryResponse, apiKey string, userID uint, channels []uint, modelGroups []uint) {
+	t.Helper()
+	if entry.ID == 0 || entry.APIKey != apiKey {
+		t.Fatalf("entry identity = id:%d key:%q, want non-zero id and %q", entry.ID, entry.APIKey, apiKey)
+	}
+	if entry.UserID == nil || *entry.UserID != userID {
+		t.Fatalf("user_id = %v, want %d", entry.UserID, userID)
+	}
+	if !reflect.DeepEqual(entry.Channels, channels) {
+		t.Fatalf("channels = %#v, want %#v", entry.Channels, channels)
+	}
+	if !reflect.DeepEqual(entry.ModelGroups, modelGroups) {
+		t.Fatalf("model_groups = %#v, want %#v", entry.ModelGroups, modelGroups)
+	}
+}

--- a/internal/cluster/management/config_compat.go
+++ b/internal/cluster/management/config_compat.go
@@ -426,11 +426,13 @@ func (h *Handler) PutSwitchPreviewModel(c *gin.Context) {
 func (h *Handler) GetAPIKeys(c *gin.Context) {
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
-	entries, errEntries := h.repo.ListAPIKeyEntries(ctx)
+	entries, etag, errEntries := h.repo.ListAPIKeyEntriesWithETag(ctx)
 	if errEntries != nil {
 		respondError(c, http.StatusInternalServerError, "api_keys_load_failed", errEntries)
 		return
 	}
+	c.Header("Cache-Control", "no-store")
+	c.Header("ETag", etag)
 	c.JSON(http.StatusOK, apiKeyEntriesResponse(entries))
 }
 
@@ -441,19 +443,30 @@ func (h *Handler) PostAPIKeys(c *gin.Context) {
 
 // PutAPIKeys replaces an api keys.
 func (h *Handler) PutAPIKeys(c *gin.Context) {
+	limitAPIKeyRequestBody(c)
 	data, errData := c.GetRawData()
 	if errData != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read body"})
+		respondAPIKeyRequestError(c, errData)
 		return
 	}
 	entries, errEntries := decodeAPIKeyEntryUpdates(data)
 	if errEntries != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		respondAPIKeyRequestError(c, errEntries)
 		return
 	}
 	ctx, cancel := h.requestContext(c)
 	defer cancel()
-	if _, errReplace := h.repo.ReplaceAPIKeyEntries(ctx, entries); errReplace != nil {
+	var ifMatch *string
+	if values := c.Request.Header.Values("If-Match"); len(values) > 0 {
+		value := strings.Join(values, ",")
+		ifMatch = &value
+	}
+	stats, errReplace := h.repo.ReplaceAPIKeyEntriesIfMatch(ctx, entries, ifMatch)
+	if errReplace != nil {
+		if errors.Is(errReplace, cluster.ErrAPIKeyPreconditionFailed) {
+			respondError(c, http.StatusPreconditionFailed, "api_keys_precondition_failed", errReplace)
+			return
+		}
 		if cluster.IsAPIKeyConflictError(errReplace) {
 			respondError(c, http.StatusConflict, "api_key_exists", errReplace)
 			return
@@ -462,12 +475,18 @@ func (h *Handler) PutAPIKeys(c *gin.Context) {
 			respondError(c, http.StatusNotFound, "user_not_found", errReplace)
 			return
 		}
+		if errors.Is(errReplace, cluster.ErrInvalidAPIKeyDisplayName) {
+			respondError(c, http.StatusBadRequest, "invalid_display_name", errReplace)
+			return
+		}
 		respondError(c, http.StatusInternalServerError, "write_failed", errReplace)
 		return
 	}
-	if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
-		respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
-		return
+	if stats.RequiresRuntimeRefresh() {
+		if errRefresh := h.refreshConfig(ctx); errRefresh != nil {
+			respondError(c, http.StatusInternalServerError, "reload_failed", errRefresh)
+			return
+		}
 	}
 	respondOK(c)
 }
@@ -475,7 +494,7 @@ func (h *Handler) PutAPIKeys(c *gin.Context) {
 // PatchAPIKeys applies a partial update to an api keys.
 func (h *Handler) PatchAPIKeys(c *gin.Context) {
 	if errPatch := h.patchAPIKeyEntries(c); errPatch != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": errPatch.Error()})
+		respondAPIKeyRequestError(c, errPatch)
 	}
 }
 

--- a/internal/cluster/models.go
+++ b/internal/cluster/models.go
@@ -425,6 +425,7 @@ func (UserSecurityThrottleRecord) TableName() string {
 type APIKeyRecord struct {
 	ID          uint           `gorm:"column:id;primaryKey;autoIncrement;index:idx_api_key_active_order,priority:2"`
 	APIKey      string         `gorm:"column:api_key;not null;uniqueIndex"`
+	DisplayName *string        `gorm:"column:display_name;type:text"`
 	UserID      *uint          `gorm:"column:user_id;index;index:idx_api_key_user_active,priority:1"`
 	Channels    JSONB          `gorm:"column:channels"`
 	ModelGroups JSONB          `gorm:"column:model_groups"`

--- a/internal/cluster/plugin_tasks.go
+++ b/internal/cluster/plugin_tasks.go
@@ -65,6 +65,11 @@ func (r *Repository) ReplaceConfigSnapshotWithLifecycleConfigAndCreatePluginTask
 	}
 	var out node.PluginTask
 	errTransaction := withConcurrencyTransaction(ctx, db, func(tx *gorm.DB) error {
+		// Keep the same advisory-lock order as direct API key mutations before
+		// config reconciliation or plugin task creation emits cluster events.
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		gate, errGate := lockConcurrencyActivationGate(tx)
 		if errGate != nil {
 			return errGate

--- a/internal/cluster/repository.go
+++ b/internal/cluster/repository.go
@@ -37,16 +37,23 @@ const (
 const clusterEventAdvisoryLockKey int64 = 749327842680272317
 
 type APIKeyUpsertStats struct {
-	Created   int
-	Updated   int
-	Unchanged int
-	Restored  int
-	Removed   int
+	Created        int
+	Updated        int
+	Unchanged      int
+	Restored       int
+	Removed        int
+	RuntimeChanged bool
 }
 
 // Changed reports whether api key rows were mutated.
 func (s APIKeyUpsertStats) Changed() bool {
 	return s.Created != 0 || s.Updated != 0 || s.Restored != 0 || s.Removed != 0
+}
+
+// RequiresRuntimeRefresh reports whether the accepted API key set or its
+// dispatch-affecting bindings changed.
+func (s APIKeyUpsertStats) RequiresRuntimeRefresh() bool {
+	return s.RuntimeChanged
 }
 
 // NewRepository creates a new repository.
@@ -860,6 +867,9 @@ func replaceAPIKeysTxWithStats(ctx context.Context, tx *gorm.DB, keys []string) 
 	if tx == nil {
 		return APIKeyUpsertStats{}, fmt.Errorf("database connection is nil")
 	}
+	if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+		return APIKeyUpsertStats{}, errLock
+	}
 	keys = normalizeAPIKeys(keys)
 
 	var existing []APIKeyRecord
@@ -925,6 +935,9 @@ func upsertAPIKeysTxWithStats(ctx context.Context, tx *gorm.DB, keys []string) (
 	// Normalize source data before building the derived payload.
 	if tx == nil {
 		return APIKeyUpsertStats{}, fmt.Errorf("database connection is nil")
+	}
+	if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+		return APIKeyUpsertStats{}, errLock
 	}
 	keys = normalizeAPIKeys(keys)
 	stats := APIKeyUpsertStats{}
@@ -1096,6 +1109,12 @@ func (r *Repository) ReplaceConfigSnapshotWithLifecycleConfig(ctx context.Contex
 		}
 	}
 	return withConcurrencyTransaction(ctx, db, func(tx *gorm.DB) error {
+		// Config replacement can emit auth or lifecycle events before it reaches
+		// the API key rows. Acquire this lock first to keep the global order
+		// API keys -> cluster events and avoid a PostgreSQL advisory-lock cycle.
+		if errLock := lockAPIKeyMutationTransaction(tx); errLock != nil {
+			return errLock
+		}
 		gate, errGate := lockConcurrencyActivationGate(tx)
 		if errGate != nil {
 			return errGate

--- a/internal/managementhttp/server.go
+++ b/internal/managementhttp/server.go
@@ -126,6 +126,7 @@ var corsExposedResponseHeaders = []string{
 	"X-CPA-HOME-BUILD-DATE",
 	"X-SERVER-VERSION",
 	"X-SERVER-BUILD-DATE",
+	"ETag",
 }
 
 var corsExposedResponseHeadersJoined = strings.Join(corsExposedResponseHeaders, ", ")

--- a/internal/managementhttp/server_test.go
+++ b/internal/managementhttp/server_test.go
@@ -421,4 +421,7 @@ func assertCORSHeaders(t *testing.T, resp *httptest.ResponseRecorder) {
 	if !strings.Contains(expose, "X-CPA-SUPPORT-PLUGIN") {
 		t.Fatalf("Access-Control-Expose-Headers = %q, want X-CPA-SUPPORT-PLUGIN", expose)
 	}
+	if !strings.Contains(expose, "ETag") {
+		t.Fatalf("Access-Control-Expose-Headers = %q, want ETag", expose)
+	}
 }


### PR DESCRIPTION
Closes #91.

## Display names for client API keys
Adds a nullable `display_name` column to `api_key` records with tri-state update semantics across `POST`/`PUT`/`PATCH /api-keys`: omitting the field preserves the stored name, an empty string or `null` clears it, and a name-only update does not rotate the key value, change ownership or group bindings, or trigger a runtime config refresh.

## Snapshot and import/export compatibility
Freezes database snapshot formats v1–v3 and bumps the current format to v4 so display names survive database export/import, while legacy `config.yaml` import and RESP string replacement keep existing names.

## Concurrency and validation hardening
`GET /api-keys` now returns a strong ETag that `PUT` can verify via `If-Match`, so a concurrent change fails with 412 instead of silently overwriting it. API key mutations serialize through one PostgreSQL advisory lock ordered before the cluster event lock, and request bodies are limited to 1 MiB with strict JSON validation.

## Docs
Updates `docs/management/api.md` and `docs/management/api_CN.md` plus both READMEs for the new field, ETag/If-Match behavior, and tri-state semantics.

## Testing
- Adds `internal/cluster/management/api_keys_test.go` and extends `internal/cluster/api_keys_test.go`, `database_snapshot_test.go`, `import_export_test.go`, and `internal/managementhttp/server_test.go` to cover tri-state updates, v1–v4 snapshot round-trips, ETag conflicts, and the body-size limit.
