### PR TITLE
fix(observability): handle SQLite auth timestamps

### DIFF
--- a/internal/cluster/management/usage_observability_test.go
+++ b/internal/cluster/management/usage_observability_test.go
@@ -1007,6 +1007,43 @@ func TestGetUsageRecordReturnsDetail(t *testing.T) {
 	}
 }
 
+func TestGetUsageRecordWithAuthNextRetryAfter(t *testing.T) {
+	handler, closeRepo := newUsageObservabilityTestHandler(t)
+	defer closeRepo()
+	seedUsageObservabilityManagementRecordWithRetry(t, handler)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.GET("/usage/records/:id", handler.GetUsageRecord)
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/usage/records/1", nil)
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s, want %d", resp.Code, resp.Body.String(), http.StatusOK)
+	}
+
+	var payload map[string]any
+	if errDecode := json.Unmarshal(resp.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	record, ok := payload["record"].(map[string]any)
+	if !ok {
+		t.Fatalf("record = %T, want object", payload["record"])
+	}
+	credential, ok := record["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential = %T, want object", record["credential"])
+	}
+	if credential["auth_index"] != "auth-observability" {
+		t.Fatalf("credential.auth_index = %v, want auth-observability", credential["auth_index"])
+	}
+	if credential["status"] != "unavailable" {
+		t.Fatalf("credential.status = %v, want unavailable", credential["status"])
+	}
+}
+
 func TestGetUsageRecordReturnsLogExcerptWhenRequested(t *testing.T) {
 	handler, closeRepo := newUsageObservabilityTestHandler(t)
 	defer closeRepo()

--- a/internal/cluster/usage_observability.go
+++ b/internal/cluster/usage_observability.go
@@ -410,8 +410,8 @@ type usageObservabilityRecordRow struct {
 	AuthStatus                 string          `gorm:"column:auth_status"`
 	AuthDisabled               bool            `gorm:"column:auth_disabled"`
 	AuthUnavailable            bool            `gorm:"column:auth_unavailable"`
-	AuthNextRefreshAfter       sql.NullTime    `gorm:"column:auth_next_refresh_after"`
-	AuthNextRetryAfter         sql.NullTime    `gorm:"column:auth_next_retry_after"`
+	AuthNextRefreshAfter       sql.NullString  `gorm:"column:auth_next_refresh_after"`
+	AuthNextRetryAfter         sql.NullString  `gorm:"column:auth_next_retry_after"`
 }
 
 type usageObservabilityAggregateRow struct {
@@ -3622,9 +3622,10 @@ func usageObservabilityAuthNextRetryAt(row *usageObservabilityRecordRow) *time.T
 	if row == nil {
 		return nil
 	}
-	if row.AuthNextRetryAfter.Valid {
-		nextRetryAt := row.AuthNextRetryAfter.Time.UTC()
-		return &nextRetryAt
+	if row.AuthNextRetryAfter.Valid && strings.TrimSpace(row.AuthNextRetryAfter.String) != "" {
+		if nextRetryAt := usageObservabilityOptionalAggregateTime(row.AuthNextRetryAfter.String); nextRetryAt != nil {
+			return nextRetryAt
+		}
 	}
 	return usageObservabilityAuthJSONNextRetryAt(string(row.AuthJSON))
 }

--- a/internal/cluster/usage_observability_test.go
+++ b/internal/cluster/usage_observability_test.go
@@ -1305,6 +1305,58 @@ func TestGetUsageObservabilityRecordReturnsRecord(t *testing.T) {
 	}
 }
 
+func TestGetUsageObservabilityRecordWithAuthNextRetryAndRefreshAfter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo, closeRepo := newBillingTestRepository(t, ctx)
+	defer closeRepo()
+
+	seedUsageObservabilityRecord(t, ctx, repo)
+
+	nextRetry := time.Date(2026, time.August, 25, 11, 59, 41, 0, time.UTC)
+	nextRefresh := time.Date(2026, time.August, 25, 12, 30, 0, 0, time.UTC)
+	auth := &coreauth.Auth{
+		ID:               "auth-observability",
+		Index:            "auth-observability",
+		Provider:         "codex",
+		Label:            "Primary OAuth",
+		Status:           coreauth.StatusActive,
+		NextRetryAfter:   nextRetry,
+		NextRefreshAfter: nextRefresh,
+		CreatedAt:        time.Date(2026, time.June, 10, 1, 0, 0, 0, time.UTC),
+		UpdatedAt:        time.Date(2026, time.June, 10, 1, 0, 0, 0, time.UTC),
+	}
+	if _, errAuth := repo.UpsertAuth(ctx, auth, "test"); errAuth != nil {
+		t.Fatalf("UpsertAuth() error = %v", errAuth)
+	}
+
+	record, errRecord := repo.GetUsageObservabilityRecord(ctx, "1")
+	if errRecord != nil {
+		t.Fatalf("GetUsageObservabilityRecord() error = %v", errRecord)
+	}
+	if record.UsageID != 1 {
+		t.Fatalf("usage id = %d, want 1", record.UsageID)
+	}
+	if record.Credential.NextRetryAt == nil {
+		t.Fatalf("NextRetryAt is nil, want %v", nextRetry)
+	}
+	if !record.Credential.NextRetryAt.UTC().Equal(nextRetry) {
+		t.Fatalf("NextRetryAt = %v, want %v", record.Credential.NextRetryAt.UTC(), nextRetry)
+	}
+
+	listResult, errList := repo.ListUsageObservabilityRecords(ctx, UsageObservabilityRecordQuery{})
+	if errList != nil {
+		t.Fatalf("ListUsageObservabilityRecords() error = %v", errList)
+	}
+	if len(listResult.Records) == 0 {
+		t.Fatalf("ListUsageObservabilityRecords() returned 0 records")
+	}
+	if listResult.Records[0].Credential.NextRetryAt == nil || !listResult.Records[0].Credential.NextRetryAt.UTC().Equal(nextRetry) {
+		t.Fatalf("list record NextRetryAt = %v, want %v", listResult.Records[0].Credential.NextRetryAt, nextRetry)
+	}
+}
+
 func TestUsageObservabilityOverviewBuildsTrendWithSQLBuckets(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- scan aliased auth next-refresh and next-retry timestamps as nullable strings so SQLite TEXT values do not fail request detail queries
- explicitly parse retry timestamps while preserving the existing auth JSON fallback
- add SQLite regression coverage for repository list/detail and the Management API Request Details path

## API contract

- no route, request, or response schema changes
- restores Request Details for SQLite databases with non-null auth retry or refresh timestamps

## Testing

- git diff --check
- focused usage observability repository and Management API tests
- go test -count=1 ./internal/cluster ./internal/cluster/management
- go build -o test-output ./cmd/home

Closes #104