### PR TITLE
fix: preserve OpenAI compatibility upstream model metadata

### DIFF
--- a/internal/cliproxy/auth/xai_api_key_test.go
+++ b/internal/cliproxy/auth/xai_api_key_test.go
@@ -60,21 +60,9 @@ func TestDispatchResolvesXAIAPIKeyModelAlias(t *testing.T) {
 	}
 }
 
-func TestDispatchResolvesOpenAICompatibilityModelAlias(t *testing.T) {
+func TestDispatchResolvesOpenAICompatibilityMetadataAliasWithEmptyConfig(t *testing.T) {
 	manager := NewManager(nil, nil, nil)
-	manager.SetConfig(&internalconfig.Config{
-		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
-			Name:    "zai-coding",
-			BaseURL: "https://api.example.test/v1",
-			APIKeyEntries: []internalconfig.OpenAICompatibilityAPIKey{{
-				APIKey: "zai-key",
-			}},
-			Models: []internalconfig.OpenAICompatibilityModel{{
-				Name:  "glm-5.3",
-				Alias: "fractalops-coding",
-			}},
-		}},
-	})
+	manager.SetConfig(&internalconfig.Config{})
 	auth := &Auth{
 		ID:       "zai-api-key-auth",
 		Provider: "zai-coding",

--- a/internal/cliproxy/auth/xai_api_key_test.go
+++ b/internal/cliproxy/auth/xai_api_key_test.go
@@ -59,3 +59,58 @@ func TestDispatchResolvesXAIAPIKeyModelAlias(t *testing.T) {
 		t.Fatalf("Dispatch() force mapping = %t/%q, want true/grok-latest", decision.ForceMapping, decision.OriginalAlias)
 	}
 }
+
+func TestDispatchResolvesOpenAICompatibilityModelAlias(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+			Name:    "zai-coding",
+			BaseURL: "https://api.example.test/v1",
+			APIKeyEntries: []internalconfig.OpenAICompatibilityAPIKey{{
+				APIKey: "zai-key",
+			}},
+			Models: []internalconfig.OpenAICompatibilityModel{{
+				Name:  "glm-5.3",
+				Alias: "fractalops-coding",
+			}},
+		}},
+	})
+	auth := &Auth{
+		ID:       "zai-api-key-auth",
+		Provider: "zai-coding",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"api_key":     "zai-key",
+			"base_url":    "https://api.example.test/v1",
+			"compat_name": "zai-coding",
+		},
+		Metadata: map[string]any{
+			homeConfigModelsMetadataKey: []map[string]any{{
+				"id":           "fractalops-coding",
+				"name":         "glm-5.3",
+				"user_defined": true,
+			}},
+		},
+	}
+	registerDispatchTestAuth(t, manager, auth, "fractalops-coding")
+
+	decision, errDispatch := manager.Dispatch(
+		context.Background(),
+		[]string{"zai-coding"},
+		"fractalops-coding",
+		Options{},
+	)
+	if errDispatch != nil {
+		t.Fatalf("Dispatch() error = %v", errDispatch)
+	}
+	if decision == nil || decision.Auth == nil || decision.Auth.ID != auth.ID {
+		t.Fatalf("Dispatch() decision = %#v", decision)
+	}
+	if decision.Provider != "zai-coding" || decision.UpstreamModel != "glm-5.3" {
+		t.Fatalf(
+			"Dispatch() provider/model = %q/%q, want zai-coding/glm-5.3",
+			decision.Provider,
+			decision.UpstreamModel,
+		)
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -597,7 +597,7 @@ func buildOpenAICompatibilityModels(models []appconfig.OpenAICompatibilityModel,
 			OwnedBy:     compatName,
 			Type:        "openai-compatibility",
 			DisplayName: modelID,
-			UserDefined: false,
+			UserDefined: true,
 			Thinking:    thinking,
 		})
 	}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -591,6 +591,7 @@ func buildOpenAICompatibilityModels(models []appconfig.OpenAICompatibilityModel,
 		}
 		out = append(out, &registry.ModelInfo{
 			ID:          modelID,
+			Name:        strings.TrimSpace(model.Name),
 			Object:      "model",
 			Created:     created,
 			OwnedBy:     compatName,

--- a/internal/watcher/synthesizer/gemini_identity_test.go
+++ b/internal/watcher/synthesizer/gemini_identity_test.go
@@ -74,7 +74,9 @@ func TestConfigSynthesizerPreservesOpenAICompatUpstreamModelInMetadata(t *testin
 	if !okModels || len(rawModels) != 1 {
 		t.Fatalf("home_config_models = %#v", auths[0].Metadata[homeConfigModelsMetadataKey])
 	}
-	if rawModels[0]["id"] != "fractalops-coding" || rawModels[0]["name"] != "glm-5.3" {
+	if rawModels[0]["id"] != "fractalops-coding" ||
+		rawModels[0]["name"] != "glm-5.3" ||
+		rawModels[0]["user_defined"] != true {
 		t.Fatalf("model metadata = %#v, want alias and upstream name", rawModels[0])
 	}
 }

--- a/internal/watcher/synthesizer/gemini_identity_test.go
+++ b/internal/watcher/synthesizer/gemini_identity_test.go
@@ -50,6 +50,35 @@ func TestConfigSynthesizerBuildsHeaderAuthenticatedInteractionsAuth(t *testing.T
 	}
 }
 
+func TestConfigSynthesizerPreservesOpenAICompatUpstreamModelInMetadata(t *testing.T) {
+	cfg := &appconfig.Config{OpenAICompatibility: []appconfig.OpenAICompatibility{{
+		Name:    "zai-coding",
+		BaseURL: "https://api.example.test/v1",
+		Models: []appconfig.OpenAICompatibilityModel{{
+			Name:  "glm-5.3",
+			Alias: "fractalops-coding",
+		}},
+	}}}
+	auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      cfg,
+		Now:         time.Unix(100, 0).UTC(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatal(errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	rawModels, okModels := auths[0].Metadata[homeConfigModelsMetadataKey].([]map[string]any)
+	if !okModels || len(rawModels) != 1 {
+		t.Fatalf("home_config_models = %#v", auths[0].Metadata[homeConfigModelsMetadataKey])
+	}
+	if rawModels[0]["id"] != "fractalops-coding" || rawModels[0]["name"] != "glm-5.3" {
+		t.Fatalf("model metadata = %#v, want alias and upstream name", rawModels[0])
+	}
+}
+
 func TestConfigSynthesizerUsesFullGeminiCredentialIdentity(t *testing.T) {
 	base := appconfig.GeminiKey{
 		APIKey:   "shared-key",


### PR DESCRIPTION
Closes #111

## Why

Home synthesizes OpenAI-compatible aliases into `home_config_models`, but currently retains only the client-facing alias ID and drops the configured upstream model name. Dynamic service-key dispatch therefore forwards the alias literally to the provider.

## What changed

- preserve `OpenAICompatibilityModel.Name` in synthesized `registry.ModelInfo`
- add a focused regression proving `fractalops-coding` retains upstream `glm-5.3` metadata

## Verification

- `go test ./internal/watcher/synthesizer ./internal/cliproxy/auth`
- `git diff --check origin/dev...HEAD`

This is separate from OAuth response-model `force-mapping`; it restores request-time alias-to-upstream resolution for OpenAI-compatible API-key providers.